### PR TITLE
feat: 척도 테스트 문항 등록 구현

### DIFF
--- a/src/main/java/server/MATE/domain/question/controller/QuestionController.java
+++ b/src/main/java/server/MATE/domain/question/controller/QuestionController.java
@@ -15,8 +15,11 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import server.MATE.domain.question.dto.request.AbTestCreateRequest;
+import server.MATE.domain.question.dto.request.ScaleCreateRequest;
 import server.MATE.domain.question.dto.response.AbTestCreateResponse;
+import server.MATE.domain.question.dto.response.ScaleCreateResponse;
 import server.MATE.domain.question.service.AbTestService;
+import server.MATE.domain.question.service.ScaleService;
 import server.MATE.global.common.response.ApiResponse;
 import server.MATE.global.security.principal.AuthenticatedUser;
 
@@ -28,6 +31,7 @@ import server.MATE.global.security.principal.AuthenticatedUser;
 public class QuestionController {
 
     private final AbTestService abTestService;
+    private final ScaleService scaleService;
 
     @Operation(summary = "A/B 테스트 문항 등록", description = "A/B 테스트 문항을 등록합니다.")
     @PostMapping("/abtest")
@@ -39,5 +43,17 @@ public class QuestionController {
         AbTestCreateResponse response = abTestService.createAbTest(testId, authenticatedUser.getId(), request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("A/B 테스트 질문이 등록되었습니다.", response));
+    }
+
+    @Operation(summary = "척도 문항 등록", description = "척도 문항을 등록합니다.")
+    @PostMapping("/scale")
+    public ResponseEntity<ApiResponse<ScaleCreateResponse>> createScale(
+            @PathVariable Long testId,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @RequestBody @Valid ScaleCreateRequest request
+    ) {
+        ScaleCreateResponse response = scaleService.createScale(testId, authenticatedUser.getId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created("척도 질문이 등록되었습니다.", response));
     }
 }

--- a/src/main/java/server/MATE/domain/question/dto/request/ScaleCreateRequest.java
+++ b/src/main/java/server/MATE/domain/question/dto/request/ScaleCreateRequest.java
@@ -9,7 +9,7 @@ public record ScaleCreateRequest(
         @Size(max = 34, message = "질문 제목은 최대 34자까지 입력 가능합니다.")
         String title,
 
-        @Size(max = 50, message = "질문 설명은 최대 55자까지 입력 가능합니다.")
+        @Size(max = 50, message = "질문 설명은 최대 50자까지 입력 가능합니다.")
         String description,
 
         String imageKey,

--- a/src/main/java/server/MATE/domain/question/dto/request/ScaleCreateRequest.java
+++ b/src/main/java/server/MATE/domain/question/dto/request/ScaleCreateRequest.java
@@ -1,0 +1,28 @@
+package server.MATE.domain.question.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ScaleCreateRequest(
+        @NotBlank
+        @Size(max = 34, message = "질문 제목은 최대 34자까지 입력 가능합니다.")
+        String title,
+
+        @Size(max = 50, message = "질문 설명은 최대 55자까지 입력 가능합니다.")
+        String description,
+
+        String imageKey,
+
+        // TODO. 기획 확인 필요
+        @Size(max = 100, message = "최소 점수 라벨은 최대 100자까지 입력 가능합니다.")
+        String minLabel,
+
+        // TODO. 기획 확인 필요
+        @Size(max = 100, message = "최대 점수 라벨은 최대 100자까지 입력 가능합니다.")
+        String maxLabel,
+
+        @NotNull(message = "척도 범위는 필수입니다. 5 또는 7을 입력해주세요.")
+        Integer range
+) {
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/ScaleCreateResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/ScaleCreateResponse.java
@@ -1,0 +1,21 @@
+package server.MATE.domain.question.dto.response;
+
+import server.MATE.domain.question.entity.Scale;
+
+public record ScaleCreateResponse(
+        Long questionId,
+        String imageKey,
+        String minLabel,
+        String maxLabel,
+        Integer range
+) {
+    public static ScaleCreateResponse from(Scale scale) {
+        return new ScaleCreateResponse(
+                scale.getId(),
+                scale.getImageKey(),
+                scale.getMinLabel(),
+                scale.getMaxLabel(),
+                scale.getRange()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/question/entity/Scale.java
+++ b/src/main/java/server/MATE/domain/question/entity/Scale.java
@@ -16,9 +16,9 @@ import server.MATE.global.common.entity.BaseEntity;
 
 @Getter
 @Entity
-@Table(name = "ab_test")
+@Table(name = "scale")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AbTest extends BaseEntity {
+public class Scale extends BaseEntity {
 
     @Id
     private Long id;
@@ -28,16 +28,24 @@ public class AbTest extends BaseEntity {
     @JoinColumn(name = "question_id", nullable = false)
     private Question question;
 
-    @Column(name = "a_image_key", nullable = false)
-    private String aImageKey;
+    @Column
+    private String imageKey;
 
-    @Column(name = "b_image_key", nullable = false)
-    private String bImageKey;
+    @Column(length = 100)
+    private String minLabel;
+
+    @Column(length = 100)
+    private String maxLabel;
+
+    @Column(name = "scale_range", nullable = false)
+    private Integer range;
 
     @Builder
-    public AbTest(Question question, String aImageKey, String bImageKey) {
+    public Scale(Question question, String imageKey, String minLabel, String maxLabel, Integer range) {
         this.question = question;
-        this.aImageKey = aImageKey;
-        this.bImageKey = bImageKey;
+        this.imageKey = imageKey;
+        this.minLabel = minLabel;
+        this.maxLabel = maxLabel;
+        this.range = range == null ? 5 : range;
     }
 }

--- a/src/main/java/server/MATE/domain/question/repository/ScaleRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/ScaleRepository.java
@@ -1,0 +1,7 @@
+package server.MATE.domain.question.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.MATE.domain.question.entity.Scale;
+
+public interface ScaleRepository extends JpaRepository<Scale, Long> {
+}

--- a/src/main/java/server/MATE/domain/question/service/ScaleService.java
+++ b/src/main/java/server/MATE/domain/question/service/ScaleService.java
@@ -1,0 +1,77 @@
+package server.MATE.domain.question.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.question.dto.request.ScaleCreateRequest;
+import server.MATE.domain.question.dto.response.ScaleCreateResponse;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.entity.Scale;
+import server.MATE.domain.question.repository.QuestionRepository;
+import server.MATE.domain.question.repository.ScaleRepository;
+import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+import server.MATE.global.image.event.ImageCleanupEvent;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ScaleService {
+
+    private final TestRepository testRepository;
+    private final QuestionRepository questionRepository;
+    private final ScaleRepository scaleRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public ScaleCreateResponse createScale(Long testId, Long makerId, ScaleCreateRequest request) {
+        Test test = testRepository.findById(testId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        if (!test.getMakerId().equals(makerId)) {
+            throw new BaseException(BaseErrorCode.COMMON_009);
+        }
+
+        validateScaleRange(request.range());
+
+        // TODO: 동시성 이슈 - 현재 MAX(sequence)+1 방식은 동시 요청 시 중복 순서값 발생 가능.
+        //  별도 시퀀스 관리 로직 개발 후 수정 예정.
+        Long sequence = questionRepository.findMaxSequenceByTestId(testId) + 1;
+
+        Question question = Question.builder()
+                .testId(testId)
+                .questionType(QuestionType.SCALE)
+                .title(request.title())
+                .description(request.description())
+                .sequence(sequence)
+                .build();
+
+        Scale scale = Scale.builder()
+                .question(question)
+                .imageKey(request.imageKey())
+                .minLabel(request.minLabel())
+                .maxLabel(request.maxLabel())
+                .range(request.range())
+                .build();
+
+        if (request.imageKey() != null) {
+            eventPublisher.publishEvent(new ImageCleanupEvent(List.of(request.imageKey())));
+        }
+
+        questionRepository.save(question);
+        scaleRepository.save(scale);
+
+        return ScaleCreateResponse.from(scale);
+    }
+
+    private void validateScaleRange(Integer range) {
+        if (range != 5 && range != 7) {
+            throw new BaseException(BaseErrorCode.COMMON_002);
+        }
+    }
+}


### PR DESCRIPTION
## 📍 요약
- 질문 유형 중 척도 테스트 문항 등록 서비스 로직 구현

## 🔗 관련 이슈
- Closes #29 

## 📌 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- 척도 테스트 문항 등록 서비스 로직 구현 및 임시 엔드포인트 추가
- 질문 등록 api로 통합될 예정이기에 스웨거 상세 작성은 생략함
- AbTest 엔티티에 BaseEntity 상속함

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법: 별도 테스트 코드 작성 없이 스웨거 실행만 확인

## 공유 사항
- #27 머지 후 본 PR의 Base를 dev로 전환하여 최종 머지 부탁드립니다!