### PR TITLE
 refactor: presigned-url 엔드포인트 경로 수정 및 인증 추가

### DIFF
--- a/src/main/java/server/MATE/global/image/ImageController.java
+++ b/src/main/java/server/MATE/global/image/ImageController.java
@@ -2,6 +2,7 @@ package server.MATE.global.image;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +21,8 @@ import java.util.UUID;
 
 @Tag(name = "[IMAGE] 이미지 API", description = "이미지 업로드 관련 API")
 @RestController
-@RequestMapping("/api/v1/images")
+@RequestMapping("/api/v1/uploads")
+@SecurityRequirement(name = "JWT")
 @RequiredArgsConstructor
 public class ImageController {
 
@@ -57,7 +59,7 @@ public class ImageController {
             | COMMON_004 | 400 | extension 파라미터 누락 |
             | TEST_003 | 400 | 지원하지 않는 이미지 형식 (jpg, jpeg, png만 허용) |
             """)
-    @PostMapping("/presigned-url")
+    @PostMapping("/presigned-urls")
     public ResponseEntity<ApiResponse<PresignedUrlResponse>> generatePresignedUrl(
             @Parameter(description = "이미지 확장자 (점 없이 입력, 예: jpg)", example = "jpg")
             @RequestParam String extension

--- a/src/main/java/server/MATE/global/image/ImageController.java
+++ b/src/main/java/server/MATE/global/image/ImageController.java
@@ -2,7 +2,6 @@ package server.MATE.global.image;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +21,6 @@ import java.util.UUID;
 @Tag(name = "[IMAGE] 이미지 API", description = "이미지 업로드 관련 API")
 @RestController
 @RequestMapping("/api/v1/uploads")
-@SecurityRequirement(name = "JWT")
 @RequiredArgsConstructor
 public class ImageController {
 


### PR DESCRIPTION
  ## 📍 요약
  - POST /api/v1/images/presigned-url → /api/v1/uploads/presigned-urls 경로 변경                                        
  - @SecurityRequirement(name = "JWT") 추가로 Swagger 인증 표시 보완                                                    
                                                                                                                        
  ## 🔗 관련 이슈 
  - Closes #42                                                                                          
                                                                                                                        
  ## 📌 변경 사항 (리팩토링)                                                                                            
  - `ImageController` — 
      @RequestMapping /images → /uploads, 
      @PostMapping /presigned-url → /presigned-urls               
  - `ImageController` — @SecurityRequirement(name = "JWT") 추가                                          
                                                                                                                        
  ## ✅ 작업 내용 
  - [x] 엔드포인트 경로 변경                                                                                            
  - [x] Swagger 인증 어노테이션 추가
                                                                                                                        
  ## 테스트                                                                                                             
  로컬 빌드 확인 완료