### PR TITLE
feat: 테스트 삭제 API 구현 (#19)

### DIFF
--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -45,4 +45,15 @@ public class TestController {
         TestUpdateResponse response = testService.updateTest(testId, request, makerId);
         return ResponseEntity.ok(ApiResponse.ok("테스트가 수정되었습니다.", response));
     }
+
+    @Operation(summary = "테스트 삭제", description = "테스트를 삭제합니다.")
+    @DeleteMapping("/{testId}")
+    public ResponseEntity<Void> deleteTest(
+            @PathVariable Long testId,
+            // TODO: 인증 구현 후 @AuthenticationPrincipal 등으로 대체
+            @RequestHeader("X-User-Id") Long makerId
+    ) {
+        testService.deleteTest(testId, makerId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -48,12 +48,12 @@ public class TestController {
 
     @Operation(summary = "테스트 삭제", description = "테스트를 삭제합니다.")
     @DeleteMapping("/{testId}")
-    public ResponseEntity<Void> deleteTest(
+    public ResponseEntity<ApiResponse<Void>> deleteTest(
             @PathVariable Long testId,
             // TODO: 인증 구현 후 @AuthenticationPrincipal 등으로 대체
             @RequestHeader("X-User-Id") Long makerId
     ) {
         testService.deleteTest(testId, makerId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(ApiResponse.ok("테스트가 삭제되었습니다.", null));
     }
 }

--- a/src/main/java/server/MATE/domain/test/entity/Test.java
+++ b/src/main/java/server/MATE/domain/test/entity/Test.java
@@ -85,6 +85,10 @@ public class Test extends BaseEntity {
         }
     }
 
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
     @Builder
     public Test(Long makerId, String title, String description, String serviceName,
                 String serviceDescription, List<String> imageKeys) {

--- a/src/main/java/server/MATE/domain/test/entity/Test.java
+++ b/src/main/java/server/MATE/domain/test/entity/Test.java
@@ -85,8 +85,8 @@ public class Test extends BaseEntity {
         }
     }
 
-    public void delete() {
-        this.deletedAt = LocalDateTime.now();
+    public void delete(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
     }
 
     @Builder

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -85,4 +85,20 @@ public class TestService {
         testRepository.saveAndFlush(test);
         return TestUpdateResponse.from(test);
     }
+
+    public void deleteTest(Long testId, Long makerId) {
+        Test test = testRepository.findById(testId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        if (!test.getMakerId().equals(makerId)) {
+            throw new BaseException(BaseErrorCode.TEST_005);
+        }
+
+        List<String> imageKeys = List.copyOf(test.getImageKeys());
+        if (!imageKeys.isEmpty()) {
+            eventPublisher.publishEvent(new ImageDeleteEvent(imageKeys));
+        }
+
+        test.delete();
+    }
 }

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -15,6 +15,8 @@ import server.MATE.global.common.exception.BaseException;
 import server.MATE.global.image.event.ImageCleanupEvent;
 import server.MATE.global.image.event.ImageDeleteEvent;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -25,6 +27,7 @@ public class TestService {
 
     private final TestRepository testRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final Clock clock;
 
     public TestCreateResponse createTest(TestCreateRequest request, Long makerId) {
         List<String> imageKeys = request.imageKeys() != null ? request.imageKeys() : List.of();
@@ -47,6 +50,7 @@ public class TestService {
 
     public TestUpdateResponse updateTest(Long testId, TestUpdateRequest request, Long makerId) {
         Test test = testRepository.findById(testId)
+                .filter(t -> t.getDeletedAt() == null)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
         if (!test.getMakerId().equals(makerId)) {
@@ -88,6 +92,7 @@ public class TestService {
 
     public void deleteTest(Long testId, Long makerId) {
         Test test = testRepository.findById(testId)
+                .filter(t -> t.getDeletedAt() == null)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
         if (!test.getMakerId().equals(makerId)) {
@@ -99,6 +104,6 @@ public class TestService {
             eventPublisher.publishEvent(new ImageDeleteEvent(imageKeys));
         }
 
-        test.delete();
+        test.delete(LocalDateTime.now(clock));
     }
 }

--- a/src/main/java/server/MATE/global/config/ClockConfig.java
+++ b/src/main/java/server/MATE/global/config/ClockConfig.java
@@ -1,0 +1,15 @@
+package server.MATE.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -8,6 +8,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.Clock;
 import server.MATE.domain.test.dto.request.TestUpdateRequest;
 import server.MATE.domain.test.entity.Category;
 import server.MATE.domain.test.repository.TestRepository;
@@ -31,6 +33,9 @@ class TestServiceTest {
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private Clock clock;
 
     @InjectMocks
     private TestService testService;


### PR DESCRIPTION
## 📍 요약
- 테스트 소유자만 테스트를 삭제할 수 있는 DELETE API 추가

## 🔗 관련 이슈
- Closes #19

## 📌 변경 사항
- [x] 기능

## ✅ 작업 내용
  - `DELETE /api/v1/tests/{testId}` 엔드포인트 추가
  - 소유자 검증 로직 추가 (불일치 시 TEST_005 / 403 응답)                                 
  - 소프트 삭제 처리 (`deletedAt` 설정)                                                   
  - 삭제 시 Azure Blob 이미지 자동 삭제 처리 

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `./gradlew test`
  - Postman으로 DELETE 요청
