### PR TITLE
docs: Presigned URL 발급 및 테스트/문항 등록 API 스웨거 설명 추가

### DIFF
--- a/src/main/java/server/MATE/domain/question/controller/SubjectiveQuestionController.java
+++ b/src/main/java/server/MATE/domain/question/controller/SubjectiveQuestionController.java
@@ -1,6 +1,7 @@
 package server.MATE.domain.question.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,12 +21,26 @@ public class SubjectiveQuestionController {
 
     private final SubjectiveQuestionService subjectiveQuestionService;
 
-    @Operation(summary = "주관식 문항 등록", description = "주관식 문항을 등록합니다.")
+    @Operation(summary = "주관식 문항 등록", description = """
+            주관식 문항을 등록합니다.
+
+            **[imageKey]**
+            - 문항에 이미지를 첨부할 경우, 이미지 업로드 URL 발급 API로 먼저 업로드한 뒤 받은 imageKey를 전달합니다.
+            - 이미지가 없으면 null로 보내거나 필드를 생략합니다.
+
+            **[에러 코드]**
+            | 코드 | HTTP | 설명 |
+            |------|------|------|
+            | COMMON_002 | 400 | 요청 값 검증 실패 (title 필수, 글자수 초과 등) |
+            | TEST_004 | 404 | 테스트를 찾을 수 없음 |
+            """)
     @PostMapping("/subjective")
     public ResponseEntity<ApiResponse<SubjectiveQuestionCreateResponse>> createSubjectiveQuestion(
+            @Parameter(description = "문항을 등록할 테스트 ID")
             @PathVariable Long testId,
             @RequestBody @Valid SubjectiveQuestionCreateRequest request,
             // TODO: 인증 구현 후 @AuthenticationPrincipal 등으로 대체
+            @Parameter(description = "테스트 제작자 ID (인증 구현 전 임시 헤더)")
             @RequestHeader("X-User-Id") Long makerId
     ) {
         SubjectiveQuestionCreateResponse response =

--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -1,6 +1,7 @@
 package server.MATE.domain.test.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,11 +21,30 @@ public class TestController {
 
     private final TestService testService;
 
-    @Operation(summary = "테스트 등록", description = "새로운 테스트를 등록합니다.")
+    @Operation(summary = "테스트 등록", description = """
+            새로운 테스트를 등록합니다.
+
+            **[categories]**
+            DAILY, FINANCE, HEALTH, SHOPPING, FOOD, GAME, CONTENT, COMMUNITY,
+            AI, EDUCATION, TRAVEL, SOCIAL, CONVENIENCE, INFORMATION, BUSINESS, TRANSPORT, PUBLIC_ADMIN
+            (1~3개 선택 필수)
+
+            **[이미지 처리]**
+            - imageKeys는 이미지 업로드 URL 발급 API로 먼저 업로드한 뒤 받은 imageKey 목록입니다.
+            - 트랜잭션 실패(롤백) 시 업로드된 이미지는 S3에서 자동 삭제됩니다.
+
+            **[에러 코드]**
+            | 코드 | HTTP | 설명 |
+            |------|------|------|
+            | COMMON_002 | 400 | 요청 값 검증 실패 (필수 필드 누락, 글자수 초과 등) |
+            | TEST_001 | 400 | 카테고리는 1~3개 선택 필수 |
+            | TEST_002 | 400 | 이미지는 최대 10개까지 업로드 가능 |
+            """)
     @PostMapping
     public ResponseEntity<ApiResponse<TestCreateResponse>> createTest(
             @RequestBody @Valid TestCreateRequest request,
             // TODO: 인증 구현 후 @AuthenticationPrincipal 등으로 대체
+            @Parameter(description = "테스트 제작자 ID (인증 구현 전 임시 헤더)")
             @RequestHeader("X-User-Id") Long makerId
     ) {
         TestCreateResponse response = testService.createTest(request, makerId);

--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -31,7 +31,7 @@ public class TestController {
 
             **[이미지 처리]**
             - imageKeys는 이미지 업로드 URL 발급 API로 먼저 업로드한 뒤 받은 imageKey 목록입니다.
-            - 트랜잭션 실패(롤백) 시 업로드된 이미지는 S3에서 자동 삭제됩니다.
+            - 트랜잭션 실패(롤백) 시 업로드된 이미지는 Azure Blob Storage에서 자동 삭제됩니다.
 
             **[에러 코드]**
             | 코드 | HTTP | 설명 |

--- a/src/main/java/server/MATE/global/image/ImageController.java
+++ b/src/main/java/server/MATE/global/image/ImageController.java
@@ -1,6 +1,7 @@
 package server.MATE.global.image;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -27,9 +28,38 @@ public class ImageController {
 
     private final ImageService imageService;
 
-    @Operation(summary = "이미지 업로드 URL 발급", description = "Azure Blob Storage에 직접 업로드할 수 있는 Presigned URL을 발급합니다.")
+    @Operation(summary = "이미지 업로드 URL 발급", description = """
+            이미지 업로드용 Presigned URL을 발급합니다. 클라이언트는 서버를 경유하지 않고 Azure Blob Storage에 직접 업로드합니다.
+
+            **[전체 업로드 플로우]**
+            1. 이 API 호출 → presignedUrl, imageKey 수령
+            2. presignedUrl로 이미지 파일 직접 PUT 업로드
+            3. 테스트 등록/수정 API 요청 시 imageKey 포함
+
+            **[응답 필드]**
+            - presignedUrl: 이미지 업로드에 사용할 URL (2단계에서만 사용)
+            - imageKey: 등록/수정 API의 imageKeys 배열에 담아 전달하는 식별자
+
+            **[2단계 PUT 업로드 예시]**
+            - Method: PUT
+            - URL: 발급받은 presignedUrl
+            - Header: x-ms-blob-type: BlockBlob
+            - Body: 이미지 바이너리
+
+            **[주의사항]**
+            - 허용 확장자: jpg, jpeg, png (대소문자 무관)
+            - URL 유효시간: 발급 후 10분
+            - 이미지 여러 장 업로드 시 이 API를 장 수만큼 반복 호출합니다
+
+            **[에러 코드]**
+            | 코드 | HTTP | 설명 |
+            |------|------|------|
+            | COMMON_004 | 400 | extension 파라미터 누락 |
+            | TEST_003 | 400 | 지원하지 않는 이미지 형식 (jpg, jpeg, png만 허용) |
+            """)
     @PostMapping("/presigned-url")
     public ResponseEntity<ApiResponse<PresignedUrlResponse>> generatePresignedUrl(
+            @Parameter(description = "이미지 확장자 (점 없이 입력, 예: jpg)", example = "jpg")
             @RequestParam String extension
     ) {
         if (!ALLOWED_EXTENSIONS.contains(extension.toLowerCase())) {


### PR DESCRIPTION
  ## 📍 요약                                                                                                            
  프론트엔드가 이미지 업로드 플로우와 각 API를 이해할 수 있도록 Swagger 설명을 보강합니다.                              
                                                                                          
  ## 🔗 관련 이슈                                                                                                       
  Closes #31                                                                                                             
                                                                                                                        
  ## 📌 변경 사항                                                                                                       
- [x] 문서            

      
  ## ✅ 작업 내용
  - Presigned URL 발급 API: 전체 업로드 플로우(3단계), 응답 필드 역할, PUT 업로드 예시(헤더 포함), 에러 코드 추가
  - 테스트 등록 API: categories 가능 값 전체 나열, 이미지 처리 주의사항, 에러 코드, X-User-Id 파라미터 설명 추가 
  - 주관식 문항 등록 API: testId 경로 파라미터, imageKey 선택 필드 안내, 에러 코드, X-User-Id 파라미터 설명 추가        
                                                                                                                        
  ## 테스트                                                                                                             
  로컬 Swagger UI(http://localhost:8080/swagger-ui.html) 렌더링 확인 완료