### PR TITLE
feat: 5초 테스트 문항 등록 API 구현

### DIFF
--- a/src/main/java/server/MATE/domain/question/controller/FiveSecondController.java
+++ b/src/main/java/server/MATE/domain/question/controller/FiveSecondController.java
@@ -1,0 +1,61 @@
+package server.MATE.domain.question.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import server.MATE.domain.question.dto.request.FiveSecondCreateRequest;
+import server.MATE.domain.question.dto.response.FiveSecondCreateResponse;
+import server.MATE.domain.question.service.FiveSecondService;
+import server.MATE.global.common.response.ApiResponse;
+
+@Tag(name = "[QUESTION] 문항 API", description = "문항 등록 관련 API")
+@RestController
+@RequestMapping("/api/v1/tests/{testId}/questions")
+@RequiredArgsConstructor
+public class FiveSecondController {
+
+    private final FiveSecondService fiveSecondService;
+
+    @Operation(summary = "5초 테스트 문항 등록", description = """
+            5초 테스트 문항을 등록합니다.
+
+            **[이미지 (imageKey)]**
+            - 이미지는 필수입니다. 이미지 업로드 URL 발급 API로 먼저 업로드한 뒤 받은 imageKey를 전달합니다.
+
+            **[객관식 전환 (isObjective)]**
+            - false: 이미지만 노출하고 참여자가 자유롭게 답변합니다. options, isDuplicate, minSelect, maxSelect는 무시됩니다.
+            - true: 이미지 하단에 선택지가 노출됩니다. 선택지는 최소 2개 이상 필요합니다.
+
+            **[중복 선택 (isDuplicate)] - isObjective=true일 때만 유효**
+            - true: 여러 선택지 선택 가능. minSelect, maxSelect로 선택 개수 범위 설정 가능 (선택값)
+            - false: 단일 선택만 가능.
+
+            **[에러 코드]**
+            | 코드 | HTTP | 설명 |
+            |------|------|------|
+            | COMMON_002 | 400 | 요청 값 검증 실패 (필수 필드 누락, 글자수 초과 등) |
+            | QUESTION_001 | 400 | 최소 선택 개수는 1 이상이어야 합니다 |
+            | QUESTION_002 | 400 | 최대 선택 개수는 최소 선택 개수 이상이어야 합니다 |
+            | QUESTION_003 | 400 | 최소/최대 선택 개수는 선택지 개수를 초과할 수 없습니다 |
+            | QUESTION_004 | 400 | 객관식 전환 시 선택지는 최소 2개 이상이어야 합니다 |
+            | TEST_004 | 404 | 테스트를 찾을 수 없음 |
+            | TEST_005 | 403 | 테스트 제작자만 접근할 수 있음 |
+            """)
+    @PostMapping("/fivesecond")
+    public ResponseEntity<ApiResponse<FiveSecondCreateResponse>> createFiveSecond(
+            @Parameter(description = "문항을 등록할 테스트 ID")
+            @PathVariable Long testId,
+            @RequestBody @Valid FiveSecondCreateRequest request,
+            @Parameter(description = "테스트 제작자 ID (인증 구현 전 임시 헤더)")
+            @RequestHeader("X-User-Id") Long makerId
+    ) {
+        FiveSecondCreateResponse response = fiveSecondService.createFiveSecond(testId, makerId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created("5초 테스트 문항이 등록되었습니다.", response));
+    }
+}

--- a/src/main/java/server/MATE/domain/question/dto/request/FiveSecondCreateRequest.java
+++ b/src/main/java/server/MATE/domain/question/dto/request/FiveSecondCreateRequest.java
@@ -1,0 +1,31 @@
+package server.MATE.domain.question.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record FiveSecondCreateRequest(
+        @NotBlank
+        @Size(max = 34, message = "질문 제목은 최대 34자까지 입력 가능합니다.")
+        String title,
+
+        @Size(max = 50, message = "질문 설명은 최대 50자까지 입력 가능합니다.")
+        String description,
+
+        @NotBlank(message = "이미지는 필수 입력 사항입니다.")
+        String imageKey,
+
+        @NotNull(message = "객관식 전환 여부는 필수 입력 사항입니다.")
+        Boolean isObjective,
+
+        Boolean isDuplicate,
+        Integer minSelect,
+        Integer maxSelect,
+
+        @Size(max = 10, message = "선택지는 최대 10개까지 추가 가능합니다.")
+        List<@Valid FiveSecondOptionRequest> options
+) {
+}

--- a/src/main/java/server/MATE/domain/question/dto/request/FiveSecondOptionRequest.java
+++ b/src/main/java/server/MATE/domain/question/dto/request/FiveSecondOptionRequest.java
@@ -1,0 +1,11 @@
+package server.MATE.domain.question.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record FiveSecondOptionRequest(
+        @NotBlank
+        @Size(max = 50, message = "선택지 내용은 최대 50자까지 입력 가능합니다.")
+        String content
+) {
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/FiveSecondCreateResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/FiveSecondCreateResponse.java
@@ -1,0 +1,29 @@
+package server.MATE.domain.question.dto.response;
+
+import server.MATE.domain.question.entity.FiveSecond;
+
+import java.util.List;
+
+public record FiveSecondCreateResponse(
+        Long questionId,
+        String imageKey,
+        boolean isObjective,
+        Boolean isDuplicate,
+        Integer minSelect,
+        Integer maxSelect,
+        List<FiveSecondOptionResponse> options
+) {
+    public static FiveSecondCreateResponse from(FiveSecond fiveSecond) {
+        return new FiveSecondCreateResponse(
+                fiveSecond.getId(),
+                fiveSecond.getImageKey(),
+                fiveSecond.isObjective(),
+                fiveSecond.getIsDuplicate(),
+                fiveSecond.getMinSelect(),
+                fiveSecond.getMaxSelect(),
+                fiveSecond.getOptions().stream()
+                        .map(FiveSecondOptionResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/FiveSecondOptionResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/FiveSecondOptionResponse.java
@@ -1,0 +1,17 @@
+package server.MATE.domain.question.dto.response;
+
+import server.MATE.domain.question.entity.FiveSecondOption;
+
+public record FiveSecondOptionResponse(
+        Long id,
+        String content,
+        Integer sequence
+) {
+    public static FiveSecondOptionResponse from(FiveSecondOption option) {
+        return new FiveSecondOptionResponse(
+                option.getId(),
+                option.getContent(),
+                option.getSequence()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/question/entity/FiveSecond.java
+++ b/src/main/java/server/MATE/domain/question/entity/FiveSecond.java
@@ -1,0 +1,53 @@
+package server.MATE.domain.question.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@Table(name = "five_second")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FiveSecond {
+
+    @Id
+    private Long id;
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
+    private Question question;
+
+    @Column(nullable = false, length = 255)
+    private String imageKey;
+
+    @Column(nullable = false)
+    private boolean isObjective;
+
+    private Boolean isDuplicate;
+    private Integer minSelect;
+    private Integer maxSelect;
+
+    @OneToMany(mappedBy = "fiveSecond", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FiveSecondOption> options = new ArrayList<>();
+
+    @Builder
+    public FiveSecond(Question question, String imageKey, boolean isObjective,
+                      Boolean isDuplicate, Integer minSelect, Integer maxSelect) {
+        this.question = question;
+        this.imageKey = imageKey;
+        this.isObjective = isObjective;
+        this.isDuplicate = isDuplicate;
+        this.minSelect = minSelect;
+        this.maxSelect = maxSelect;
+    }
+
+    public void addOption(FiveSecondOption option) {
+        options.add(option);
+    }
+}

--- a/src/main/java/server/MATE/domain/question/entity/FiveSecondOption.java
+++ b/src/main/java/server/MATE/domain/question/entity/FiveSecondOption.java
@@ -1,0 +1,35 @@
+package server.MATE.domain.question.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "five_second_option")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FiveSecondOption {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "five_second_id", nullable = false)
+    private FiveSecond fiveSecond;
+
+    @Column(nullable = false, length = 50)
+    private String content;
+
+    @Column(nullable = false)
+    private Integer sequence;
+
+    @Builder
+    public FiveSecondOption(FiveSecond fiveSecond, String content, Integer sequence) {
+        this.fiveSecond = fiveSecond;
+        this.content = content;
+        this.sequence = sequence;
+    }
+}

--- a/src/main/java/server/MATE/domain/question/repository/FiveSecondRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/FiveSecondRepository.java
@@ -1,0 +1,7 @@
+package server.MATE.domain.question.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.MATE.domain.question.entity.FiveSecond;
+
+public interface FiveSecondRepository extends JpaRepository<FiveSecond, Long> {
+}

--- a/src/main/java/server/MATE/domain/question/service/FiveSecondService.java
+++ b/src/main/java/server/MATE/domain/question/service/FiveSecondService.java
@@ -1,0 +1,115 @@
+package server.MATE.domain.question.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.question.dto.request.FiveSecondCreateRequest;
+import server.MATE.domain.question.dto.request.FiveSecondOptionRequest;
+import server.MATE.domain.question.dto.response.FiveSecondCreateResponse;
+import server.MATE.domain.question.entity.FiveSecond;
+import server.MATE.domain.question.entity.FiveSecondOption;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.FiveSecondRepository;
+import server.MATE.domain.question.repository.QuestionRepository;
+import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+import server.MATE.global.image.event.ImageCleanupEvent;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FiveSecondService {
+
+    private final TestRepository testRepository;
+    private final QuestionRepository questionRepository;
+    private final FiveSecondRepository fiveSecondRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public FiveSecondCreateResponse createFiveSecond(Long testId, Long makerId, FiveSecondCreateRequest request) {
+        Test test = testRepository.findById(testId)
+                .filter(t -> t.getDeletedAt() == null)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        if (!test.getMakerId().equals(makerId)) {
+            throw new BaseException(BaseErrorCode.TEST_005);
+        }
+
+        validateRequest(request);
+
+        // TODO: 동시성 이슈 - 현재 MAX(sequence)+1 방식은 동시 요청 시 중복 순서값 발생 가능.
+        //  별도 시퀀스 관리 로직 개발 후 수정 예정.
+        Long sequence = questionRepository.findMaxSequenceByTestId(testId) + 1;
+
+        eventPublisher.publishEvent(new ImageCleanupEvent(List.of(request.imageKey())));
+
+        Question question = Question.builder()
+                .testId(testId)
+                .questionType(QuestionType.FIVE_SECOND_TEST)
+                .title(request.title())
+                .description(request.description())
+                .sequence(sequence)
+                .build();
+        questionRepository.save(question);
+
+        boolean isDuplicate = Boolean.TRUE.equals(request.isDuplicate());
+        Integer minSelect = (request.isObjective() && isDuplicate) ? request.minSelect() : null;
+        Integer maxSelect = (request.isObjective() && isDuplicate) ? request.maxSelect() : null;
+
+        FiveSecond fiveSecond = FiveSecond.builder()
+                .question(question)
+                .imageKey(request.imageKey())
+                .isObjective(request.isObjective())
+                .isDuplicate(request.isObjective() ? request.isDuplicate() : null)
+                .minSelect(minSelect)
+                .maxSelect(maxSelect)
+                .build();
+
+        if (request.isObjective() && request.options() != null) {
+            List<FiveSecondOptionRequest> optionRequests = request.options();
+            for (int i = 0; i < optionRequests.size(); i++) {
+                FiveSecondOption option = FiveSecondOption.builder()
+                        .fiveSecond(fiveSecond)
+                        .content(optionRequests.get(i).content())
+                        .sequence(i + 1)
+                        .build();
+                fiveSecond.addOption(option);
+            }
+        }
+
+        fiveSecondRepository.save(fiveSecond);
+
+        return FiveSecondCreateResponse.from(fiveSecond);
+    }
+
+    private void validateRequest(FiveSecondCreateRequest request) {
+        if (!request.isObjective()) return;
+
+        List<FiveSecondOptionRequest> options = request.options();
+        if (options == null || options.size() < 2) {
+            throw new BaseException(BaseErrorCode.QUESTION_004);
+        }
+
+        int optionCount = options.size();
+        Integer min = request.minSelect();
+        Integer max = request.maxSelect();
+
+        if (min != null && min < 1) {
+            throw new BaseException(BaseErrorCode.QUESTION_001);
+        }
+        if (min != null && max != null && max < min) {
+            throw new BaseException(BaseErrorCode.QUESTION_002);
+        }
+        if (min != null && min > optionCount) {
+            throw new BaseException(BaseErrorCode.QUESTION_003);
+        }
+        if (max != null && max > optionCount) {
+            throw new BaseException(BaseErrorCode.QUESTION_003);
+        }
+    }
+}

--- a/src/main/java/server/MATE/domain/question/service/FiveSecondService.java
+++ b/src/main/java/server/MATE/domain/question/service/FiveSecondService.java
@@ -95,6 +95,8 @@ public class FiveSecondService {
             throw new BaseException(BaseErrorCode.QUESTION_004);
         }
 
+        if (!Boolean.TRUE.equals(request.isDuplicate())) return;
+
         int optionCount = options.size();
         Integer min = request.minSelect();
         Integer max = request.maxSelect();

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -26,6 +26,13 @@ public enum BaseErrorCode implements ErrorCode {
     TEST_002(HttpStatus.BAD_REQUEST, "TEST_002", "이미지는 최대 10개까지 업로드할 수 있습니다."),
     TEST_003(HttpStatus.BAD_REQUEST, "TEST_003", "지원하지 않는 이미지 형식입니다. JPG, PNG만 허용됩니다."),
     TEST_004(HttpStatus.NOT_FOUND, "TEST_004", "테스트를 찾을 수 없습니다."),
+    TEST_005(HttpStatus.FORBIDDEN, "TEST_005", "테스트 제작자만 접근할 수 있습니다."),
+
+    // Question
+    QUESTION_001(HttpStatus.BAD_REQUEST, "QUESTION_001", "최소 선택 개수는 1 이상이어야 합니다."),
+    QUESTION_002(HttpStatus.BAD_REQUEST, "QUESTION_002", "최대 선택 개수는 최소 선택 개수 이상이어야 합니다."),
+    QUESTION_003(HttpStatus.BAD_REQUEST, "QUESTION_003", "최소/최대 선택 개수는 선택지 개수를 초과할 수 없습니다."),
+    QUESTION_004(HttpStatus.BAD_REQUEST, "QUESTION_004", "객관식 전환 시 선택지는 최소 2개 이상이어야 합니다."),
 
     // File
     FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_001", "파일 업로드에 실패했습니다."),


### PR DESCRIPTION
## 📍 요약
  - 5초 테스트 문항 등록 API 구현

## 🔗 관련 이슈
- Closes #21 

## 📌 변경 사항
- [x] 기능

## ✅ 작업 내용
  - FiveSecond, FiveSecondOption 엔티티 추가                                               
  - 등록 요청/응답 DTO 추가
  - 테스트 소유자 검증 및 soft-delete 필터 적용
  - 입력값 검증 (선택지 수, minSelect/maxSelect 범위)                                      
  - ImageCleanupEvent 발행 — 롤백 시 업로드된 이미지 자동 정리
  - Swagger 문서 작성 (에러 코드 포함)                                                     
  - BaseErrorCode에 QUESTION_001~004, TEST_005 추가

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - Swagger UI로 주관식/객관식 케이스 및 에러 케이스 확인   
