### PR TITLE
feat: A/B 테스트 문항 등록 구현

### DIFF
--- a/src/main/java/server/MATE/domain/question/controller/QuestionController.java
+++ b/src/main/java/server/MATE/domain/question/controller/QuestionController.java
@@ -33,7 +33,7 @@ public class QuestionController {
             // TODO: 인증 구현 후 @AuthenticationPrincipal 등으로 대체
             @RequestHeader("X-User-Id") Long makerId
     ) {
-        AbTestCreateResponse response = abTestService.createAbTest(testId, request);
+        AbTestCreateResponse response = abTestService.createAbTest(testId, makerId, request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("A/B 테스트 질문이 등록되었습니다.", response));
     }

--- a/src/main/java/server/MATE/domain/question/controller/QuestionController.java
+++ b/src/main/java/server/MATE/domain/question/controller/QuestionController.java
@@ -1,0 +1,40 @@
+package server.MATE.domain.question.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import server.MATE.domain.question.dto.request.AbTestCreateRequest;
+import server.MATE.domain.question.dto.response.AbTestCreateResponse;
+import server.MATE.domain.question.service.AbTestService;
+import server.MATE.global.common.response.ApiResponse;
+
+@Tag(name = "[QUESTION] 문항 API", description = "문항 등록 관련 API")
+@RestController
+@RequestMapping("/api/v1/tests/{testId}/questions")
+@RequiredArgsConstructor
+public class QuestionController {
+
+    private final AbTestService abTestService;
+
+    @Operation(summary = "A/B 테스트 문항 등록", description = "A/B 테스트 문항을 등록합니다.")
+    @PostMapping("/abtest")
+    public ResponseEntity<ApiResponse<AbTestCreateResponse>> createAbTest(
+            @PathVariable Long testId,
+            @RequestBody @Valid AbTestCreateRequest request,
+            // TODO: 인증 구현 후 @AuthenticationPrincipal 등으로 대체
+            @RequestHeader("X-User-Id") Long makerId
+    ) {
+        AbTestCreateResponse response = abTestService.createAbTest(testId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created("A/B 테스트 질문이 등록되었습니다.", response));
+    }
+}

--- a/src/main/java/server/MATE/domain/question/dto/request/AbTestCreateRequest.java
+++ b/src/main/java/server/MATE/domain/question/dto/request/AbTestCreateRequest.java
@@ -1,0 +1,20 @@
+package server.MATE.domain.question.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AbTestCreateRequest(
+        @NotBlank
+        @Size(max = 34, message = "질문 제목은 최대 34자까지 입력 가능합니다.")
+        String title,
+
+        @Size(max = 50, message = "질문 설명은 최대 50자까지 입력 가능합니다.")
+        String description,
+
+        @NotBlank
+        String aImageKey,
+
+        @NotBlank
+        String bImageKey
+) {
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/AbTestCreateResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/AbTestCreateResponse.java
@@ -1,0 +1,17 @@
+package server.MATE.domain.question.dto.response;
+
+import server.MATE.domain.question.entity.AbTest;
+
+public record AbTestCreateResponse(
+        Long questionId,
+        String aImageKey,
+        String bImageKey
+) {
+    public static AbTestCreateResponse from(AbTest abTest) {
+        return new AbTestCreateResponse(
+                abTest.getId(),
+                abTest.getAImageKey(),
+                abTest.getBImageKey()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/question/entity/AbTest.java
+++ b/src/main/java/server/MATE/domain/question/entity/AbTest.java
@@ -1,0 +1,42 @@
+package server.MATE.domain.question.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "ab_test")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AbTest {
+
+    @Id
+    private Long id;
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    private Question question;
+
+    @Column(name = "a_image_key", nullable = false)
+    private String aImageKey;
+
+    @Column(name = "b_image_key", nullable = false)
+    private String bImageKey;
+
+    @Builder
+    public AbTest(Question question, String aImageKey, String bImageKey) {
+        this.question = question;
+        this.aImageKey = aImageKey;
+        this.bImageKey = bImageKey;
+    }
+}

--- a/src/main/java/server/MATE/domain/question/entity/Question.java
+++ b/src/main/java/server/MATE/domain/question/entity/Question.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 import server.MATE.global.common.entity.BaseEntity;
 
 import java.time.LocalDateTime;
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
         name = "question",
         uniqueConstraints = @UniqueConstraint(columnNames = {"test_id", "sequence"})
 )
+@Where(clause = "deleted_at is null")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Question extends BaseEntity {
 

--- a/src/main/java/server/MATE/domain/question/entity/QuestionType.java
+++ b/src/main/java/server/MATE/domain/question/entity/QuestionType.java
@@ -1,9 +1,9 @@
 package server.MATE.domain.question.entity;
 
 public enum QuestionType {
+    OBJECTIVE,
     SUBJECTIVE,
-    MULTIPLE_CHOICE,
-    FIVE_SECOND_TEST,
+    FIVE_SECOND,
     SCALE,
     AB_TEST,
     CARD_SORTING,

--- a/src/main/java/server/MATE/domain/question/entity/Subjective.java
+++ b/src/main/java/server/MATE/domain/question/entity/Subjective.java
@@ -20,7 +20,7 @@ public class Subjective {
     @JoinColumn(name = "question_id")
     private Question question;
 
-    @Column(length = 255)
+    @Column
     private String imageKey;
 
     @Builder

--- a/src/main/java/server/MATE/domain/question/repository/AbTestRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/AbTestRepository.java
@@ -1,0 +1,7 @@
+package server.MATE.domain.question.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.MATE.domain.question.entity.AbTest;
+
+public interface AbTestRepository extends JpaRepository<AbTest, Long> {
+}

--- a/src/main/java/server/MATE/domain/question/service/AbTestService.java
+++ b/src/main/java/server/MATE/domain/question/service/AbTestService.java
@@ -1,0 +1,61 @@
+package server.MATE.domain.question.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.question.dto.request.AbTestCreateRequest;
+import server.MATE.domain.question.dto.response.AbTestCreateResponse;
+import server.MATE.domain.question.entity.AbTest;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.AbTestRepository;
+import server.MATE.domain.question.repository.QuestionRepository;
+import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+import server.MATE.global.image.event.ImageCleanupEvent;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AbTestService {
+
+    private final TestRepository testRepository;
+    private final QuestionRepository questionRepository;
+    private final AbTestRepository abTestRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public AbTestCreateResponse createAbTest(Long testId, AbTestCreateRequest request) {
+        testRepository.findById(testId).orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        // TODO: 동시성 이슈 - 현재 MAX(sequence)+1 방식은 동시 요청 시 중복 순서값 발생 가능.
+        //  별도 시퀀스 관리 로직 개발 후 수정 예정.
+        Long sequence = questionRepository.findMaxSequenceByTestId(testId) + 1;
+
+        Question question = Question.builder()
+                .testId(testId)
+                .questionType(QuestionType.AB_TEST)
+                .title(request.title())
+                .description(request.description())
+                .sequence(sequence)
+                .build();
+
+        AbTest abTest = AbTest.builder()
+                .question(question)
+                .aImageKey(request.aImageKey())
+                .bImageKey(request.bImageKey())
+                .build();
+
+        eventPublisher.publishEvent(new ImageCleanupEvent(
+                List.of(request.aImageKey(), request.bImageKey())
+        ));
+
+        questionRepository.save(question);
+        abTestRepository.save(abTest);
+
+        return AbTestCreateResponse.from(abTest);
+    }
+}

--- a/src/main/java/server/MATE/domain/question/service/AbTestService.java
+++ b/src/main/java/server/MATE/domain/question/service/AbTestService.java
@@ -11,6 +11,7 @@ import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.repository.AbTestRepository;
 import server.MATE.domain.question.repository.QuestionRepository;
+import server.MATE.domain.test.entity.Test;
 import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
@@ -28,8 +29,13 @@ public class AbTestService {
     private final AbTestRepository abTestRepository;
     private final ApplicationEventPublisher eventPublisher;
 
-    public AbTestCreateResponse createAbTest(Long testId, AbTestCreateRequest request) {
-        testRepository.findById(testId).orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+    public AbTestCreateResponse createAbTest(Long testId, Long makerId, AbTestCreateRequest request) {
+        Test test = testRepository.findById(testId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        if (!test.getMakerId().equals(makerId)) {
+            throw new BaseException(BaseErrorCode.COMMON_009);
+        }
 
         // TODO: 동시성 이슈 - 현재 MAX(sequence)+1 방식은 동시 요청 시 중복 순서값 발생 가능.
         //  별도 시퀀스 관리 로직 개발 후 수정 예정.

--- a/src/main/java/server/MATE/domain/test/entity/Test.java
+++ b/src/main/java/server/MATE/domain/test/entity/Test.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 import server.MATE.global.common.entity.BaseEntity;
 
 import java.time.LocalDateTime;
@@ -14,6 +15,7 @@ import java.util.List;
 @Getter
 @Entity
 @Table(name = "test")
+@Where(clause = "deleted_at is null")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Test extends BaseEntity {
 

--- a/src/main/java/server/MATE/domain/test/entity/TestCategory.java
+++ b/src/main/java/server/MATE/domain/test/entity/TestCategory.java
@@ -5,12 +5,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Entity
 @Table(name = "test_category")
+@Where(clause = "deleted_at is null")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TestCategory {
 


### PR DESCRIPTION
## 📍 요약
- 질문 유형 중 A/B 테스트 문항 등록 서비스 로직 구현

## 🔗 관련 이슈
- Closes #24

## 📌 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- A/B 테스트 문항 등록 서비스 로직 구현 및 임시 엔드포인트 추가
- ENUM QuestionType 최신 내용으로 수정
- 질문 등록 api로 통합될 예정이기에 스웨거 상세 작성은 생략함

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법: 별도 테스트 코드 작성 없이 스웨거 실행만 확인