### PR TITLE
feat: JWT 인증 기반 Spring Security 설정 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	// validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	// DB
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,11 @@ dependencies {
 	// security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	// DB
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/server/MATE/domain/auth/controller/AuthController.java
+++ b/src/main/java/server/MATE/domain/auth/controller/AuthController.java
@@ -1,0 +1,35 @@
+package server.MATE.domain.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import server.MATE.domain.auth.dto.request.TestTokenRequest;
+import server.MATE.domain.auth.dto.response.TestTokenResponse;
+import server.MATE.domain.auth.service.AuthService;
+import server.MATE.global.common.response.ApiResponse;
+
+@Profile("local")
+@Tag(name = "[AUTH] 인증 API", description = "인증 관련 API")
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "테스트용 액세스 토큰 발급", description = "토스 로그인 구현 전 사용자 ID로 테스트용 JWT를 발급합니다.")
+    @PostMapping("/test-token")
+    public ResponseEntity<ApiResponse<TestTokenResponse>> issueTestToken(
+            @RequestBody @Valid TestTokenRequest request
+    ) {
+        TestTokenResponse response = authService.issueTestAccessToken(request.userId());
+        return ResponseEntity.ok(ApiResponse.ok("테스트용 액세스 토큰이 발급되었습니다.", response));
+    }
+}

--- a/src/main/java/server/MATE/domain/auth/dto/request/TestTokenRequest.java
+++ b/src/main/java/server/MATE/domain/auth/dto/request/TestTokenRequest.java
@@ -1,0 +1,9 @@
+package server.MATE.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record TestTokenRequest(
+        @NotNull(message = "userId는 필수입니다.")
+        Long userId
+) {
+}

--- a/src/main/java/server/MATE/domain/auth/dto/response/TestTokenResponse.java
+++ b/src/main/java/server/MATE/domain/auth/dto/response/TestTokenResponse.java
@@ -1,0 +1,7 @@
+package server.MATE.domain.auth.dto.response;
+
+public record TestTokenResponse(
+        String accessToken,
+        String tokenType
+) {
+}

--- a/src/main/java/server/MATE/domain/auth/jwt/JwtConstants.java
+++ b/src/main/java/server/MATE/domain/auth/jwt/JwtConstants.java
@@ -1,0 +1,10 @@
+package server.MATE.domain.auth.jwt;
+
+public final class JwtConstants {
+
+    public static final String AUTH_HEADER = "Authorization";
+    public static final String TOKEN_PREFIX = "Bearer ";
+
+    private JwtConstants() {
+    }
+}

--- a/src/main/java/server/MATE/domain/auth/jwt/JwtProperties.java
+++ b/src/main/java/server/MATE/domain/auth/jwt/JwtProperties.java
@@ -1,0 +1,36 @@
+package server.MATE.domain.auth.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+    private String secret;
+
+    private Map<TokenType, TokenProperty> tokens = new EnumMap<>(TokenType.class);
+
+    public long getExpiration(TokenType tokenType) {
+        TokenProperty property = tokens.get(tokenType);
+        if (property == null) {
+            throw new BaseException(BaseErrorCode.AUTH_005);
+        }
+        return property.getExpiration();
+    }
+
+    @Getter
+    @Setter
+    public static class TokenProperty {
+        private long expiration;
+    }
+}

--- a/src/main/java/server/MATE/domain/auth/jwt/JwtProvider.java
+++ b/src/main/java/server/MATE/domain/auth/jwt/JwtProvider.java
@@ -1,0 +1,61 @@
+package server.MATE.domain.auth.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    private final JwtProperties jwtProperties;
+
+    private Key getSigningKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateToken(Long userId, String role, TokenType tokenType) {
+        long expiration = jwtProperties.getExpiration(tokenType);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .claim("role", role)
+                .claim("tokenType", tokenType.name())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public Long extractUserId(String token) {
+        return Long.valueOf(parseClaims(token).getSubject());
+    }
+
+    public TokenType extractTokenType(String token) {
+        return TokenType.valueOf(parseClaims(token).get("tokenType", String.class));
+    }
+
+    public void validateTokenTypeOrThrow(String token, TokenType expected) {
+        TokenType actual = extractTokenType(token);
+        if (actual != expected) {
+            throw new BaseException(BaseErrorCode.AUTH_003);
+        }
+    }
+}

--- a/src/main/java/server/MATE/domain/auth/jwt/TokenType.java
+++ b/src/main/java/server/MATE/domain/auth/jwt/TokenType.java
@@ -1,0 +1,6 @@
+package server.MATE.domain.auth.jwt;
+
+public enum TokenType {
+    ACCESS,
+    REFRESH
+}

--- a/src/main/java/server/MATE/domain/auth/service/AuthService.java
+++ b/src/main/java/server/MATE/domain/auth/service/AuthService.java
@@ -1,0 +1,34 @@
+package server.MATE.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.auth.dto.response.TestTokenResponse;
+import server.MATE.domain.auth.jwt.JwtProvider;
+import server.MATE.domain.auth.jwt.TokenType;
+import server.MATE.domain.users.entity.Users;
+import server.MATE.domain.users.repository.UsersRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UsersRepository usersRepository;
+    private final JwtProvider jwtProvider;
+
+    public TestTokenResponse issueTestAccessToken(Long userId) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.AUTH_004));
+
+        String accessToken = jwtProvider.generateToken(
+                user.getId(),
+                user.getRole().name(),
+                TokenType.ACCESS
+        );
+
+        return new TestTokenResponse(accessToken, TokenType.ACCESS.name());
+    }
+}

--- a/src/main/java/server/MATE/domain/question/controller/QuestionController.java
+++ b/src/main/java/server/MATE/domain/question/controller/QuestionController.java
@@ -29,9 +29,7 @@ public class QuestionController {
     @PostMapping("/abtest")
     public ResponseEntity<ApiResponse<AbTestCreateResponse>> createAbTest(
             @PathVariable Long testId,
-            @RequestBody @Valid AbTestCreateRequest request,
-            // TODO: 인증 구현 후 @AuthenticationPrincipal 등으로 대체
-            @RequestHeader("X-User-Id") Long makerId
+            @RequestBody @Valid AbTestCreateRequest request
     ) {
         AbTestCreateResponse response = abTestService.createAbTest(testId, request);
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/src/main/java/server/MATE/domain/question/controller/QuestionController.java
+++ b/src/main/java/server/MATE/domain/question/controller/QuestionController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,6 +18,7 @@ import server.MATE.domain.question.dto.request.AbTestCreateRequest;
 import server.MATE.domain.question.dto.response.AbTestCreateResponse;
 import server.MATE.domain.question.service.AbTestService;
 import server.MATE.global.common.response.ApiResponse;
+import server.MATE.global.security.principal.AuthenticatedUser;
 
 @Tag(name = "[QUESTION] 문항 API", description = "문항 등록 관련 API")
 @RestController
@@ -31,9 +33,10 @@ public class QuestionController {
     @PostMapping("/abtest")
     public ResponseEntity<ApiResponse<AbTestCreateResponse>> createAbTest(
             @PathVariable Long testId,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
             @RequestBody @Valid AbTestCreateRequest request
     ) {
-        AbTestCreateResponse response = abTestService.createAbTest(testId, makerId, request);
+        AbTestCreateResponse response = abTestService.createAbTest(testId, authenticatedUser.getId(), request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("A/B 테스트 질문이 등록되었습니다.", response));
     }

--- a/src/main/java/server/MATE/domain/question/controller/QuestionController.java
+++ b/src/main/java/server/MATE/domain/question/controller/QuestionController.java
@@ -1,6 +1,7 @@
 package server.MATE.domain.question.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ import server.MATE.global.common.response.ApiResponse;
 @Tag(name = "[QUESTION] 문항 API", description = "문항 등록 관련 API")
 @RestController
 @RequestMapping("/api/v1/tests/{testId}/questions")
+@SecurityRequirement(name = "JWT")
 @RequiredArgsConstructor
 public class QuestionController {
 

--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -6,11 +6,13 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import server.MATE.domain.test.dto.request.TestCreateRequest;
 import server.MATE.domain.test.dto.response.TestCreateResponse;
 import server.MATE.domain.test.service.TestService;
 import server.MATE.global.common.response.ApiResponse;
+import server.MATE.global.security.principal.AuthenticatedUser;
 
 @Tag(name = "[TEST] 테스트 API", description = "테스트 등록 관련 API")
 @RestController
@@ -24,10 +26,9 @@ public class TestController {
     @PostMapping
     public ResponseEntity<ApiResponse<TestCreateResponse>> createTest(
             @RequestBody @Valid TestCreateRequest request,
-            // TODO: 인증 구현 후 @AuthenticationPrincipal 등으로 대체
-            @RequestHeader("X-User-Id") Long makerId
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
     ) {
-        TestCreateResponse response = testService.createTest(request, makerId);
+        TestCreateResponse response = testService.createTest(request, authenticatedUser.getId());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("테스트가 등록되었습니다.", response));
     }

--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -1,6 +1,7 @@
 package server.MATE.domain.test.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import server.MATE.global.security.principal.AuthenticatedUser;
 @Tag(name = "[TEST] 테스트 API", description = "테스트 등록 관련 API")
 @RestController
 @RequestMapping("/api/v1/tests")
+@SecurityRequirement(name = "JWT")
 @RequiredArgsConstructor
 public class TestController {
 

--- a/src/main/java/server/MATE/domain/users/controller/UsersController.java
+++ b/src/main/java/server/MATE/domain/users/controller/UsersController.java
@@ -1,0 +1,32 @@
+package server.MATE.domain.users.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import server.MATE.domain.users.dto.response.MeResponse;
+import server.MATE.domain.users.service.UsersService;
+import server.MATE.global.common.response.ApiResponse;
+import server.MATE.global.security.principal.AuthenticatedUser;
+
+@Tag(name = "[USERS] 사용자 API", description = "사용자 정보 관련 API")
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UsersController {
+
+    private final UsersService usersService;
+
+    @Operation(summary = "내 정보 조회", description = "현재 인증된 사용자의 정보를 조회합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<MeResponse>> getMe(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        MeResponse response = usersService.getMe(authenticatedUser.getId());
+        return ResponseEntity.ok(ApiResponse.ok("내 정보를 조회했습니다.", response));
+    }
+}

--- a/src/main/java/server/MATE/domain/users/controller/UsersController.java
+++ b/src/main/java/server/MATE/domain/users/controller/UsersController.java
@@ -1,6 +1,7 @@
 package server.MATE.domain.users.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,7 @@ import server.MATE.global.security.principal.AuthenticatedUser;
 @Tag(name = "[USERS] 사용자 API", description = "사용자 정보 관련 API")
 @RestController
 @RequestMapping("/api/v1/users")
+@SecurityRequirement(name = "JWT")
 @RequiredArgsConstructor
 public class UsersController {
 

--- a/src/main/java/server/MATE/domain/users/dto/response/MeResponse.java
+++ b/src/main/java/server/MATE/domain/users/dto/response/MeResponse.java
@@ -1,0 +1,22 @@
+package server.MATE.domain.users.dto.response;
+
+import server.MATE.domain.users.entity.Role;
+import server.MATE.domain.users.entity.Users;
+
+public record MeResponse(
+        Long id,
+        String name,
+        Role role
+) {
+    public static MeResponse from(Users user) {
+        return new MeResponse(
+                user.getId(),
+                user.getName(),
+                user.getRole()
+        );
+    }
+
+    public static MeResponse of(Long id, String name, Role role) {
+        return new MeResponse(id, name, role);
+    }
+}

--- a/src/main/java/server/MATE/domain/users/entity/Role.java
+++ b/src/main/java/server/MATE/domain/users/entity/Role.java
@@ -1,0 +1,6 @@
+package server.MATE.domain.users.entity;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/server/MATE/domain/users/entity/Users.java
+++ b/src/main/java/server/MATE/domain/users/entity/Users.java
@@ -1,0 +1,43 @@
+package server.MATE.domain.users.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.MATE.global.common.entity.BaseEntity;
+
+@Getter
+@Entity
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Users extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String ci;
+
+    @Column
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Builder
+    public Users(String ci, String name, Role role) {
+        this.ci = ci;
+        this.name = name;
+        this.role = role == null ? Role.USER : role;
+    }
+}

--- a/src/main/java/server/MATE/domain/users/repository/UsersRepository.java
+++ b/src/main/java/server/MATE/domain/users/repository/UsersRepository.java
@@ -1,0 +1,9 @@
+package server.MATE.domain.users.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.MATE.domain.users.entity.Users;
+
+import java.util.Optional;
+
+public interface UsersRepository extends JpaRepository<Users, Long> {
+}

--- a/src/main/java/server/MATE/domain/users/service/UsersService.java
+++ b/src/main/java/server/MATE/domain/users/service/UsersService.java
@@ -1,0 +1,25 @@
+package server.MATE.domain.users.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.users.dto.response.MeResponse;
+import server.MATE.domain.users.entity.Users;
+import server.MATE.domain.users.repository.UsersRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UsersService {
+
+    private final UsersRepository usersRepository;
+
+    public MeResponse getMe(Long userId) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.AUTH_004));
+
+        return MeResponse.from(user);
+    }
+}

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -21,6 +21,13 @@ public enum BaseErrorCode implements ErrorCode {
     COMMON_009(HttpStatus.FORBIDDEN, "COMMON_009", "접근 권한이 없습니다."),
     COMMON_999(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_999", "서버 내부 오류가 발생했습니다."),
 
+    // Auth
+    AUTH_001(HttpStatus.UNAUTHORIZED, "AUTH_001", "유효하지 않은 액세스 토큰입니다."),
+    AUTH_002(HttpStatus.UNAUTHORIZED, "AUTH_002", "만료된 토큰입니다."),
+    AUTH_003(HttpStatus.UNAUTHORIZED, "AUTH_003", "허용되지 않은 토큰 타입입니다."),
+    AUTH_004(HttpStatus.UNAUTHORIZED, "AUTH_004", "사용자를 찾을 수 없습니다."),
+    AUTH_005(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH_005", "JWT 설정 정보를 찾을 수 없습니다."),
+
     // Test
     TEST_001(HttpStatus.BAD_REQUEST, "TEST_001", "카테고리는 1개 이상 3개 이하로 선택해야 합니다."),
     TEST_002(HttpStatus.BAD_REQUEST, "TEST_002", "이미지는 최대 10개까지 업로드할 수 있습니다."),

--- a/src/main/java/server/MATE/global/config/SwaggerConfig.java
+++ b/src/main/java/server/MATE/global/config/SwaggerConfig.java
@@ -1,19 +1,26 @@
 package server.MATE.global.config;
 
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Info;
-import org.springframework.context.annotation.Bean;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@OpenAPIDefinition(
+        info = @io.swagger.v3.oas.annotations.info.Info(
+                title = "MATE API",
+                description = "MATE 서버 API 문서",
+                version = "v1.0.0"
+        ),
+        security = @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "JWT")
+)
+@io.swagger.v3.oas.annotations.security.SecurityScheme(
+        name = "JWT",
+        description = "AccessToken를 입력해주세요.",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        in = SecuritySchemeIn.HEADER
+)
 public class SwaggerConfig {
-
-    @Bean
-    public OpenAPI openAPI() {
-        return new OpenAPI()
-                .info(new Info()
-                        .title("MATE API")
-                        .description("MATE 서버 API 문서")
-                        .version("v1.0.0"));
-    }
 }

--- a/src/main/java/server/MATE/global/security/config/SecurityConfig.java
+++ b/src/main/java/server/MATE/global/security/config/SecurityConfig.java
@@ -1,0 +1,60 @@
+package server.MATE.global.security.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import server.MATE.domain.auth.jwt.JwtProvider;
+import server.MATE.domain.users.repository.UsersRepository;
+import server.MATE.global.security.filter.JwtAuthenticationFilter;
+import server.MATE.global.security.handler.CustomAccessDeniedHandler;
+import server.MATE.global.security.handler.CustomAuthenticationEntryPoint;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final JwtProvider jwtProvider;
+    private final UsersRepository usersRepository;
+
+    private static final String[] PUBLIC_WHITELIST = {
+            "/", "/api/v1/auth/test-token",
+            "/swagger-ui/**", "/swagger-ui.html", "/api-docs/**", "/v3/api-docs/**", "/docs/error-codes"
+    };
+
+    public static final String[] INFRA_WHITELIST = {
+    };
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(PUBLIC_WHITELIST).permitAll()
+                        .requestMatchers(INFRA_WHITELIST).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtProvider, usersRepository, customAuthenticationEntryPoint),
+                        UsernamePasswordAuthenticationFilter.class
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler)
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/server/MATE/global/security/exception/JwtAuthenticationException.java
+++ b/src/main/java/server/MATE/global/security/exception/JwtAuthenticationException.java
@@ -1,0 +1,21 @@
+package server.MATE.global.security.exception;
+
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+import server.MATE.global.common.exception.ErrorCode;
+
+@Getter
+public class JwtAuthenticationException extends AuthenticationException {
+
+    private final ErrorCode errorCode;
+
+    public JwtAuthenticationException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public JwtAuthenticationException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/server/MATE/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/server/MATE/global/security/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package server.MATE.global.security.filter;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
@@ -43,12 +44,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         try {
             String token = bearer.substring(JwtConstants.TOKEN_PREFIX.length());
-            TokenType tokenType = jwtProvider.extractTokenType(token);
+            Claims claims = jwtProvider.parseClaims(token);
+            TokenType tokenType = TokenType.valueOf(claims.get("tokenType", String.class));
             if (tokenType != TokenType.ACCESS) {
                 throw new JwtAuthenticationException(BaseErrorCode.AUTH_003);
             }
 
-            Long userId = jwtProvider.extractUserId(token);
+            Long userId = Long.valueOf(claims.getSubject());
             Users user = usersRepository.findById(userId)
                     .orElseThrow(() -> new JwtAuthenticationException(BaseErrorCode.AUTH_004));
 

--- a/src/main/java/server/MATE/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/server/MATE/global/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,79 @@
+package server.MATE.global.security.filter;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.web.filter.OncePerRequestFilter;
+import server.MATE.domain.auth.jwt.JwtConstants;
+import server.MATE.domain.auth.jwt.JwtProvider;
+import server.MATE.domain.auth.jwt.TokenType;
+import server.MATE.domain.users.entity.Users;
+import server.MATE.domain.users.repository.UsersRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.security.exception.JwtAuthenticationException;
+import server.MATE.global.security.principal.AuthenticatedUser;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final UsersRepository usersRepository;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String bearer = request.getHeader(JwtConstants.AUTH_HEADER);
+        if (bearer == null || !bearer.startsWith(JwtConstants.TOKEN_PREFIX)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            String token = bearer.substring(JwtConstants.TOKEN_PREFIX.length());
+            TokenType tokenType = jwtProvider.extractTokenType(token);
+            if (tokenType != TokenType.ACCESS) {
+                throw new JwtAuthenticationException(BaseErrorCode.AUTH_003);
+            }
+
+            Long userId = jwtProvider.extractUserId(token);
+            Users user = usersRepository.findById(userId)
+                    .orElseThrow(() -> new JwtAuthenticationException(BaseErrorCode.AUTH_004));
+
+            AuthenticatedUser principal = AuthenticatedUser.from(user, tokenType);
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            SecurityContextHolder.clearContext();
+            authenticationEntryPoint.commence(
+                    request,
+                    response,
+                    new JwtAuthenticationException(BaseErrorCode.AUTH_002, e)
+            );
+        } catch (JwtException | IllegalArgumentException e) {
+            SecurityContextHolder.clearContext();
+            authenticationEntryPoint.commence(
+                    request,
+                    response,
+                    new JwtAuthenticationException(BaseErrorCode.AUTH_001, e)
+            );
+        } catch (JwtAuthenticationException e) {
+            SecurityContextHolder.clearContext();
+            authenticationEntryPoint.commence(request, response, e);
+        }
+    }
+}

--- a/src/main/java/server/MATE/global/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/server/MATE/global/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,32 @@
+package server.MATE.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.response.ErrorResponse;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException {
+        response.setStatus(BaseErrorCode.COMMON_009.getHttpStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), ErrorResponse.of(BaseErrorCode.COMMON_009));
+    }
+}

--- a/src/main/java/server/MATE/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/server/MATE/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,39 @@
+package server.MATE.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.ErrorCode;
+import server.MATE.global.common.response.ErrorResponse;
+import server.MATE.global.security.exception.JwtAuthenticationException;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        ErrorCode errorCode = BaseErrorCode.COMMON_008;
+        if (authException instanceof JwtAuthenticationException jwtAuthenticationException) {
+            errorCode = jwtAuthenticationException.getErrorCode();
+        }
+
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), ErrorResponse.of(errorCode));
+    }
+}

--- a/src/main/java/server/MATE/global/security/principal/AuthenticatedUser.java
+++ b/src/main/java/server/MATE/global/security/principal/AuthenticatedUser.java
@@ -1,0 +1,31 @@
+package server.MATE.global.security.principal;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import server.MATE.domain.auth.jwt.TokenType;
+import server.MATE.domain.users.entity.Role;
+import server.MATE.domain.users.entity.Users;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class AuthenticatedUser {
+
+    private final Long id;
+    private final Role role;
+    private final TokenType tokenType;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public AuthenticatedUser(Long id, Role role, TokenType tokenType) {
+        this.id = id;
+        this.role = role;
+        this.tokenType = tokenType;
+        this.authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+    }
+
+    public static AuthenticatedUser from(Users user, TokenType tokenType) {
+        return new AuthenticatedUser(user.getId(), user.getRole(), tokenType);
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -26,3 +26,16 @@ toss:
 
 discord:
   webhook-url: ${DISCORD_WEBHOOK_URL:}
+
+azure:
+  storage:
+    connection-string: ${AZURE_CONNECTION:}
+    container-name: ${AZURE_CONTAINER_NAME:}
+
+jwt:
+  secret: ${JWT_SECRET:}
+  tokens:
+    ACCESS:
+      expiration: 3600000
+    REFRESH:
+      expiration: 1209600000

--- a/src/test/java/server/MATE/domain/auth/jwt/JwtProviderTest.java
+++ b/src/test/java/server/MATE/domain/auth/jwt/JwtProviderTest.java
@@ -1,0 +1,69 @@
+package server.MATE.domain.auth.jwt;
+
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtProviderTest {
+
+    private final JwtProvider jwtProvider = new JwtProvider(createJwtProperties());
+
+    @Test
+    @DisplayName("토큰을 생성하면 subject, role, tokenType claim을 다시 추출할 수 있다")
+    void generateTokenAndExtractClaims() {
+        String token = jwtProvider.generateToken(1L, "USER", TokenType.ACCESS);
+
+        Claims claims = jwtProvider.parseClaims(token);
+
+        assertThat(claims.getSubject()).isEqualTo("1");
+        assertThat(claims.get("role", String.class)).isEqualTo("USER");
+        assertThat(claims.get("tokenType", String.class)).isEqualTo("ACCESS");
+        assertThat(jwtProvider.extractUserId(token)).isEqualTo(1L);
+        assertThat(jwtProvider.extractTokenType(token)).isEqualTo(TokenType.ACCESS);
+    }
+
+    @Test
+    @DisplayName("토큰 타입이 기대값과 같으면 예외가 발생하지 않는다")
+    void validateTokenTypeWhenExpectedTokenTypeMatches() {
+        String token = jwtProvider.generateToken(1L, "USER", TokenType.ACCESS);
+
+        jwtProvider.validateTokenTypeOrThrow(token, TokenType.ACCESS);
+    }
+
+    @Test
+    @DisplayName("토큰 타입이 기대값과 다르면 AUTH_003 예외를 던진다")
+    void validateTokenTypeWhenExpectedTokenTypeDoesNotMatch() {
+        String token = jwtProvider.generateToken(1L, "USER", TokenType.REFRESH);
+
+        assertThatThrownBy(() -> jwtProvider.validateTokenTypeOrThrow(token, TokenType.ACCESS))
+                .isInstanceOf(BaseException.class)
+                .extracting(exception -> ((BaseException) exception).getErrorCode())
+                .isEqualTo(BaseErrorCode.AUTH_003);
+    }
+
+    private JwtProperties createJwtProperties() {
+        JwtProperties properties = new JwtProperties();
+        properties.setSecret("mate-local-jwt-secret-key-must-be-at-least-32bytes");
+
+        JwtProperties.TokenProperty access = new JwtProperties.TokenProperty();
+        access.setExpiration(3_600_000L);
+
+        JwtProperties.TokenProperty refresh = new JwtProperties.TokenProperty();
+        refresh.setExpiration(1_209_600_000L);
+
+        Map<TokenType, JwtProperties.TokenProperty> tokens = new EnumMap<>(TokenType.class);
+        tokens.put(TokenType.ACCESS, access);
+        tokens.put(TokenType.REFRESH, refresh);
+        properties.setTokens(tokens);
+
+        return properties;
+    }
+}

--- a/src/test/java/server/MATE/global/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/server/MATE/global/security/filter/JwtAuthenticationFilterTest.java
@@ -1,7 +1,9 @@
 package server.MATE.global.security.filter;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,7 +35,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -86,8 +87,7 @@ class JwtAuthenticationFilterTest {
                 .build();
         ReflectionTestUtils.setField(user, "id", 1L);
 
-        when(jwtProvider.extractTokenType("valid-token")).thenReturn(TokenType.ACCESS);
-        when(jwtProvider.extractUserId("valid-token")).thenReturn(1L);
+        when(jwtProvider.parseClaims("valid-token")).thenReturn(claims(1L, TokenType.ACCESS));
         when(usersRepository.findById(1L)).thenReturn(Optional.of(user));
 
         jwtAuthenticationFilter.doFilter(request, response, filterChain);
@@ -106,7 +106,7 @@ class JwtAuthenticationFilterTest {
         MockHttpServletRequest request = bearerRequest("invalid-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        when(jwtProvider.extractTokenType("invalid-token")).thenReturn(TokenType.REFRESH);
+        when(jwtProvider.parseClaims("invalid-token")).thenReturn(claims(1L, TokenType.REFRESH));
 
         jwtAuthenticationFilter.doFilter(request, response, filterChain);
 
@@ -123,8 +123,7 @@ class JwtAuthenticationFilterTest {
         MockHttpServletRequest request = bearerRequest("missing-user-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        when(jwtProvider.extractTokenType("missing-user-token")).thenReturn(TokenType.ACCESS);
-        when(jwtProvider.extractUserId("missing-user-token")).thenReturn(99L);
+        when(jwtProvider.parseClaims("missing-user-token")).thenReturn(claims(99L, TokenType.ACCESS));
         when(usersRepository.findById(99L)).thenReturn(Optional.empty());
 
         jwtAuthenticationFilter.doFilter(request, response, filterChain);
@@ -141,7 +140,7 @@ class JwtAuthenticationFilterTest {
         MockHttpServletRequest request = bearerRequest("expired-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        when(jwtProvider.extractTokenType("expired-token")).thenThrow(new ExpiredJwtException(null, null, "expired"));
+        when(jwtProvider.parseClaims("expired-token")).thenThrow(new ExpiredJwtException(null, null, "expired"));
 
         jwtAuthenticationFilter.doFilter(request, response, filterChain);
 
@@ -157,7 +156,7 @@ class JwtAuthenticationFilterTest {
         MockHttpServletRequest request = bearerRequest("malformed-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        when(jwtProvider.extractTokenType("malformed-token")).thenThrow(new JwtException("invalid"));
+        when(jwtProvider.parseClaims("malformed-token")).thenThrow(new JwtException("invalid"));
 
         jwtAuthenticationFilter.doFilter(request, response, filterChain);
 
@@ -171,5 +170,12 @@ class JwtAuthenticationFilterTest {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader(JwtConstants.AUTH_HEADER, JwtConstants.TOKEN_PREFIX + token);
         return request;
+    }
+
+    private Claims claims(Long userId, TokenType tokenType) {
+        Claims claims = Jwts.claims();
+        claims.setSubject(String.valueOf(userId));
+        claims.put("tokenType", tokenType.name());
+        return claims;
     }
 }

--- a/src/test/java/server/MATE/global/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/server/MATE/global/security/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,175 @@
+package server.MATE.global.security.filter;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.test.util.ReflectionTestUtils;
+import server.MATE.domain.auth.jwt.JwtConstants;
+import server.MATE.domain.auth.jwt.JwtProvider;
+import server.MATE.domain.auth.jwt.TokenType;
+import server.MATE.domain.users.entity.Role;
+import server.MATE.domain.users.entity.Users;
+import server.MATE.domain.users.repository.UsersRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.security.exception.JwtAuthenticationException;
+import server.MATE.global.security.principal.AuthenticatedUser;
+
+import jakarta.servlet.FilterChain;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private UsersRepository usersRepository;
+
+    @Mock
+    private AuthenticationEntryPoint authenticationEntryPoint;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @InjectMocks
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더가 없으면 인증 없이 다음 필터로 요청을 넘긴다")
+    void passThroughWhenAuthorizationHeaderIsMissing() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verify(authenticationEntryPoint, never()).commence(any(), any(), any());
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    @DisplayName("유효한 access token이면 SecurityContext에 인증 정보를 저장한다")
+    void setAuthenticationWhenAccessTokenIsValid() throws Exception {
+        MockHttpServletRequest request = bearerRequest("valid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        Users user = Users.builder()
+                .ci("ci-1")
+                .name("tester")
+                .role(Role.USER)
+                .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        when(jwtProvider.extractTokenType("valid-token")).thenReturn(TokenType.ACCESS);
+        when(jwtProvider.extractUserId("valid-token")).thenReturn(1L);
+        when(usersRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.getPrincipal()).isInstanceOf(AuthenticatedUser.class);
+        assertThat(((AuthenticatedUser) authentication.getPrincipal()).getId()).isEqualTo(1L);
+        verify(filterChain).doFilter(request, response);
+        verify(authenticationEntryPoint, never()).commence(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("access token이 아닌 토큰 타입이면 AUTH_003 에러로 인증을 거부한다")
+    void invokeEntryPointWhenTokenTypeIsNotAccess() throws Exception {
+        MockHttpServletRequest request = bearerRequest("invalid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(jwtProvider.extractTokenType("invalid-token")).thenReturn(TokenType.REFRESH);
+
+        jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+        ArgumentCaptor<AuthenticationException> captor = ArgumentCaptor.forClass(AuthenticationException.class);
+        verify(authenticationEntryPoint).commence(any(), any(), captor.capture());
+        assertThat(captor.getValue()).isInstanceOf(JwtAuthenticationException.class);
+        assertThat(((JwtAuthenticationException) captor.getValue()).getErrorCode()).isEqualTo(BaseErrorCode.AUTH_003);
+        verify(filterChain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    @DisplayName("토큰의 사용자 정보가 존재하지 않으면 AUTH_004 에러로 인증을 거부한다")
+    void invokeEntryPointWhenUserDoesNotExist() throws Exception {
+        MockHttpServletRequest request = bearerRequest("missing-user-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(jwtProvider.extractTokenType("missing-user-token")).thenReturn(TokenType.ACCESS);
+        when(jwtProvider.extractUserId("missing-user-token")).thenReturn(99L);
+        when(usersRepository.findById(99L)).thenReturn(Optional.empty());
+
+        jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+        ArgumentCaptor<AuthenticationException> captor = ArgumentCaptor.forClass(AuthenticationException.class);
+        verify(authenticationEntryPoint).commence(any(), any(), captor.capture());
+        assertThat(((JwtAuthenticationException) captor.getValue()).getErrorCode()).isEqualTo(BaseErrorCode.AUTH_004);
+        verify(filterChain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    @DisplayName("만료된 토큰이면 AUTH_002 에러로 인증을 거부한다")
+    void invokeEntryPointWhenTokenIsExpired() throws Exception {
+        MockHttpServletRequest request = bearerRequest("expired-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(jwtProvider.extractTokenType("expired-token")).thenThrow(new ExpiredJwtException(null, null, "expired"));
+
+        jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+        ArgumentCaptor<AuthenticationException> captor = ArgumentCaptor.forClass(AuthenticationException.class);
+        verify(authenticationEntryPoint).commence(any(), any(), captor.capture());
+        assertThat(((JwtAuthenticationException) captor.getValue()).getErrorCode()).isEqualTo(BaseErrorCode.AUTH_002);
+        verify(filterChain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    @DisplayName("형식이 잘못된 토큰이면 AUTH_001 에러로 인증을 거부한다")
+    void invokeEntryPointWhenTokenIsMalformed() throws Exception {
+        MockHttpServletRequest request = bearerRequest("malformed-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(jwtProvider.extractTokenType("malformed-token")).thenThrow(new JwtException("invalid"));
+
+        jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+        ArgumentCaptor<AuthenticationException> captor = ArgumentCaptor.forClass(AuthenticationException.class);
+        verify(authenticationEntryPoint).commence(any(), any(), captor.capture());
+        assertThat(((JwtAuthenticationException) captor.getValue()).getErrorCode()).isEqualTo(BaseErrorCode.AUTH_001);
+        verify(filterChain, never()).doFilter(any(), any());
+    }
+
+    private MockHttpServletRequest bearerRequest(String token) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(JwtConstants.AUTH_HEADER, JwtConstants.TOKEN_PREFIX + token);
+        return request;
+    }
+}

--- a/src/test/java/server/MATE/global/security/handler/CustomAccessDeniedHandlerTest.java
+++ b/src/test/java/server/MATE/global/security/handler/CustomAccessDeniedHandlerTest.java
@@ -1,0 +1,33 @@
+package server.MATE.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import server.MATE.global.common.exception.BaseErrorCode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CustomAccessDeniedHandlerTest {
+
+    private final CustomAccessDeniedHandler accessDeniedHandler = new CustomAccessDeniedHandler(new ObjectMapper());
+
+    @Test
+    @DisplayName("인가 실패가 발생하면 COMMON_009 접근 권한 없음 응답을 반환한다")
+    void returnForbiddenErrorResponse() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        accessDeniedHandler.handle(
+                request,
+                response,
+                new AccessDeniedException("forbidden")
+        );
+
+        assertThat(response.getStatus()).isEqualTo(BaseErrorCode.COMMON_009.getHttpStatus().value());
+        assertThat(response.getContentType()).startsWith("application/json");
+        assertThat(response.getContentAsString()).contains("\"code\":\"COMMON_009\"");
+    }
+}

--- a/src/test/java/server/MATE/global/security/handler/CustomAuthenticationEntryPointTest.java
+++ b/src/test/java/server/MATE/global/security/handler/CustomAuthenticationEntryPointTest.java
@@ -1,0 +1,50 @@
+package server.MATE.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.security.exception.JwtAuthenticationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CustomAuthenticationEntryPointTest {
+
+    private final CustomAuthenticationEntryPoint entryPoint = new CustomAuthenticationEntryPoint(new ObjectMapper());
+
+    @Test
+    @DisplayName("일반 인증 예외가 들어오면 COMMON_008 인증 필요 응답을 반환한다")
+    void returnCommonUnauthorizedWhenAuthenticationExceptionIsGeneric() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        entryPoint.commence(
+                request,
+                response,
+                new InsufficientAuthenticationException("authentication required")
+        );
+
+        assertThat(response.getStatus()).isEqualTo(BaseErrorCode.COMMON_008.getHttpStatus().value());
+        assertThat(response.getContentType()).startsWith("application/json");
+        assertThat(response.getContentAsString()).contains("\"code\":\"COMMON_008\"");
+    }
+
+    @Test
+    @DisplayName("JWT 인증 예외가 들어오면 해당 JWT 에러코드로 응답을 반환한다")
+    void returnJwtErrorCodeWhenAuthenticationExceptionIsJwtAuthenticationException() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        entryPoint.commence(
+                request,
+                response,
+                new JwtAuthenticationException(BaseErrorCode.AUTH_001)
+        );
+
+        assertThat(response.getStatus()).isEqualTo(BaseErrorCode.AUTH_001.getHttpStatus().value());
+        assertThat(response.getContentAsString()).contains("\"code\":\"AUTH_001\"");
+    }
+}


### PR DESCRIPTION
## 📍 요약
- Spring Security와 JWT 기반 인증 구조를 추가하고 토스 로그인 연동 전까지 사용할 임시 유저 기능을 구현함

## 🔗 관련 이슈
- Closes #26 

## 📌 변경 사항
- [x] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- 인증 인프라 구성
    - Spring Security stateless 설정 및 JWT 인증 필터 적용
    - JWT 검증을 위한 `JwtProvider`, `JwtProperties`, `TokenType`, `JwtConstants` 추가
    - 인증/인가 예외 처리를 위한 `CustomAuthenticationEntryPoint`, `CustomAccessDeniedHandler`, `JwtAuthenticationException` 추가

- 인증/사용자 API 구현
    - 인증 사용자 주입용 `AuthenticatedUser` principal 추가
    - 로컬 환경에서 사용자 ID 기준으로 JWT를 발급하는 테스트용 `/api/v1/auth/test-token` API 추가
       - 요청 전 DB에 수동으로 users 데이터 삽입 필요
    - 현재 로그인 사용자 정보를 조회하는 `/api/v1/users/me` API 추가
    - 기존 테스트/질문 등록 컨트롤러의 사용자 주입 방식을 헤더 기반에서 인증 principal 기반으로 수정

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `JwtProviderTest`: 토큰 생성, claim 추출, 토큰 타입 검증 확인
  - `JwtAuthenticationFilterTest`: 토큰 없음, 잘못된 토큰, 만료 토큰, 유효한 토큰 처리 확인
  - `CustomAuthenticationEntryPointTest`, `CustomAccessDeniedHandlerTest`: 인증/인가 실패 응답 확인
  - Swagger에서 `/api/v1/auth/test-token` 호출 후 발급된 토큰으로 `/api/v1/users/me` 및 보호 API 수동 검증

## 공유 사항
- 인증이 필요한 api라면 controller에 `@SecurityRequirement(name = "JWT")`를 추가하여 문서상 명시해주세요.
- #25 머지 후 본 PR의 Base를 dev로 전환하여 최종 머지 부탁드립니다!