### PR TITLE
feat: 객관식 문항 등록 API 구현

### DIFF
--- a/src/main/java/server/MATE/domain/question/controller/ObjectiveController.java
+++ b/src/main/java/server/MATE/domain/question/controller/ObjectiveController.java
@@ -52,7 +52,7 @@ public class ObjectiveController {
             @Parameter(description = "테스트 제작자 ID (인증 구현 전 임시 헤더)")
             @RequestHeader("X-User-Id") Long makerId
     ) {
-        ObjectiveCreateResponse response = objectiveService.createObjective(testId, request);
+        ObjectiveCreateResponse response = objectiveService.createObjective(testId, makerId, request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("객관식 문항이 등록되었습니다.", response));
     }

--- a/src/main/java/server/MATE/domain/question/controller/ObjectiveController.java
+++ b/src/main/java/server/MATE/domain/question/controller/ObjectiveController.java
@@ -1,0 +1,59 @@
+package server.MATE.domain.question.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import server.MATE.domain.question.dto.request.ObjectiveCreateRequest;
+import server.MATE.domain.question.dto.response.ObjectiveCreateResponse;
+import server.MATE.domain.question.service.ObjectiveService;
+import server.MATE.global.common.response.ApiResponse;
+
+@Tag(name = "[QUESTION] 문항 API", description = "문항 등록 관련 API")
+@RestController
+@RequestMapping("/api/v1/tests/{testId}/questions")
+@RequiredArgsConstructor
+public class ObjectiveController {
+
+    private final ObjectiveService objectiveService;
+
+    @Operation(summary = "객관식 문항 등록", description = """
+            객관식 문항을 등록합니다.
+
+            **[선택지 (options)]**
+            - 최소 2개, 최대 10개까지 추가 가능합니다.
+            - 선택지에 이미지를 첨부할 경우 이미지 업로드 URL 발급 API로 먼저 업로드한 뒤 받은 imageKey를 전달합니다.
+            - imageKey가 없으면 null로 보내거나 필드를 생략합니다.
+
+            **[중복 선택 (isDuplicate)]**
+            - true: 여러 선택지 선택 가능. minSelect, maxSelect로 선택 개수 범위 설정 가능 (선택값)
+            - false: 단일 선택만 가능. minSelect, maxSelect는 무시됩니다.
+
+            **[기타 직접 입력 (isOther)]**
+            - true: 기타(직접 입력) 선택지가 자동으로 추가됩니다.
+
+            **[에러 코드]**
+            | 코드 | HTTP | 설명 |
+            |------|------|------|
+            | COMMON_002 | 400 | 요청 값 검증 실패 (필수 필드 누락, 글자수 초과 등) |
+            | QUESTION_001 | 400 | 최소 선택 개수는 1 이상이어야 합니다 |
+            | QUESTION_002 | 400 | 최대 선택 개수는 최소 선택 개수 이상이어야 합니다 |
+            | TEST_004 | 404 | 테스트를 찾을 수 없음 |
+            """)
+    @PostMapping("/objective")
+    public ResponseEntity<ApiResponse<ObjectiveCreateResponse>> createObjective(
+            @Parameter(description = "문항을 등록할 테스트 ID")
+            @PathVariable Long testId,
+            @RequestBody @Valid ObjectiveCreateRequest request,
+            @Parameter(description = "테스트 제작자 ID (인증 구현 전 임시 헤더)")
+            @RequestHeader("X-User-Id") Long makerId
+    ) {
+        ObjectiveCreateResponse response = objectiveService.createObjective(testId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created("객관식 문항이 등록되었습니다.", response));
+    }
+}

--- a/src/main/java/server/MATE/domain/question/controller/SubjectiveController.java
+++ b/src/main/java/server/MATE/domain/question/controller/SubjectiveController.java
@@ -29,7 +29,7 @@ public class SubjectiveController {
             @RequestHeader("X-User-Id") Long makerId
     ) {
         SubjectiveCreateResponse response =
-                subjectiveService.createSubjective(testId, request);
+                subjectiveService.createSubjective(testId, makerId, request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("주관식 질문이 등록되었습니다.", response));
     }

--- a/src/main/java/server/MATE/domain/question/controller/SubjectiveController.java
+++ b/src/main/java/server/MATE/domain/question/controller/SubjectiveController.java
@@ -7,29 +7,29 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import server.MATE.domain.question.dto.request.SubjectiveQuestionCreateRequest;
-import server.MATE.domain.question.dto.response.SubjectiveQuestionCreateResponse;
-import server.MATE.domain.question.service.SubjectiveQuestionService;
+import server.MATE.domain.question.dto.request.SubjectiveCreateRequest;
+import server.MATE.domain.question.dto.response.SubjectiveCreateResponse;
+import server.MATE.domain.question.service.SubjectiveService;
 import server.MATE.global.common.response.ApiResponse;
 
 @Tag(name = "[QUESTION] 문항 API", description = "문항 등록 관련 API")
 @RestController
 @RequestMapping("/api/v1/tests/{testId}/questions")
 @RequiredArgsConstructor
-public class SubjectiveQuestionController {
+public class SubjectiveController {
 
-    private final SubjectiveQuestionService subjectiveQuestionService;
+    private final SubjectiveService subjectiveService;
 
     @Operation(summary = "주관식 문항 등록", description = "주관식 문항을 등록합니다.")
     @PostMapping("/subjective")
-    public ResponseEntity<ApiResponse<SubjectiveQuestionCreateResponse>> createSubjectiveQuestion(
+    public ResponseEntity<ApiResponse<SubjectiveCreateResponse>> createSubjective(
             @PathVariable Long testId,
-            @RequestBody @Valid SubjectiveQuestionCreateRequest request,
+            @RequestBody @Valid SubjectiveCreateRequest request,
             // TODO: 인증 구현 후 @AuthenticationPrincipal 등으로 대체
             @RequestHeader("X-User-Id") Long makerId
     ) {
-        SubjectiveQuestionCreateResponse response =
-                subjectiveQuestionService.createSubjectiveQuestion(testId, request);
+        SubjectiveCreateResponse response =
+                subjectiveService.createSubjective(testId, request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("주관식 질문이 등록되었습니다.", response));
     }

--- a/src/main/java/server/MATE/domain/question/dto/request/ObjectiveCreateRequest.java
+++ b/src/main/java/server/MATE/domain/question/dto/request/ObjectiveCreateRequest.java
@@ -1,0 +1,31 @@
+package server.MATE.domain.question.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record ObjectiveCreateRequest(
+        @NotBlank
+        @Size(max = 34, message = "질문 제목은 최대 34자까지 입력 가능합니다.")
+        String title,
+
+        @Size(max = 55, message = "질문 설명은 최대 55자까지 입력 가능합니다.")
+        String description,
+
+        @NotNull(message = "중복 선택 여부는 필수 입력 사항입니다.")
+        Boolean isDuplicate,
+
+        Integer maxSelect,
+        Integer minSelect,
+
+        @NotNull(message = "기타 선택지 여부는 필수 입력 사항입니다.")
+        Boolean isOther,
+
+        @NotNull(message = "선택지는 필수 입력 사항입니다.")
+        @Size(min = 2, max = 10, message = "선택지는 최소 2개, 최대 10개까지 추가 가능합니다.")
+        List<@Valid ObjectiveOptionRequest> options
+) {
+}

--- a/src/main/java/server/MATE/domain/question/dto/request/ObjectiveOptionRequest.java
+++ b/src/main/java/server/MATE/domain/question/dto/request/ObjectiveOptionRequest.java
@@ -1,0 +1,13 @@
+package server.MATE.domain.question.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ObjectiveOptionRequest(
+        @NotBlank
+        @Size(max = 17, message = "선택지명은 최대 17자까지 입력 가능합니다.")
+        String content,
+
+        String imageKey
+) {
+}

--- a/src/main/java/server/MATE/domain/question/dto/request/SubjectiveCreateRequest.java
+++ b/src/main/java/server/MATE/domain/question/dto/request/SubjectiveCreateRequest.java
@@ -3,7 +3,7 @@ package server.MATE.domain.question.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-public record SubjectiveQuestionCreateRequest(
+public record SubjectiveCreateRequest(
         @NotBlank
         @Size(max = 34, message = "질문 제목은 최대 34자까지 입력 가능합니다.")
         String title,

--- a/src/main/java/server/MATE/domain/question/dto/response/ObjectiveCreateResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/ObjectiveCreateResponse.java
@@ -1,0 +1,27 @@
+package server.MATE.domain.question.dto.response;
+
+import server.MATE.domain.question.entity.Objective;
+
+import java.util.List;
+
+public record ObjectiveCreateResponse(
+        Long questionId,
+        boolean isDuplicate,
+        Integer maxSelect,
+        Integer minSelect,
+        boolean isOther,
+        List<ObjectiveOptionResponse> options
+) {
+    public static ObjectiveCreateResponse from(Objective objective) {
+        return new ObjectiveCreateResponse(
+                objective.getId(),
+                objective.isDuplicate(),
+                objective.getMaxSelect(),
+                objective.getMinSelect(),
+                objective.isOther(),
+                objective.getOptions().stream()
+                        .map(ObjectiveOptionResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/ObjectiveOptionResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/ObjectiveOptionResponse.java
@@ -1,0 +1,19 @@
+package server.MATE.domain.question.dto.response;
+
+import server.MATE.domain.question.entity.ObjectiveOption;
+
+public record ObjectiveOptionResponse(
+        Long id,
+        String content,
+        String imageKey,
+        Integer sequence
+) {
+    public static ObjectiveOptionResponse from(ObjectiveOption option) {
+        return new ObjectiveOptionResponse(
+                option.getId(),
+                option.getContent(),
+                option.getImageKey(),
+                option.getSequence()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/SubjectiveCreateResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/SubjectiveCreateResponse.java
@@ -2,12 +2,12 @@ package server.MATE.domain.question.dto.response;
 
 import server.MATE.domain.question.entity.Subjective;
 
-public record SubjectiveQuestionCreateResponse(
+public record SubjectiveCreateResponse(
         Long questionId,
         String imageKey
 ) {
-    public static SubjectiveQuestionCreateResponse from(Subjective subjective) {
-        return new SubjectiveQuestionCreateResponse(
+    public static SubjectiveCreateResponse from(Subjective subjective) {
+        return new SubjectiveCreateResponse(
                 subjective.getId(),
                 subjective.getImageKey()
         );

--- a/src/main/java/server/MATE/domain/question/entity/Objective.java
+++ b/src/main/java/server/MATE/domain/question/entity/Objective.java
@@ -1,0 +1,50 @@
+package server.MATE.domain.question.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@Table(name = "objective")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Objective {
+
+    @Id
+    private Long id;
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
+    private Question question;
+
+    @Column(nullable = false)
+    private boolean isDuplicate;
+
+    private Integer maxSelect;
+    private Integer minSelect;
+
+    @Column(nullable = false)
+    private boolean isOther;
+
+    @OneToMany(mappedBy = "objective", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ObjectiveOption> options = new ArrayList<>();
+
+    @Builder
+    public Objective(Question question, boolean isDuplicate, Integer maxSelect, Integer minSelect, boolean isOther) {
+        this.question = question;
+        this.isDuplicate = isDuplicate;
+        this.maxSelect = maxSelect;
+        this.minSelect = minSelect;
+        this.isOther = isOther;
+    }
+
+    public void addOption(ObjectiveOption option) {
+        options.add(option);
+    }
+}

--- a/src/main/java/server/MATE/domain/question/entity/ObjectiveOption.java
+++ b/src/main/java/server/MATE/domain/question/entity/ObjectiveOption.java
@@ -1,0 +1,39 @@
+package server.MATE.domain.question.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "objective_option")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ObjectiveOption {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "objective_id", nullable = false)
+    private Objective objective;
+
+    @Column(nullable = false, length = 17)
+    private String content;
+
+    @Column(length = 255)
+    private String imageKey;
+
+    @Column(nullable = false)
+    private Integer sequence;
+
+    @Builder
+    public ObjectiveOption(Objective objective, String content, String imageKey, Integer sequence) {
+        this.objective = objective;
+        this.content = content;
+        this.imageKey = imageKey;
+        this.sequence = sequence;
+    }
+}

--- a/src/main/java/server/MATE/domain/question/repository/ObjectiveRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/ObjectiveRepository.java
@@ -1,0 +1,7 @@
+package server.MATE.domain.question.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.MATE.domain.question.entity.Objective;
+
+public interface ObjectiveRepository extends JpaRepository<Objective, Long> {
+}

--- a/src/main/java/server/MATE/domain/question/service/ObjectiveService.java
+++ b/src/main/java/server/MATE/domain/question/service/ObjectiveService.java
@@ -13,6 +13,7 @@ import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.repository.ObjectiveRepository;
 import server.MATE.domain.question.repository.QuestionRepository;
+import server.MATE.domain.test.entity.Test;
 import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
@@ -32,10 +33,15 @@ public class ObjectiveService {
 
     public ObjectiveCreateResponse createObjective(
             Long testId,
+            Long makerId,
             ObjectiveCreateRequest request
     ) {
-        if (!testRepository.existsById(testId)) {
-            throw new BaseException(BaseErrorCode.TEST_004);
+        Test test = testRepository.findById(testId)
+                .filter(t -> t.getDeletedAt() == null)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        if (!test.getMakerId().equals(makerId)) {
+            throw new BaseException(BaseErrorCode.TEST_005);
         }
 
         validateSelectRange(request);

--- a/src/main/java/server/MATE/domain/question/service/ObjectiveService.java
+++ b/src/main/java/server/MATE/domain/question/service/ObjectiveService.java
@@ -1,0 +1,112 @@
+package server.MATE.domain.question.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.question.dto.request.ObjectiveOptionRequest;
+import server.MATE.domain.question.dto.request.ObjectiveCreateRequest;
+import server.MATE.domain.question.dto.response.ObjectiveCreateResponse;
+import server.MATE.domain.question.entity.Objective;
+import server.MATE.domain.question.entity.ObjectiveOption;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.ObjectiveRepository;
+import server.MATE.domain.question.repository.QuestionRepository;
+import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+import server.MATE.global.image.event.ImageCleanupEvent;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ObjectiveService {
+
+    private final TestRepository testRepository;
+    private final QuestionRepository questionRepository;
+    private final ObjectiveRepository objectiveRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public ObjectiveCreateResponse createObjective(
+            Long testId,
+            ObjectiveCreateRequest request
+    ) {
+        if (!testRepository.existsById(testId)) {
+            throw new BaseException(BaseErrorCode.TEST_004);
+        }
+
+        validateSelectRange(request);
+
+        // TODO: 동시성 이슈 - 현재 MAX(sequence)+1 방식은 동시 요청 시 중복 순서값 발생 가능.
+        //  별도 시퀀스 관리 로직 개발 후 수정 예정.
+        Long sequence = questionRepository.findMaxSequenceByTestId(testId) + 1;
+
+        Question question = Question.builder()
+                .testId(testId)
+                .questionType(QuestionType.MULTIPLE_CHOICE)
+                .title(request.title())
+                .description(request.description())
+                .sequence(sequence)
+                .build();
+        questionRepository.save(question);
+
+        Integer maxSelect = request.isDuplicate() ? request.maxSelect() : null;
+        Integer minSelect = request.isDuplicate() ? request.minSelect() : null;
+
+        Objective objective = Objective.builder()
+                .question(question)
+                .isDuplicate(request.isDuplicate())
+                .maxSelect(maxSelect)
+                .minSelect(minSelect)
+                .isOther(request.isOther())
+                .build();
+
+        List<ObjectiveOptionRequest> optionRequests = request.options();
+        for (int i = 0; i < optionRequests.size(); i++) {
+            ObjectiveOptionRequest optionRequest = optionRequests.get(i);
+            ObjectiveOption option = ObjectiveOption.builder()
+                    .objective(objective)
+                    .content(optionRequest.content())
+                    .imageKey(optionRequest.imageKey())
+                    .sequence(i + 1)
+                    .build();
+            objective.addOption(option);
+        }
+
+        List<String> imageKeys = optionRequests.stream()
+                .map(ObjectiveOptionRequest::imageKey)
+                .filter(key -> key != null)
+                .toList();
+        if (!imageKeys.isEmpty()) {
+            eventPublisher.publishEvent(new ImageCleanupEvent(imageKeys));
+        }
+
+        objectiveRepository.save(objective);
+
+        return ObjectiveCreateResponse.from(objective);
+    }
+
+    private void validateSelectRange(ObjectiveCreateRequest request) {
+        if (!request.isDuplicate()) return;
+
+        Integer min = request.minSelect();
+        Integer max = request.maxSelect();
+        int optionCount = request.options().size();
+
+        if (min != null && min < 1) {
+            throw new BaseException(BaseErrorCode.QUESTION_001);
+        }
+        if (min != null && max != null && max < min) {
+            throw new BaseException(BaseErrorCode.QUESTION_002);
+        }
+        if (max != null && max > optionCount) {
+            throw new BaseException(BaseErrorCode.QUESTION_003);
+        }
+        if (min != null && min > optionCount) {
+            throw new BaseException(BaseErrorCode.QUESTION_003);
+        }
+    }
+}

--- a/src/main/java/server/MATE/domain/question/service/SubjectiveService.java
+++ b/src/main/java/server/MATE/domain/question/service/SubjectiveService.java
@@ -4,8 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import server.MATE.domain.question.dto.request.SubjectiveQuestionCreateRequest;
-import server.MATE.domain.question.dto.response.SubjectiveQuestionCreateResponse;
+import server.MATE.domain.question.dto.request.SubjectiveCreateRequest;
+import server.MATE.domain.question.dto.response.SubjectiveCreateResponse;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.entity.Subjective;
@@ -22,16 +22,16 @@ import java.util.List;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class SubjectiveQuestionService {
+public class SubjectiveService {
 
     private final TestRepository testRepository;
     private final QuestionRepository questionRepository;
     private final SubjectiveRepository subjectiveRepository;
     private final ApplicationEventPublisher eventPublisher;
 
-    public SubjectiveQuestionCreateResponse createSubjectiveQuestion(
+    public SubjectiveCreateResponse createSubjective(
             Long testId,
-            SubjectiveQuestionCreateRequest request
+            SubjectiveCreateRequest request
     ) {
         if (!testRepository.existsById(testId)) {
             throw new BaseException(BaseErrorCode.TEST_004);
@@ -60,6 +60,6 @@ public class SubjectiveQuestionService {
         questionRepository.save(question);
         subjectiveRepository.save(subjective);
 
-        return SubjectiveQuestionCreateResponse.from(subjective);
+        return SubjectiveCreateResponse.from(subjective);
     }
 }

--- a/src/main/java/server/MATE/domain/question/service/SubjectiveService.java
+++ b/src/main/java/server/MATE/domain/question/service/SubjectiveService.java
@@ -11,10 +11,10 @@ import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.entity.Subjective;
 import server.MATE.domain.question.repository.QuestionRepository;
 import server.MATE.domain.question.repository.SubjectiveRepository;
+import server.MATE.domain.test.entity.Test;
 import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
-import server.MATE.global.common.exception.ErrorCode;
 import server.MATE.global.image.event.ImageCleanupEvent;
 
 import java.util.List;
@@ -31,10 +31,15 @@ public class SubjectiveService {
 
     public SubjectiveCreateResponse createSubjective(
             Long testId,
+            Long makerId,
             SubjectiveCreateRequest request
     ) {
-        if (!testRepository.existsById(testId)) {
-            throw new BaseException(BaseErrorCode.TEST_004);
+        Test test = testRepository.findById(testId)
+                .filter(t -> t.getDeletedAt() == null)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        if (!test.getMakerId().equals(makerId)) {
+            throw new BaseException(BaseErrorCode.TEST_005);
         }
 
         // TODO: 동시성 이슈 - 현재 MAX(sequence)+1 방식은 동시 요청 시 중복 순서값 발생 가능.

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -27,6 +27,11 @@ public enum BaseErrorCode implements ErrorCode {
     TEST_003(HttpStatus.BAD_REQUEST, "TEST_003", "지원하지 않는 이미지 형식입니다. JPG, PNG만 허용됩니다."),
     TEST_004(HttpStatus.NOT_FOUND, "TEST_004", "테스트를 찾을 수 없습니다."),
 
+    // Question
+    QUESTION_001(HttpStatus.BAD_REQUEST, "QUESTION_001", "최소 선택 개수는 1 이상이어야 합니다."),
+    QUESTION_002(HttpStatus.BAD_REQUEST, "QUESTION_002", "최대 선택 개수는 최소 선택 개수 이상이어야 합니다."),
+    QUESTION_003(HttpStatus.BAD_REQUEST, "QUESTION_003", "최대 선택 개수는 선택지 개수를 초과할 수 없습니다."),
+
     // File
     FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_001", "파일 업로드에 실패했습니다."),
 

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -26,6 +26,7 @@ public enum BaseErrorCode implements ErrorCode {
     TEST_002(HttpStatus.BAD_REQUEST, "TEST_002", "이미지는 최대 10개까지 업로드할 수 있습니다."),
     TEST_003(HttpStatus.BAD_REQUEST, "TEST_003", "지원하지 않는 이미지 형식입니다. JPG, PNG만 허용됩니다."),
     TEST_004(HttpStatus.NOT_FOUND, "TEST_004", "테스트를 찾을 수 없습니다."),
+    TEST_005(HttpStatus.FORBIDDEN, "TEST_005", "테스트 제작자만 접근할 수 있습니다."),
 
     // Question
     QUESTION_001(HttpStatus.BAD_REQUEST, "QUESTION_001", "최소 선택 개수는 1 이상이어야 합니다."),


### PR DESCRIPTION
  ## 📍 요약      
  객관식 문항 등록 API를 구현합니다. 중복 선택, 기타 직접 입력, 선택지별 이미지 첨부를 지원합니다.

  ## 🔗 관련 이슈                                                                                                       
  Closes #20 
                                                                                                                        
  ## 📌 변경 사항 
- [x] 기능
- [x] 리팩토링
                
  ## ✅ 작업 내용                                                                                                       
  - `Objective`, `ObjectiveOption` 엔티티 추가
  - 객관식 문항 등록 요청/응답 DTO 추가                                                                                 
  - 객관식 문항 등록 서비스 구현       
    - `isDuplicate=false` 시 `minSelect/maxSelect null` 처리                                                                
    - `minSelect/maxSelect` 범위 검증 (QUESTION_001~003)  
    - `ImageCleanupEvent`를 save 이전에 발행하여 롤백 시 이미지 누수 방지                                                 
  - 객관식 문항 등록 API 구현 (`POST /api/v1/tests/{testId}/questions/objective`)                                         
  - QUESTION_001~003 에러 코드 추가                                                                                     
  - 주관식 문항 클래스명 Question 중복 제거 (SubjectiveQuestion* → Subjective*)                                         
                                                                                                                        
  ## 테스트                                                                                                             
- [x] 로컬 테스트 완료
- 로컬 Swagger UI에서 아래 케이스 확인 완료
    - 단일/중복 선택 정상 등록                                                                                            
    - 선택지 2개 미만 / 10개 초과 시 400                                                                                  
    - maxSelect/minSelect가 선택지 개수 초과 시 400
    - 존재하지 않는 testId 시 404   
