### PR TITLE
fix: QuestionServiceTest, TestServiceTest 테스트 코드 수정

### DIFF
--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
@@ -5,11 +5,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.test.util.ReflectionTestUtils;
 import server.MATE.domain.question.dto.request.ObjectiveCreateRequest;
 import server.MATE.domain.question.dto.request.ObjectiveOptionRequest;
 import server.MATE.domain.question.dto.request.QuestionCreateRequest;
@@ -56,7 +54,6 @@ class QuestionServiceTest {
     @Mock
     private QuestionCreateHandler scaleHandler;
 
-    @InjectMocks
     private QuestionService questionService;
 
     private static final Long TEST_ID = 10L;
@@ -75,10 +72,11 @@ class QuestionServiceTest {
                 .imageKeys(List.of())
                 .build();
 
-        ReflectionTestUtils.setField(questionService, "handlers", List.of(objectiveHandler, scaleHandler));
-
         lenient().when(objectiveHandler.supports()).thenReturn(QuestionType.OBJECTIVE);
         lenient().when(scaleHandler.supports()).thenReturn(QuestionType.SCALE);
+
+        questionService = new QuestionService(testRepository, questionRepository, eventPublisher,
+                List.of(objectiveHandler, scaleHandler));
         lenient().when(questionRepository.save(any(Question.class))).thenAnswer(invocation -> invocation.getArgument(0));
     }
 

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -59,7 +59,7 @@ class TestServiceTest {
 
     @Test
     void 이미지_교체_시_추가된_키는_CleanupEvent_제거된_키는_DeleteEvent_발행() {
-        given(testRepository.findById(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
 
         // old: [old-key-1, old-key-2] → new: [old-key-1, new-key-1]
         TestUpdateRequest request = new TestUpdateRequest(null, null, null, null, null,
@@ -85,7 +85,7 @@ class TestServiceTest {
 
     @Test
     void 이미지_필드_생략_시_이벤트_미발행() {
-        given(testRepository.findById(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
 
         TestUpdateRequest request = new TestUpdateRequest("새 제목", null, null, null, null, null);
         testService.updateTest(TEST_ID, request, MAKER_ID);


### PR DESCRIPTION
  ## 📍 요약                                                                                                            
  - #28 머지 이후 변경된 서비스 구현과 맞지 않아 실패하던 테스트 2종 수정                                               
                                                                         
  ## 🔗 관련 이슈 
  - Closes #53                                                                                           
                                                                                                                        
  ## 📌 변경 사항 (버그수정)                                                                                            
  - `TestServiceTest` — findById mock을 findByIdAndDeletedAtIsNull로 교체                                               
  - `QuestionServiceTest` — @InjectMocks 제거, @BeforeEach에서 QuestionService 직접 생성 및 핸들러 주입 순서 수정
                                                                                                                        
  ## ✅ 작업 내용                                                                                                       
  - [x] TestServiceTest mock 메서드 수정                                                                                
  - [x] QuestionServiceTest 생성자 주입 방식으로 변경                                                                   
                                                                                                                        
  ## 테스트
  75개 전체 통과 확인