### PR TITLE
feat: 테스트 수정 API 구현

### DIFF
--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -22,7 +22,13 @@ public class TestController {
 
     private final TestService testService;
 
-    @Operation(summary = "테스트 등록", description = "새로운 테스트를 등록합니다.")
+    @Operation(summary = "테스트 등록", description = """
+            새로운 테스트를 등록합니다.
+
+            **[이미지 처리]**
+            - `imageKeys`는 S3 Presigned URL로 미리 업로드한 객체 키 목록입니다.
+            - 트랜잭션 실패(롤백) 시 업로드된 이미지는 S3에서 자동 삭제됩니다.
+            """)
     @PostMapping
     public ResponseEntity<ApiResponse<TestCreateResponse>> createTest(
             @RequestBody @Valid TestCreateRequest request,
@@ -34,7 +40,14 @@ public class TestController {
                 .body(ApiResponse.created("테스트가 등록되었습니다.", response));
     }
 
-    @Operation(summary = "테스트 수정", description = "테스트 기본 정보를 수정합니다.")
+    @Operation(summary = "테스트 수정", description = """
+            테스트 기본 정보를 수정합니다.
+
+            **[이미지 처리]**
+            - `imageKeys`를 전달하면 기존 이미지 목록이 전체 교체됩니다.
+            - 기존 목록에서 제거된 이미지는 트랜잭션 커밋 후 S3에서 영구 삭제됩니다.
+            - `imageKeys`를 `null`로 보내면 이미지는 변경되지 않습니다.
+            """)
     @PatchMapping("/{testId}")
     public ResponseEntity<ApiResponse<TestUpdateResponse>> updateTest(
             @PathVariable Long testId,

--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import server.MATE.domain.test.dto.request.TestCreateRequest;
+import server.MATE.domain.test.dto.request.TestUpdateRequest;
 import server.MATE.domain.test.dto.response.TestCreateResponse;
+import server.MATE.domain.test.dto.response.TestUpdateResponse;
 import server.MATE.domain.test.service.TestService;
 import server.MATE.global.common.response.ApiResponse;
 
@@ -30,5 +32,17 @@ public class TestController {
         TestCreateResponse response = testService.createTest(request, makerId);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("테스트가 등록되었습니다.", response));
+    }
+
+    @Operation(summary = "테스트 수정", description = "테스트 기본 정보를 수정합니다.")
+    @PatchMapping("/{testId}")
+    public ResponseEntity<ApiResponse<TestUpdateResponse>> updateTest(
+            @PathVariable Long testId,
+            @RequestBody @Valid TestUpdateRequest request,
+            // TODO: 인증 구현 후 @AuthenticationPrincipal 등으로 대체
+            @RequestHeader("X-User-Id") Long makerId
+    ) {
+        TestUpdateResponse response = testService.updateTest(testId, request, makerId);
+        return ResponseEntity.ok(ApiResponse.ok("테스트가 수정되었습니다.", response));
     }
 }

--- a/src/main/java/server/MATE/domain/test/dto/request/TestUpdateRequest.java
+++ b/src/main/java/server/MATE/domain/test/dto/request/TestUpdateRequest.java
@@ -1,0 +1,27 @@
+package server.MATE.domain.test.dto.request;
+
+import jakarta.validation.constraints.Size;
+import server.MATE.domain.test.entity.Category;
+
+import java.util.List;
+
+public record TestUpdateRequest(
+        @Size(max = 17, message = "테스트 이름은 최대 17자까지 입력 가능합니다.")
+        String title,
+
+        @Size(max = 60, message = "테스트 한줄 소개는 최대 60자까지 입력 가능합니다.")
+        String description,
+
+        @Size(min = 1, max = 3, message = "카테고리는 1개에서 3개까지 선택 가능합니다.")
+        List<Category> categories,
+
+        @Size(max = 17, message = "서비스 이름은 최대 17자까지 입력 가능합니다.")
+        String serviceName,
+
+        @Size(max = 70, message = "서비스 소개는 최대 70자까지 입력 가능합니다.")
+        String serviceDescription,
+
+        @Size(max = 10, message = "이미지는 최대 10개까지 등록 가능합니다.")
+        List<String> imageKeys
+) {
+}

--- a/src/main/java/server/MATE/domain/test/dto/response/TestUpdateResponse.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/TestUpdateResponse.java
@@ -1,0 +1,44 @@
+package server.MATE.domain.test.dto.response;
+
+import server.MATE.domain.test.entity.Category;
+import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.entity.TestCategory;
+import server.MATE.domain.test.entity.TestStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TestUpdateResponse(
+        Long id,
+        Long makerId,
+        String title,
+        String description,
+        List<String> categories,
+        String serviceName,
+        String serviceDescription,
+        List<String> imageKeys,
+        TestStatus status,
+        Integer goalPpl,
+        Integer reward,
+        LocalDateTime updatedAt
+) {
+    public static TestUpdateResponse from(Test test) {
+        return new TestUpdateResponse(
+                test.getId(),
+                test.getMakerId(),
+                test.getTitle(),
+                test.getDescription(),
+                test.getCategories().stream()
+                        .map(TestCategory::getCategory)
+                        .map(Category::name)
+                        .toList(),
+                test.getServiceName(),
+                test.getServiceDescription(),
+                test.getImageKeys(),
+                test.getStatus(),
+                test.getGoalPpl(),
+                test.getReward(),
+                test.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/test/dto/response/TestUpdateResponse.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/TestUpdateResponse.java
@@ -6,6 +6,7 @@ import server.MATE.domain.test.entity.TestCategory;
 import server.MATE.domain.test.entity.TestStatus;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 public record TestUpdateResponse(
@@ -34,7 +35,7 @@ public record TestUpdateResponse(
                         .toList(),
                 test.getServiceName(),
                 test.getServiceDescription(),
-                test.getImageKeys(),
+                new ArrayList<>(test.getImageKeys()),
                 test.getStatus(),
                 test.getGoalPpl(),
                 test.getReward(),

--- a/src/main/java/server/MATE/domain/test/entity/Test.java
+++ b/src/main/java/server/MATE/domain/test/entity/Test.java
@@ -69,6 +69,22 @@ public class Test extends BaseEntity {
         });
     }
 
+    public void update(String title, String description, List<Category> categories,
+                       String serviceName, String serviceDescription, List<String> imageKeys) {
+        if (title != null) this.title = title;
+        if (description != null) this.description = description;
+        if (categories != null) {
+            this.categories.clear();
+            addCategories(categories);
+        }
+        if (serviceName != null) this.serviceName = serviceName;
+        if (serviceDescription != null) this.serviceDescription = serviceDescription;
+        if (imageKeys != null) {
+            this.imageKeys.clear();
+            this.imageKeys.addAll(imageKeys);
+        }
+    }
+
     @Builder
     public Test(Long makerId, String title, String description, String serviceName,
                 String serviceDescription, List<String> imageKeys) {

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -16,6 +16,7 @@ import server.MATE.global.image.event.ImageCleanupEvent;
 import server.MATE.global.image.event.ImageDeleteEvent;
 
 import java.util.List;
+import java.util.Set;
 
 @Service
 @Transactional
@@ -54,13 +55,14 @@ public class TestService {
 
         List<String> newImageKeys = request.imageKeys();
         if (newImageKeys != null) {
-            List<String> oldImageKeys = List.copyOf(test.getImageKeys());
+            Set<String> oldKeySet = Set.copyOf(test.getImageKeys());
+            Set<String> newKeySet = Set.copyOf(newImageKeys);
 
-            List<String> addedKeys = newImageKeys.stream()
-                    .filter(key -> !oldImageKeys.contains(key))
+            List<String> addedKeys = newKeySet.stream()
+                    .filter(key -> !oldKeySet.contains(key))
                     .toList();
-            List<String> removedKeys = oldImageKeys.stream()
-                    .filter(key -> !newImageKeys.contains(key))
+            List<String> removedKeys = oldKeySet.stream()
+                    .filter(key -> !newKeySet.contains(key))
                     .toList();
 
             if (!addedKeys.isEmpty()) {
@@ -80,6 +82,7 @@ public class TestService {
                 newImageKeys
         );
 
+        testRepository.saveAndFlush(test);
         return TestUpdateResponse.from(test);
     }
 }

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -5,10 +5,15 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.MATE.domain.test.dto.request.TestCreateRequest;
+import server.MATE.domain.test.dto.request.TestUpdateRequest;
 import server.MATE.domain.test.dto.response.TestCreateResponse;
+import server.MATE.domain.test.dto.response.TestUpdateResponse;
 import server.MATE.domain.test.entity.Test;
 import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
 import server.MATE.global.image.event.ImageCleanupEvent;
+import server.MATE.global.image.event.ImageDeleteEvent;
 
 import java.util.List;
 
@@ -37,5 +42,44 @@ public class TestService {
         testRepository.save(test);
 
         return TestCreateResponse.from(test);
+    }
+
+    public TestUpdateResponse updateTest(Long testId, TestUpdateRequest request, Long makerId) {
+        Test test = testRepository.findById(testId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        if (!test.getMakerId().equals(makerId)) {
+            throw new BaseException(BaseErrorCode.TEST_005);
+        }
+
+        List<String> newImageKeys = request.imageKeys();
+        if (newImageKeys != null) {
+            List<String> oldImageKeys = List.copyOf(test.getImageKeys());
+
+            List<String> addedKeys = newImageKeys.stream()
+                    .filter(key -> !oldImageKeys.contains(key))
+                    .toList();
+            List<String> removedKeys = oldImageKeys.stream()
+                    .filter(key -> !newImageKeys.contains(key))
+                    .toList();
+
+            if (!addedKeys.isEmpty()) {
+                eventPublisher.publishEvent(new ImageCleanupEvent(addedKeys));
+            }
+            if (!removedKeys.isEmpty()) {
+                eventPublisher.publishEvent(new ImageDeleteEvent(removedKeys));
+            }
+        }
+
+        test.update(
+                request.title(),
+                request.description(),
+                request.categories(),
+                request.serviceName(),
+                request.serviceDescription(),
+                newImageKeys
+        );
+
+        return TestUpdateResponse.from(test);
     }
 }

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -26,6 +26,7 @@ public enum BaseErrorCode implements ErrorCode {
     TEST_002(HttpStatus.BAD_REQUEST, "TEST_002", "이미지는 최대 10개까지 업로드할 수 있습니다."),
     TEST_003(HttpStatus.BAD_REQUEST, "TEST_003", "지원하지 않는 이미지 형식입니다. JPG, PNG만 허용됩니다."),
     TEST_004(HttpStatus.NOT_FOUND, "TEST_004", "테스트를 찾을 수 없습니다."),
+    TEST_005(HttpStatus.FORBIDDEN, "TEST_005", "해당 테스트에 대한 권한이 없습니다."),
 
     // File
     FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_001", "파일 업로드에 실패했습니다."),

--- a/src/main/java/server/MATE/global/image/event/ImageDeleteEvent.java
+++ b/src/main/java/server/MATE/global/image/event/ImageDeleteEvent.java
@@ -1,0 +1,6 @@
+package server.MATE.global.image.event;
+
+import java.util.List;
+
+public record ImageDeleteEvent(List<String> imageKeys) {
+}

--- a/src/main/java/server/MATE/global/image/event/ImageDeleteEventListener.java
+++ b/src/main/java/server/MATE/global/image/event/ImageDeleteEventListener.java
@@ -1,0 +1,21 @@
+package server.MATE.global.image.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import server.MATE.global.image.ImageService;
+
+@Component
+@RequiredArgsConstructor
+public class ImageDeleteEventListener {
+
+    private final ImageService imageService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleImageDelete(ImageDeleteEvent event) {
+        if (event.imageKeys() != null && !event.imageKeys().isEmpty()) {
+            imageService.deleteFiles(event.imageKeys());
+        }
+    }
+}

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -1,0 +1,90 @@
+package server.MATE.domain.test.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import server.MATE.domain.test.dto.request.TestUpdateRequest;
+import server.MATE.domain.test.entity.Category;
+import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.global.image.event.ImageCleanupEvent;
+import server.MATE.global.image.event.ImageDeleteEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TestServiceTest {
+
+    @Mock
+    private TestRepository testRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private TestService testService;
+
+    private server.MATE.domain.test.entity.Test test;
+    private final Long MAKER_ID = 1L;
+    private final Long TEST_ID = 10L;
+
+    @BeforeEach
+    void setUp() {
+        test = server.MATE.domain.test.entity.Test.builder()
+                .makerId(MAKER_ID)
+                .title("기존 제목")
+                .description("기존 소개")
+                .serviceName("기존 서비스")
+                .serviceDescription("기존 서비스 소개")
+                .imageKeys(new ArrayList<>(List.of("old-key-1", "old-key-2")))
+                .build();
+        test.addCategories(List.of(Category.FOOD));
+    }
+
+    @Test
+    void 이미지_교체_시_추가된_키는_CleanupEvent_제거된_키는_DeleteEvent_발행() {
+        given(testRepository.findById(TEST_ID)).willReturn(Optional.of(test));
+
+        // old: [old-key-1, old-key-2] → new: [old-key-1, new-key-1]
+        TestUpdateRequest request = new TestUpdateRequest(null, null, null, null, null,
+                List.of("old-key-1", "new-key-1"));
+        testService.updateTest(TEST_ID, request, MAKER_ID);
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(eventPublisher, times(2)).publishEvent(captor.capture());
+
+        List<Object> events = captor.getAllValues();
+        ImageCleanupEvent cleanupEvent = events.stream()
+                .filter(e -> e instanceof ImageCleanupEvent)
+                .map(e -> (ImageCleanupEvent) e)
+                .findFirst().orElseThrow();
+        ImageDeleteEvent deleteEvent = events.stream()
+                .filter(e -> e instanceof ImageDeleteEvent)
+                .map(e -> (ImageDeleteEvent) e)
+                .findFirst().orElseThrow();
+
+        assertThat(cleanupEvent.imageKeys()).containsExactly("new-key-1");
+        assertThat(deleteEvent.imageKeys()).containsExactly("old-key-2");
+    }
+
+    @Test
+    void 이미지_필드_생략_시_이벤트_미발행() {
+        given(testRepository.findById(TEST_ID)).willReturn(Optional.of(test));
+
+        TestUpdateRequest request = new TestUpdateRequest("새 제목", null, null, null, null, null);
+        testService.updateTest(TEST_ID, request, MAKER_ID);
+
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+}


### PR DESCRIPTION
## 📍 요약
- 테스트 소유자만 기본 정보·이미지를 수정할 수 있는 PATCH API 추가

## 🔗 관련 이슈
- Closes #18

## 📌 변경 사항
- [x] 기능
- [x]  테스트

## ✅ 작업 내용
  - `PATCH /api/v1/tests/{testId}` 엔드포인트 추가
  - 소유자 검증 로직 추가 (불일치 시 TEST_005 / 403 응답)
  - 이미지 교체 시 기존 이미지 Azure Blob 자동 삭제 처리

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `./gradlew test`
  - Postman : 테스트 수정 테스트

## 📢 공유 사항
  **PATCH 필드 규칙**
  수정하지 않을 필드는 요청 바디에서 생략하면 기존 값이 유지됩니다.
  보내는 필드만 업데이트됩니다.

  | 필드 | 타입 | 설명 |
  |---|---|---|
  | title | String (max 17) | 테스트 이름 |
  | description | String (max 60) | 한줄 소개 |
  | categories | List (1~3개) | 카테고리 |
  | serviceName | String (max 17) | 서비스 이름 |
  | serviceDescription | String (max 70) | 서비스 소개 |
  | imageKeys | List (max 10) | 이미지 키 목록 |

  **이미지 처리 주의**
  - 이미지를 전부 삭제하려면 → `"imageKeys": []` (빈 배열)
  - 이미지를 유지하려면 → `imageKeys` 필드 자체를 생략

  **에러 코드**
  - `TEST_004` (404): 존재하지 않는 테스트
  - `TEST_005` (403): 해당 테스트의 소유자가 아님

