### PR TITLE
feat: 테스트 질문 조회 API 구현

### DIFF
--- a/src/main/java/server/MATE/domain/question/controller/QuestionController.java
+++ b/src/main/java/server/MATE/domain/question/controller/QuestionController.java
@@ -1,6 +1,7 @@
 package server.MATE.domain.question.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import server.MATE.domain.question.dto.request.QuestionCreateRequest;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
+import server.MATE.domain.question.dto.response.QuestionDetailResponse;
 import server.MATE.domain.question.service.QuestionService;
 import server.MATE.global.common.response.ApiResponse;
 import server.MATE.global.security.principal.AuthenticatedUser;
@@ -29,6 +32,241 @@ import server.MATE.global.security.principal.AuthenticatedUser;
 public class QuestionController {
 
     private final QuestionService questionService;
+
+    @Operation(summary = "질문 문항 목록 조회", description = """
+            특정 테스트에 등록된 질문 문항 목록을 조회합니다.
+            - 응답 루트에 `testId`와 `questions`를 함께 반환합니다.
+            - `questions` 배열은 `sequence` 오름차순입니다.
+            - 각 질문 항목은 공통 필드와 유형별 상세 필드를 모두 포함합니다.
+            """)
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "객관식 조회",
+                                            summary = "OBJECTIVE 조회 예시",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "code": "200",
+                                                      "message": "문항을 조회했습니다.",
+                                                      "data": {
+                                                        "testId": 10,
+                                                        "questions": [
+                                                          {
+                                                            "questionId": 101,
+                                                            "objectiveId": 101,
+                                                            "type": "OBJECTIVE",
+                                                            "sequence": 1,
+                                                            "title": "가장 자주 사용하는 기능은 무엇인가요?",
+                                                            "description": "해당 서비스를 사용할 때 가장 자주 쓰는 기능을 골라주세요.",
+                                                            "isDuplicate": false,
+                                                            "minSelect": null,
+                                                            "maxSelect": null,
+                                                            "isOther": true,
+                                                            "options": [
+                                                              { "objectiveOptionId": 1001, "content": "검색", "imageKey": null, "sequence": 1 },
+                                                              { "objectiveOptionId": 1002, "content": "결제", "imageKey": "objective-option-image-key", "sequence": 2 }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "주관식 조회",
+                                            summary = "SUBJECTIVE 조회 예시",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "code": "200",
+                                                      "message": "문항을 조회했습니다.",
+                                                      "data": {
+                                                        "testId": 10,
+                                                        "questions": [
+                                                          {
+                                                            "questionId": 102,
+                                                            "subjectiveId": 102,
+                                                            "type": "SUBJECTIVE",
+                                                            "sequence": 2,
+                                                            "title": "개선이 필요한 점은 무엇인가요?",
+                                                            "description": "자유롭게 작성해주세요.",
+                                                            "imageKey": "subjective-image-key"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "5초 테스트 조회",
+                                            summary = "FIVE_SECOND 조회 예시",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "code": "200",
+                                                      "message": "문항을 조회했습니다.",
+                                                      "data": {
+                                                        "testId": 10,
+                                                        "questions": [
+                                                          {
+                                                            "questionId": 103,
+                                                            "fiveSecondId": 103,
+                                                            "type": "FIVE_SECOND",
+                                                            "sequence": 3,
+                                                            "title": "첫 화면에서 눈에 띄는 요소는 무엇인가요?",
+                                                            "description": "이미지를 5초간 본 뒤 답변해주세요.",
+                                                            "imageKey": "five-second-image-key",
+                                                            "isObjective": true,
+                                                            "isDuplicate": true,
+                                                            "minSelect": 1,
+                                                            "maxSelect": 3,
+                                                            "options": [
+                                                              { "fiveSecondOptionId": 2001, "content": "검색창", "sequence": 1 },
+                                                              { "fiveSecondOptionId": 2002, "content": "메인 배너", "sequence": 2 }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "척도형 조회",
+                                            summary = "SCALE 조회 예시",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "code": "200",
+                                                      "message": "문항을 조회했습니다.",
+                                                      "data": {
+                                                        "testId": 10,
+                                                        "questions": [
+                                                          {
+                                                            "questionId": 104,
+                                                            "scaleId": 104,
+                                                            "type": "SCALE",
+                                                            "sequence": 4,
+                                                            "title": "전반적인 만족도를 평가해주세요.",
+                                                            "description": "5점 척도로 응답해주세요.",
+                                                            "imageKey": null,
+                                                            "minLabel": "매우 불만족",
+                                                            "maxLabel": "매우 만족",
+                                                            "range": 5
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "AB 테스트 조회",
+                                            summary = "AB_TEST 조회 예시",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "code": "200",
+                                                      "message": "문항을 조회했습니다.",
+                                                      "data": {
+                                                        "testId": 10,
+                                                        "questions": [
+                                                          {
+                                                            "questionId": 105,
+                                                            "abTestId": 105,
+                                                            "type": "AB_TEST",
+                                                            "sequence": 5,
+                                                            "title": "어느 시안이 더 마음에 드시나요?",
+                                                            "description": "두 시안을 비교하고 더 선호하는 쪽을 선택해주세요.",
+                                                            "aImageKey": "image-a.jpg",
+                                                            "bImageKey": "image-b.jpg"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "카드소팅 조회",
+                                            summary = "CARD_SORTING 조회 예시",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "code": "200",
+                                                      "message": "문항을 조회했습니다.",
+                                                      "data": {
+                                                        "testId": 10,
+                                                        "questions": [
+                                                          {
+                                                            "questionId": 106,
+                                                            "cardSortingId": 106,
+                                                            "type": "CARD_SORTING",
+                                                            "sequence": 6,
+                                                            "title": "기능 카드를 그룹으로 묶어주세요.",
+                                                            "description": "비슷하다고 생각하는 항목끼리 분류해주세요.",
+                                                            "cards": ["티셔츠", "꽃무늬가 들어간 티셔츠", "찢어진 청바지", "닥터마틴 워커"],
+                                                            "categories": ["상의", "하의", "신발"]
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "트리 테스트 조회",
+                                            summary = "TREE_TEST 조회 예시",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "code": "200",
+                                                      "message": "문항을 조회했습니다.",
+                                                      "data": {
+                                                        "testId": 10,
+                                                        "questions": [
+                                                          {
+                                                            "questionId": 107,
+                                                            "type": "TREE_TEST",
+                                                            "sequence": 7,
+                                                            "title": "설정 메뉴에서 알림 설정을 어디서 찾으시겠어요?",
+                                                            "description": "예상되는 경로를 따라 선택해주세요.",
+                                                            "features": [
+                                                              {
+                                                                "treeTestId": 3001,
+                                                                "label": "마이페이지",
+                                                                "children": [
+                                                                  {
+                                                                    "treeTestId": 3002,
+                                                                    "label": "설정",
+                                                                    "children": [
+                                                                      {
+                                                                        "treeTestId": 3003,
+                                                                        "label": "알림 설정",
+                                                                        "children": []
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            }
+                    ))
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<QuestionDetailResponse>> getQuestions(
+            @PathVariable Long testId,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        QuestionDetailResponse response = questionService.getQuestions(testId, authenticatedUser.getId());
+        return ResponseEntity.ok(ApiResponse.ok("문항을 조회했습니다.", response));
+    }
 
     @Operation(summary = "질문 문항 일괄 등록", description = """
             여러 유형의 질문 문항을 한 번에 등록합니다. MKTT_03 (질문 목록) 에 해당하는 api 입니다.

--- a/src/main/java/server/MATE/domain/question/dto/response/AbTestDetailResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/AbTestDetailResponse.java
@@ -1,0 +1,30 @@
+package server.MATE.domain.question.dto.response;
+
+import server.MATE.domain.question.entity.AbTest;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+
+public record AbTestDetailResponse(
+        Long questionId,
+        Long abTestId,
+        QuestionType type,
+        Long sequence,
+        String title,
+        String description,
+        String aImageKey,
+        String bImageKey
+) implements QuestionDetailItem {
+
+    public static AbTestDetailResponse of(Question question, AbTest abTest) {
+        return new AbTestDetailResponse(
+                question.getId(),
+                abTest.getId(),
+                question.getQuestionType(),
+                question.getSequence(),
+                question.getTitle(),
+                question.getDescription(),
+                abTest.getAImageKey(),
+                abTest.getBImageKey()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/CardSortingDetailResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/CardSortingDetailResponse.java
@@ -1,0 +1,32 @@
+package server.MATE.domain.question.dto.response;
+
+import server.MATE.domain.question.entity.CardSorting;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+
+import java.util.List;
+
+public record CardSortingDetailResponse(
+        Long questionId,
+        Long cardSortingId,
+        QuestionType type,
+        Long sequence,
+        String title,
+        String description,
+        List<String> cards,
+        List<String> categories
+) implements QuestionDetailItem {
+
+    public static CardSortingDetailResponse of(Question question, CardSorting cardSorting) {
+        return new CardSortingDetailResponse(
+                question.getId(),
+                cardSorting.getId(),
+                question.getQuestionType(),
+                question.getSequence(),
+                question.getTitle(),
+                question.getDescription(),
+                List.copyOf(cardSorting.getCards()),
+                List.copyOf(cardSorting.getCategories())
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/FiveSecondDetailResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/FiveSecondDetailResponse.java
@@ -1,0 +1,42 @@
+package server.MATE.domain.question.dto.response;
+
+import server.MATE.domain.question.entity.FiveSecond;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+
+import java.util.List;
+
+public record FiveSecondDetailResponse(
+        Long questionId,
+        Long fiveSecondId,
+        QuestionType type,
+        Long sequence,
+        String title,
+        String description,
+        String imageKey,
+        boolean isObjective,
+        Boolean isDuplicate,
+        Integer minSelect,
+        Integer maxSelect,
+        List<FiveSecondOptionDetailResponse> options
+) implements QuestionDetailItem {
+
+    public static FiveSecondDetailResponse of(Question question, FiveSecond fiveSecond) {
+        return new FiveSecondDetailResponse(
+                question.getId(),
+                fiveSecond.getId(),
+                question.getQuestionType(),
+                question.getSequence(),
+                question.getTitle(),
+                question.getDescription(),
+                fiveSecond.getImageKey(),
+                fiveSecond.isObjective(),
+                fiveSecond.getIsDuplicate(),
+                fiveSecond.getMinSelect(),
+                fiveSecond.getMaxSelect(),
+                fiveSecond.getOptions().stream()
+                        .map(FiveSecondOptionDetailResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/FiveSecondOptionDetailResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/FiveSecondOptionDetailResponse.java
@@ -1,0 +1,13 @@
+package server.MATE.domain.question.dto.response;
+
+import server.MATE.domain.question.entity.FiveSecondOption;
+
+public record FiveSecondOptionDetailResponse(
+        Long fiveSecondOptionId,
+        String content,
+        Integer sequence
+) {
+    public static FiveSecondOptionDetailResponse from(FiveSecondOption option) {
+        return new FiveSecondOptionDetailResponse(option.getId(), option.getContent(), option.getSequence());
+    }
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/ObjectiveDetailResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/ObjectiveDetailResponse.java
@@ -1,0 +1,40 @@
+package server.MATE.domain.question.dto.response;
+
+import server.MATE.domain.question.entity.Objective;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+
+import java.util.List;
+
+public record ObjectiveDetailResponse(
+        Long questionId,
+        Long objectiveId,
+        QuestionType type,
+        Long sequence,
+        String title,
+        String description,
+        boolean isDuplicate,
+        Integer minSelect,
+        Integer maxSelect,
+        boolean isOther,
+        List<ObjectiveOptionDetailResponse> options
+) implements QuestionDetailItem {
+
+    public static ObjectiveDetailResponse of(Question question, Objective objective) {
+        return new ObjectiveDetailResponse(
+                question.getId(),
+                objective.getId(),
+                question.getQuestionType(),
+                question.getSequence(),
+                question.getTitle(),
+                question.getDescription(),
+                objective.isDuplicate(),
+                objective.getMinSelect(),
+                objective.getMaxSelect(),
+                objective.isOther(),
+                objective.getOptions().stream()
+                        .map(ObjectiveOptionDetailResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/ObjectiveOptionDetailResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/ObjectiveOptionDetailResponse.java
@@ -1,0 +1,19 @@
+package server.MATE.domain.question.dto.response;
+
+import server.MATE.domain.question.entity.ObjectiveOption;
+
+public record ObjectiveOptionDetailResponse(
+        Long objectiveOptionId,
+        String content,
+        String imageKey,
+        Integer sequence
+) {
+    public static ObjectiveOptionDetailResponse from(ObjectiveOption option) {
+        return new ObjectiveOptionDetailResponse(
+                option.getId(),
+                option.getContent(),
+                option.getImageKey(),
+                option.getSequence()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/QuestionDetailItem.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/QuestionDetailItem.java
@@ -1,0 +1,23 @@
+package server.MATE.domain.question.dto.response;
+
+import server.MATE.domain.question.entity.QuestionType;
+
+public sealed interface QuestionDetailItem permits
+        ObjectiveDetailResponse,
+        SubjectiveDetailResponse,
+        FiveSecondDetailResponse,
+        ScaleDetailResponse,
+        AbTestDetailResponse,
+        CardSortingDetailResponse,
+        TreeTestDetailResponse {
+
+    Long questionId();
+
+    QuestionType type();
+
+    Long sequence();
+
+    String title();
+
+    String description();
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/QuestionDetailResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/QuestionDetailResponse.java
@@ -1,0 +1,9 @@
+package server.MATE.domain.question.dto.response;
+
+import java.util.List;
+
+public record QuestionDetailResponse(
+        Long testId,
+        List<QuestionDetailItem> questions
+) {
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/ScaleDetailResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/ScaleDetailResponse.java
@@ -1,0 +1,34 @@
+package server.MATE.domain.question.dto.response;
+
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.entity.Scale;
+
+public record ScaleDetailResponse(
+        Long questionId,
+        Long scaleId,
+        QuestionType type,
+        Long sequence,
+        String title,
+        String description,
+        String imageKey,
+        String minLabel,
+        String maxLabel,
+        Integer range
+) implements QuestionDetailItem {
+
+    public static ScaleDetailResponse of(Question question, Scale scale) {
+        return new ScaleDetailResponse(
+                question.getId(),
+                scale.getId(),
+                question.getQuestionType(),
+                question.getSequence(),
+                question.getTitle(),
+                question.getDescription(),
+                scale.getImageKey(),
+                scale.getMinLabel(),
+                scale.getMaxLabel(),
+                scale.getRange()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/SubjectiveDetailResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/SubjectiveDetailResponse.java
@@ -1,0 +1,28 @@
+package server.MATE.domain.question.dto.response;
+
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.entity.Subjective;
+
+public record SubjectiveDetailResponse(
+        Long questionId,
+        Long subjectiveId,
+        QuestionType type,
+        Long sequence,
+        String title,
+        String description,
+        String imageKey
+) implements QuestionDetailItem {
+
+    public static SubjectiveDetailResponse of(Question question, Subjective subjective) {
+        return new SubjectiveDetailResponse(
+                question.getId(),
+                subjective.getId(),
+                question.getQuestionType(),
+                question.getSequence(),
+                question.getTitle(),
+                question.getDescription(),
+                subjective.getImageKey()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/TreeTestDetailResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/TreeTestDetailResponse.java
@@ -1,0 +1,27 @@
+package server.MATE.domain.question.dto.response;
+
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+
+import java.util.List;
+
+public record TreeTestDetailResponse(
+        Long questionId,
+        QuestionType type,
+        Long sequence,
+        String title,
+        String description,
+        List<TreeTestNodeDetailResponse> features
+) implements QuestionDetailItem {
+
+    public static TreeTestDetailResponse of(Question question, List<TreeTestNodeDetailResponse> features) {
+        return new TreeTestDetailResponse(
+                question.getId(),
+                question.getQuestionType(),
+                question.getSequence(),
+                question.getTitle(),
+                question.getDescription(),
+                features
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/TreeTestNodeDetailResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/TreeTestNodeDetailResponse.java
@@ -1,0 +1,10 @@
+package server.MATE.domain.question.dto.response;
+
+import java.util.List;
+
+public record TreeTestNodeDetailResponse(
+        Long treeTestId,
+        String label,
+        List<TreeTestNodeDetailResponse> children
+) {
+}

--- a/src/main/java/server/MATE/domain/question/entity/FiveSecond.java
+++ b/src/main/java/server/MATE/domain/question/entity/FiveSecond.java
@@ -34,6 +34,7 @@ public class FiveSecond {
     private Integer maxSelect;
 
     @OneToMany(mappedBy = "fiveSecond", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sequence ASC")
     private List<FiveSecondOption> options = new ArrayList<>();
 
     @Builder

--- a/src/main/java/server/MATE/domain/question/entity/Objective.java
+++ b/src/main/java/server/MATE/domain/question/entity/Objective.java
@@ -33,6 +33,7 @@ public class Objective {
     private boolean isOther;
 
     @OneToMany(mappedBy = "objective", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sequence ASC")
     private List<ObjectiveOption> options = new ArrayList<>();
 
     @Builder

--- a/src/main/java/server/MATE/domain/question/repository/AbTestRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/AbTestRepository.java
@@ -3,5 +3,9 @@ package server.MATE.domain.question.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import server.MATE.domain.question.entity.AbTest;
 
+import java.util.List;
+
 public interface AbTestRepository extends JpaRepository<AbTest, Long> {
+
+    List<AbTest> findAllByIdIn(Iterable<Long> ids);
 }

--- a/src/main/java/server/MATE/domain/question/repository/CardSortingRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/CardSortingRepository.java
@@ -3,6 +3,9 @@ package server.MATE.domain.question.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import server.MATE.domain.question.entity.CardSorting;
 
+import java.util.List;
+
 public interface CardSortingRepository extends JpaRepository<CardSorting, Long> {
 
+    List<CardSorting> findAllByIdIn(Iterable<Long> ids);
 }

--- a/src/main/java/server/MATE/domain/question/repository/FiveSecondRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/FiveSecondRepository.java
@@ -1,5 +1,6 @@
 package server.MATE.domain.question.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import server.MATE.domain.question.entity.FiveSecond;
 
@@ -7,5 +8,6 @@ import java.util.List;
 
 public interface FiveSecondRepository extends JpaRepository<FiveSecond, Long> {
 
+    @EntityGraph(attributePaths = "options")
     List<FiveSecond> findAllByIdIn(Iterable<Long> ids);
 }

--- a/src/main/java/server/MATE/domain/question/repository/FiveSecondRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/FiveSecondRepository.java
@@ -3,5 +3,9 @@ package server.MATE.domain.question.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import server.MATE.domain.question.entity.FiveSecond;
 
+import java.util.List;
+
 public interface FiveSecondRepository extends JpaRepository<FiveSecond, Long> {
+
+    List<FiveSecond> findAllByIdIn(Iterable<Long> ids);
 }

--- a/src/main/java/server/MATE/domain/question/repository/ObjectiveRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/ObjectiveRepository.java
@@ -3,5 +3,9 @@ package server.MATE.domain.question.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import server.MATE.domain.question.entity.Objective;
 
+import java.util.List;
+
 public interface ObjectiveRepository extends JpaRepository<Objective, Long> {
+
+    List<Objective> findAllByIdIn(Iterable<Long> ids);
 }

--- a/src/main/java/server/MATE/domain/question/repository/ObjectiveRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/ObjectiveRepository.java
@@ -1,5 +1,6 @@
 package server.MATE.domain.question.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import server.MATE.domain.question.entity.Objective;
 
@@ -7,5 +8,6 @@ import java.util.List;
 
 public interface ObjectiveRepository extends JpaRepository<Objective, Long> {
 
+    @EntityGraph(attributePaths = "options")
     List<Objective> findAllByIdIn(Iterable<Long> ids);
 }

--- a/src/main/java/server/MATE/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/QuestionRepository.java
@@ -3,8 +3,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import server.MATE.domain.question.entity.Question;
 
+import java.util.List;
+
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     @Query("SELECT COALESCE(MAX(q.sequence), 0) FROM Question q WHERE q.testId = :testId")
     Long findMaxSequenceByTestId(Long testId);
+
+    List<Question> findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(Long testId);
 }

--- a/src/main/java/server/MATE/domain/question/repository/ScaleRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/ScaleRepository.java
@@ -3,5 +3,9 @@ package server.MATE.domain.question.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import server.MATE.domain.question.entity.Scale;
 
+import java.util.List;
+
 public interface ScaleRepository extends JpaRepository<Scale, Long> {
+
+    List<Scale> findAllByIdIn(Iterable<Long> ids);
 }

--- a/src/main/java/server/MATE/domain/question/repository/SubjectiveRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/SubjectiveRepository.java
@@ -3,5 +3,9 @@ package server.MATE.domain.question.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import server.MATE.domain.question.entity.Subjective;
 
+import java.util.List;
+
 public interface SubjectiveRepository extends JpaRepository<Subjective, Long> {
+
+    List<Subjective> findAllByIdIn(Iterable<Long> ids);
 }

--- a/src/main/java/server/MATE/domain/question/repository/TreeTestRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/TreeTestRepository.java
@@ -1,7 +1,19 @@
 package server.MATE.domain.question.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import server.MATE.domain.question.entity.TreeTest;
 
+import java.util.List;
+
 public interface TreeTestRepository extends JpaRepository<TreeTest, Long> {
+
+    @Query("""
+            select node
+            from TreeTest node
+            left join fetch node.parent
+            where node.question.id in :questionIds
+            order by node.question.id asc, node.depth asc, node.sequence asc, node.id asc
+            """)
+    List<TreeTest> findAllByQuestionIdInOrderByQuestionAndTree(List<Long> questionIds);
 }

--- a/src/main/java/server/MATE/domain/question/service/QuestionService.java
+++ b/src/main/java/server/MATE/domain/question/service/QuestionService.java
@@ -7,10 +7,13 @@ import server.MATE.domain.question.dto.request.QuestionCreateItem;
 import server.MATE.domain.question.dto.request.QuestionCreateRequest;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResult;
+import server.MATE.domain.question.dto.response.QuestionDetailItem;
+import server.MATE.domain.question.dto.response.QuestionDetailResponse;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.repository.QuestionRepository;
 import server.MATE.domain.question.service.handler.QuestionCreateHandler;
+import server.MATE.domain.question.service.fetcher.QuestionDetailFetcher;
 import server.MATE.domain.test.entity.Test;
 import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
@@ -30,15 +33,18 @@ public class QuestionService {
     private final QuestionRepository questionRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final Map<QuestionType, QuestionCreateHandler> handlerMap;
+    private final Map<QuestionType, QuestionDetailFetcher> fetcherMap;
 
     public QuestionService(TestRepository testRepository,
                            QuestionRepository questionRepository,
                            ApplicationEventPublisher eventPublisher,
-                           List<QuestionCreateHandler> handlers) {
+                           List<QuestionCreateHandler> handlers,
+                           List<QuestionDetailFetcher> fetchers) {
         this.testRepository = testRepository;
         this.questionRepository = questionRepository;
         this.eventPublisher = eventPublisher;
         this.handlerMap = buildHandlerMap(handlers);
+        this.fetcherMap = buildFetcherMap(fetchers);
     }
 
     public QuestionCreateResponse createQuestions(Long testId, Long makerId, QuestionCreateRequest request) {
@@ -87,12 +93,45 @@ public class QuestionService {
         return new QuestionCreateResponse(results);
     }
 
+    @Transactional(readOnly = true)
+    public QuestionDetailResponse getQuestions(Long testId, Long makerId) {
+        Test test = testRepository.findByIdAndDeletedAtIsNull(testId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        if (!test.getMakerId().equals(makerId)) throw new BaseException(BaseErrorCode.TEST_005);
+
+        List<Question> questions = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId);
+        Map<QuestionType, List<Question>> questionsByType = questions.stream()
+                .collect(java.util.stream.Collectors.groupingBy(Question::getQuestionType, () -> new EnumMap<>(QuestionType.class), java.util.stream.Collectors.toList()));
+
+        Map<Long, QuestionDetailItem> detailMap = new java.util.LinkedHashMap<>();
+        for (Map.Entry<QuestionType, List<Question>> entry : questionsByType.entrySet()) {
+            QuestionDetailFetcher fetcher = fetcherMap.get(entry.getKey());
+            if (fetcher == null) throw new BaseException(BaseErrorCode.COMMON_002);
+            detailMap.putAll(fetcher.fetch(entry.getValue()));
+        }
+
+        List<QuestionDetailItem> results = questions.stream()
+                .map(question -> detailMap.get(question.getId()))
+                .toList();
+
+        return new QuestionDetailResponse(testId, results);
+    }
+
     private Map<QuestionType, QuestionCreateHandler> buildHandlerMap(List<QuestionCreateHandler> handlers) {
         Map<QuestionType, QuestionCreateHandler> handlerMap = new EnumMap<>(QuestionType.class);
         for (QuestionCreateHandler handler : handlers) {
             handlerMap.put(handler.supports(), handler);
         }
         return handlerMap;
+    }
+
+    private Map<QuestionType, QuestionDetailFetcher> buildFetcherMap(List<QuestionDetailFetcher> fetchers) {
+        Map<QuestionType, QuestionDetailFetcher> fetcherMap = new EnumMap<>(QuestionType.class);
+        for (QuestionDetailFetcher fetcher : fetchers) {
+            fetcherMap.put(fetcher.supports(), fetcher);
+        }
+        return fetcherMap;
     }
 
     private record PendingQuestionCreate(

--- a/src/main/java/server/MATE/domain/question/service/QuestionService.java
+++ b/src/main/java/server/MATE/domain/question/service/QuestionService.java
@@ -23,7 +23,9 @@ import server.MATE.global.image.event.ImageCleanupEvent;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -102,9 +104,13 @@ public class QuestionService {
 
         List<Question> questions = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId);
         Map<QuestionType, List<Question>> questionsByType = questions.stream()
-                .collect(java.util.stream.Collectors.groupingBy(Question::getQuestionType, () -> new EnumMap<>(QuestionType.class), java.util.stream.Collectors.toList()));
+                .collect(Collectors.groupingBy(
+                        Question::getQuestionType,
+                        () -> new EnumMap<>(QuestionType.class),
+                        Collectors.toList()
+                ));
 
-        Map<Long, QuestionDetailItem> detailMap = new java.util.LinkedHashMap<>();
+        Map<Long, QuestionDetailItem> detailMap = new LinkedHashMap<>();
         for (Map.Entry<QuestionType, List<Question>> entry : questionsByType.entrySet()) {
             QuestionDetailFetcher fetcher = fetcherMap.get(entry.getKey());
             if (fetcher == null) throw new BaseException(BaseErrorCode.COMMON_002);

--- a/src/main/java/server/MATE/domain/question/service/fetcher/AbTestQuestionDetailFetcher.java
+++ b/src/main/java/server/MATE/domain/question/service/fetcher/AbTestQuestionDetailFetcher.java
@@ -1,0 +1,40 @@
+package server.MATE.domain.question.service.fetcher;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.question.dto.response.AbTestDetailResponse;
+import server.MATE.domain.question.dto.response.QuestionDetailItem;
+import server.MATE.domain.question.entity.AbTest;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.AbTestRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class AbTestQuestionDetailFetcher implements QuestionDetailFetcher {
+
+    private final AbTestRepository abTestRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.AB_TEST;
+    }
+
+    @Override
+    public Map<Long, QuestionDetailItem> fetch(List<Question> questions) {
+        Map<Long, Question> questionMap = questions.stream()
+                .collect(Collectors.toMap(Question::getId, Function.identity()));
+
+        List<AbTest> abTests = abTestRepository.findAllByIdIn(questionMap.keySet());
+        return abTests.stream()
+                .collect(Collectors.toMap(
+                        AbTest::getId,
+                        abTest -> AbTestDetailResponse.of(questionMap.get(abTest.getId()), abTest)
+                ));
+    }
+}

--- a/src/main/java/server/MATE/domain/question/service/fetcher/CardSortingQuestionDetailFetcher.java
+++ b/src/main/java/server/MATE/domain/question/service/fetcher/CardSortingQuestionDetailFetcher.java
@@ -1,0 +1,40 @@
+package server.MATE.domain.question.service.fetcher;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.question.dto.response.CardSortingDetailResponse;
+import server.MATE.domain.question.dto.response.QuestionDetailItem;
+import server.MATE.domain.question.entity.CardSorting;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.CardSortingRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class CardSortingQuestionDetailFetcher implements QuestionDetailFetcher {
+
+    private final CardSortingRepository cardSortingRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.CARD_SORTING;
+    }
+
+    @Override
+    public Map<Long, QuestionDetailItem> fetch(List<Question> questions) {
+        Map<Long, Question> questionMap = questions.stream()
+                .collect(Collectors.toMap(Question::getId, Function.identity()));
+
+        List<CardSorting> cardSortings = cardSortingRepository.findAllByIdIn(questionMap.keySet());
+        return cardSortings.stream()
+                .collect(Collectors.toMap(
+                        CardSorting::getId,
+                        cardSorting -> CardSortingDetailResponse.of(questionMap.get(cardSorting.getId()), cardSorting)
+                ));
+    }
+}

--- a/src/main/java/server/MATE/domain/question/service/fetcher/FiveSecondQuestionDetailFetcher.java
+++ b/src/main/java/server/MATE/domain/question/service/fetcher/FiveSecondQuestionDetailFetcher.java
@@ -1,0 +1,40 @@
+package server.MATE.domain.question.service.fetcher;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.question.dto.response.FiveSecondDetailResponse;
+import server.MATE.domain.question.dto.response.QuestionDetailItem;
+import server.MATE.domain.question.entity.FiveSecond;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.FiveSecondRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class FiveSecondQuestionDetailFetcher implements QuestionDetailFetcher {
+
+    private final FiveSecondRepository fiveSecondRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.FIVE_SECOND;
+    }
+
+    @Override
+    public Map<Long, QuestionDetailItem> fetch(List<Question> questions) {
+        Map<Long, Question> questionMap = questions.stream()
+                .collect(Collectors.toMap(Question::getId, Function.identity()));
+
+        List<FiveSecond> fiveSeconds = fiveSecondRepository.findAllByIdIn(questionMap.keySet());
+        return fiveSeconds.stream()
+                .collect(Collectors.toMap(
+                        FiveSecond::getId,
+                        fiveSecond -> FiveSecondDetailResponse.of(questionMap.get(fiveSecond.getId()), fiveSecond)
+                ));
+    }
+}

--- a/src/main/java/server/MATE/domain/question/service/fetcher/ObjectiveQuestionDetailFetcher.java
+++ b/src/main/java/server/MATE/domain/question/service/fetcher/ObjectiveQuestionDetailFetcher.java
@@ -1,0 +1,40 @@
+package server.MATE.domain.question.service.fetcher;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.question.dto.response.ObjectiveDetailResponse;
+import server.MATE.domain.question.dto.response.QuestionDetailItem;
+import server.MATE.domain.question.entity.Objective;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.ObjectiveRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ObjectiveQuestionDetailFetcher implements QuestionDetailFetcher {
+
+    private final ObjectiveRepository objectiveRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.OBJECTIVE;
+    }
+
+    @Override
+    public Map<Long, QuestionDetailItem> fetch(List<Question> questions) {
+        Map<Long, Question> questionMap = questions.stream()
+                .collect(Collectors.toMap(Question::getId, Function.identity()));
+
+        List<Objective> objectives = objectiveRepository.findAllByIdIn(questionMap.keySet());
+        return objectives.stream()
+                .collect(Collectors.toMap(
+                        Objective::getId,
+                        objective -> ObjectiveDetailResponse.of(questionMap.get(objective.getId()), objective)
+                ));
+    }
+}

--- a/src/main/java/server/MATE/domain/question/service/fetcher/QuestionDetailFetcher.java
+++ b/src/main/java/server/MATE/domain/question/service/fetcher/QuestionDetailFetcher.java
@@ -1,0 +1,15 @@
+package server.MATE.domain.question.service.fetcher;
+
+import server.MATE.domain.question.dto.response.QuestionDetailItem;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+
+import java.util.List;
+import java.util.Map;
+
+public interface QuestionDetailFetcher {
+
+    QuestionType supports();
+
+    Map<Long, QuestionDetailItem> fetch(List<Question> questions);
+}

--- a/src/main/java/server/MATE/domain/question/service/fetcher/ScaleQuestionDetailFetcher.java
+++ b/src/main/java/server/MATE/domain/question/service/fetcher/ScaleQuestionDetailFetcher.java
@@ -1,0 +1,40 @@
+package server.MATE.domain.question.service.fetcher;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.question.dto.response.QuestionDetailItem;
+import server.MATE.domain.question.dto.response.ScaleDetailResponse;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.entity.Scale;
+import server.MATE.domain.question.repository.ScaleRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ScaleQuestionDetailFetcher implements QuestionDetailFetcher {
+
+    private final ScaleRepository scaleRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.SCALE;
+    }
+
+    @Override
+    public Map<Long, QuestionDetailItem> fetch(List<Question> questions) {
+        Map<Long, Question> questionMap = questions.stream()
+                .collect(Collectors.toMap(Question::getId, Function.identity()));
+
+        List<Scale> scales = scaleRepository.findAllByIdIn(questionMap.keySet());
+        return scales.stream()
+                .collect(Collectors.toMap(
+                        Scale::getId,
+                        scale -> ScaleDetailResponse.of(questionMap.get(scale.getId()), scale)
+                ));
+    }
+}

--- a/src/main/java/server/MATE/domain/question/service/fetcher/SubjectiveQuestionDetailFetcher.java
+++ b/src/main/java/server/MATE/domain/question/service/fetcher/SubjectiveQuestionDetailFetcher.java
@@ -1,0 +1,40 @@
+package server.MATE.domain.question.service.fetcher;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.question.dto.response.QuestionDetailItem;
+import server.MATE.domain.question.dto.response.SubjectiveDetailResponse;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.entity.Subjective;
+import server.MATE.domain.question.repository.SubjectiveRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class SubjectiveQuestionDetailFetcher implements QuestionDetailFetcher {
+
+    private final SubjectiveRepository subjectiveRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.SUBJECTIVE;
+    }
+
+    @Override
+    public Map<Long, QuestionDetailItem> fetch(List<Question> questions) {
+        Map<Long, Question> questionMap = questions.stream()
+                .collect(Collectors.toMap(Question::getId, Function.identity()));
+
+        List<Subjective> subjectives = subjectiveRepository.findAllByIdIn(questionMap.keySet());
+        return subjectives.stream()
+                .collect(Collectors.toMap(
+                        Subjective::getId,
+                        subjective -> SubjectiveDetailResponse.of(questionMap.get(subjective.getId()), subjective)
+                ));
+    }
+}

--- a/src/main/java/server/MATE/domain/question/service/fetcher/TreeTestQuestionDetailFetcher.java
+++ b/src/main/java/server/MATE/domain/question/service/fetcher/TreeTestQuestionDetailFetcher.java
@@ -1,0 +1,67 @@
+package server.MATE.domain.question.service.fetcher;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.question.dto.response.QuestionDetailItem;
+import server.MATE.domain.question.dto.response.TreeTestNodeDetailResponse;
+import server.MATE.domain.question.dto.response.TreeTestDetailResponse;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.entity.TreeTest;
+import server.MATE.domain.question.repository.TreeTestRepository;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class TreeTestQuestionDetailFetcher implements QuestionDetailFetcher {
+
+    private final TreeTestRepository treeTestRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.TREE_TEST;
+    }
+
+    @Override
+    public Map<Long, QuestionDetailItem> fetch(List<Question> questions) {
+        Map<Long, Question> questionMap = questions.stream()
+                .collect(Collectors.toMap(Question::getId, Function.identity(), (left, right) -> left, LinkedHashMap::new));
+        List<Long> questionIds = new ArrayList<>(questionMap.keySet());
+
+        List<TreeTest> nodes = treeTestRepository.findAllByQuestionIdInOrderByQuestionAndTree(questionIds);
+        Map<Long, List<TreeTest>> nodesByQuestionId = nodes.stream()
+                .collect(Collectors.groupingBy(node -> node.getQuestion().getId(), LinkedHashMap::new, Collectors.toList()));
+
+        Map<Long, QuestionDetailItem> result = new LinkedHashMap<>();
+        for (Long questionId : questionIds) {
+            List<TreeTestNodeDetailResponse> features = buildFeatures(nodesByQuestionId.getOrDefault(questionId, List.of()));
+            result.put(questionId, TreeTestDetailResponse.of(questionMap.get(questionId), features));
+        }
+        return result;
+    }
+
+    private List<TreeTestNodeDetailResponse> buildFeatures(List<TreeTest> nodes) {
+        Map<Long, List<TreeTest>> childrenByParentId = nodes.stream()
+                .filter(node -> node.getParent() != null)
+                .collect(Collectors.groupingBy(node -> node.getParent().getId(), LinkedHashMap::new, Collectors.toList()));
+
+        return nodes.stream()
+                .filter(node -> node.getParent() == null)
+                .map(node -> toNode(node, childrenByParentId))
+                .toList();
+    }
+
+    private TreeTestNodeDetailResponse toNode(TreeTest node, Map<Long, List<TreeTest>> childrenByParentId) {
+        List<TreeTestNodeDetailResponse> children = childrenByParentId.getOrDefault(node.getId(), List.of()).stream()
+                .map(child -> toNode(child, childrenByParentId))
+                .toList();
+
+        return new TreeTestNodeDetailResponse(node.getId(), node.getLabel(), children);
+    }
+}

--- a/src/test/java/server/MATE/domain/question/controller/QuestionControllerTest.java
+++ b/src/test/java/server/MATE/domain/question/controller/QuestionControllerTest.java
@@ -18,8 +18,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import server.MATE.domain.auth.jwt.TokenType;
+import server.MATE.domain.question.dto.response.ObjectiveOptionDetailResponse;
+import server.MATE.domain.question.dto.response.ObjectiveDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResult;
+import server.MATE.domain.question.dto.response.QuestionDetailResponse;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.service.QuestionService;
 import server.MATE.domain.users.entity.Role;
@@ -34,6 +37,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -65,6 +69,50 @@ class QuestionControllerTest {
     @org.junit.jupiter.api.AfterEach
     void clearSecurityContext() {
         SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("문항 목록 조회 요청을 정상 처리한다")
+    void handlesQuestionListRequestSuccessfully() throws Exception {
+        QuestionDetailResponse response = new QuestionDetailResponse(
+                10L,
+                List.of(
+                        new ObjectiveDetailResponse(
+                                101L,
+                                101L,
+                                QuestionType.OBJECTIVE,
+                                1L,
+                                "객관식 질문",
+                                "설명",
+                                false,
+                                null,
+                                null,
+                                true,
+                                List.of(
+                                        new ObjectiveOptionDetailResponse(1001L, "A", null, 1),
+                                        new ObjectiveOptionDetailResponse(1002L, "B", "image-b", 2)
+                                )
+                        )
+                )
+        );
+        given(questionService.getQuestions(10L, 1L)).willReturn(response);
+
+        mockMvc.perform(get("/api/v1/tests/10/questions")
+                        .with(authenticationPrincipal()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("문항을 조회했습니다."))
+                .andExpect(jsonPath("$.data.testId").value(10))
+                .andExpect(jsonPath("$.data.questions.length()").value(1))
+                .andExpect(jsonPath("$.data.questions[0].questionId").value(101))
+                .andExpect(jsonPath("$.data.questions[0].objectiveId").value(101))
+                .andExpect(jsonPath("$.data.questions[0].type").value("OBJECTIVE"))
+                .andExpect(jsonPath("$.data.questions[0].sequence").value(1))
+                .andExpect(jsonPath("$.data.questions[0].isDuplicate").value(false))
+                .andExpect(jsonPath("$.data.questions[0].isOther").value(true))
+                .andExpect(jsonPath("$.data.questions[0].options[0].objectiveOptionId").value(1001))
+                .andExpect(jsonPath("$.data.questions[0].options[1].sequence").value(2));
     }
 
     @Test

--- a/src/test/java/server/MATE/domain/question/controller/QuestionControllerTest.java
+++ b/src/test/java/server/MATE/domain/question/controller/QuestionControllerTest.java
@@ -18,11 +18,19 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import server.MATE.domain.auth.jwt.TokenType;
+import server.MATE.domain.question.dto.response.AbTestDetailResponse;
+import server.MATE.domain.question.dto.response.CardSortingDetailResponse;
+import server.MATE.domain.question.dto.response.FiveSecondDetailResponse;
+import server.MATE.domain.question.dto.response.FiveSecondOptionDetailResponse;
 import server.MATE.domain.question.dto.response.ObjectiveOptionDetailResponse;
 import server.MATE.domain.question.dto.response.ObjectiveDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResult;
 import server.MATE.domain.question.dto.response.QuestionDetailResponse;
+import server.MATE.domain.question.dto.response.ScaleDetailResponse;
+import server.MATE.domain.question.dto.response.SubjectiveDetailResponse;
+import server.MATE.domain.question.dto.response.TreeTestDetailResponse;
+import server.MATE.domain.question.dto.response.TreeTestNodeDetailResponse;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.service.QuestionService;
 import server.MATE.domain.users.entity.Role;
@@ -113,6 +121,127 @@ class QuestionControllerTest {
                 .andExpect(jsonPath("$.data.questions[0].isOther").value(true))
                 .andExpect(jsonPath("$.data.questions[0].options[0].objectiveOptionId").value(1001))
                 .andExpect(jsonPath("$.data.questions[0].options[1].sequence").value(2));
+    }
+
+    @Test
+    @DisplayName("문항 목록 조회 응답은 타입별 상세 id 필드와 트리 노드 계약을 포함한다")
+    void returnsDetailIdsAndTreeContractInQuestionListResponse() throws Exception {
+        QuestionDetailResponse response = new QuestionDetailResponse(
+                10L,
+                List.of(
+                        new ObjectiveDetailResponse(
+                                101L, 100L, QuestionType.OBJECTIVE, 1L, "객관식", "설명",
+                                false, null, null, true,
+                                List.of(new ObjectiveOptionDetailResponse(1001L, "A", null, 1))
+                        ),
+                        new SubjectiveDetailResponse(102L, 200L, QuestionType.SUBJECTIVE, 2L, "주관식", "설명", "subjective-image"),
+                        new FiveSecondDetailResponse(
+                                103L, 300L, QuestionType.FIVE_SECOND, 3L, "5초", "설명",
+                                "five-second-image", true, true, 1, 2,
+                                List.of(new FiveSecondOptionDetailResponse(3001L, "검색창", 1))
+                        ),
+                        new ScaleDetailResponse(104L, 400L, QuestionType.SCALE, 4L, "척도", "설명", null, "낮음", "높음", 5),
+                        new AbTestDetailResponse(105L, 500L, QuestionType.AB_TEST, 5L, "AB", "설명", "a.jpg", "b.jpg"),
+                        new CardSortingDetailResponse(106L, 600L, QuestionType.CARD_SORTING, 6L, "카드", "설명", List.of("A", "B", "C", "D"), List.of("cat")),
+                        new TreeTestDetailResponse(
+                                107L, QuestionType.TREE_TEST, 7L, "트리", "설명",
+                                List.of(new TreeTestNodeDetailResponse(
+                                        7001L,
+                                        "마이페이지",
+                                        List.of(new TreeTestNodeDetailResponse(7002L, "설정", List.of()))
+                                ))
+                        )
+                )
+        );
+        given(questionService.getQuestions(10L, 1L)).willReturn(response);
+
+        mockMvc.perform(get("/api/v1/tests/10/questions")
+                        .with(authenticationPrincipal()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.testId").value(10))
+                .andExpect(jsonPath("$.data.questions[0].objectiveId").value(100))
+                .andExpect(jsonPath("$.data.questions[0].options[0].objectiveOptionId").value(1001))
+                .andExpect(jsonPath("$.data.questions[1].subjectiveId").value(200))
+                .andExpect(jsonPath("$.data.questions[2].fiveSecondId").value(300))
+                .andExpect(jsonPath("$.data.questions[2].options[0].fiveSecondOptionId").value(3001))
+                .andExpect(jsonPath("$.data.questions[3].scaleId").value(400))
+                .andExpect(jsonPath("$.data.questions[4].abTestId").value(500))
+                .andExpect(jsonPath("$.data.questions[5].cardSortingId").value(600))
+                .andExpect(jsonPath("$.data.questions[6].features[0].treeTestId").value(7001))
+                .andExpect(jsonPath("$.data.questions[6].features[0].children[0].treeTestId").value(7002))
+                .andExpect(jsonPath("$.data.questions[6].features[0].sequence").doesNotExist())
+                .andExpect(jsonPath("$.data.questions[6].features[0].children[0].sequence").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("문항 목록 조회 응답은 null 필드와 빈 리스트를 계약대로 직렬화한다")
+    void serializesNullAndEmptyFieldsAsExpectedForQuestionDetails() throws Exception {
+        QuestionDetailResponse response = new QuestionDetailResponse(
+                10L,
+                List.of(
+                        new SubjectiveDetailResponse(101L, 201L, QuestionType.SUBJECTIVE, 1L, "주관식", "설명", null),
+                        new FiveSecondDetailResponse(
+                                102L, 202L, QuestionType.FIVE_SECOND, 2L, "5초 주관식", "설명",
+                                "five-second-image", false, null, null, null, List.of()
+                        ),
+                        new ScaleDetailResponse(103L, 203L, QuestionType.SCALE, 3L, "척도", "설명", null, null, null, 5),
+                        new TreeTestDetailResponse(
+                                104L, QuestionType.TREE_TEST, 4L, "트리", "설명",
+                                List.of(new TreeTestNodeDetailResponse(3001L, "리프", List.of()))
+                        )
+                )
+        );
+        given(questionService.getQuestions(10L, 1L)).willReturn(response);
+
+        mockMvc.perform(get("/api/v1/tests/10/questions")
+                        .with(authenticationPrincipal()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.questions[0].imageKey").value((String) null))
+                .andExpect(jsonPath("$.data.questions[1].isDuplicate").value((String) null))
+                .andExpect(jsonPath("$.data.questions[1].minSelect").value((String) null))
+                .andExpect(jsonPath("$.data.questions[1].maxSelect").value((String) null))
+                .andExpect(jsonPath("$.data.questions[1].options").isArray())
+                .andExpect(jsonPath("$.data.questions[1].options.length()").value(0))
+                .andExpect(jsonPath("$.data.questions[2].imageKey").value((String) null))
+                .andExpect(jsonPath("$.data.questions[2].minLabel").value((String) null))
+                .andExpect(jsonPath("$.data.questions[2].maxLabel").value((String) null))
+                .andExpect(jsonPath("$.data.questions[3].features[0].children").isArray())
+                .andExpect(jsonPath("$.data.questions[3].features[0].children.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("문항 목록 조회 응답은 상세 DTO 필드명을 안정적으로 유지한다")
+    void usesStableResponseFieldNamesForDetailDtos() throws Exception {
+        QuestionDetailResponse response = new QuestionDetailResponse(
+                10L,
+                List.of(
+                        new ObjectiveDetailResponse(
+                                101L, 201L, QuestionType.OBJECTIVE, 1L, "객관식", "설명",
+                                true, 1, 2, true,
+                                List.of(new ObjectiveOptionDetailResponse(1001L, "A", null, 1))
+                        ),
+                        new FiveSecondDetailResponse(
+                                102L, 202L, QuestionType.FIVE_SECOND, 2L, "5초", "설명",
+                                "five-second-image", true, true, 1, 2,
+                                List.of(new FiveSecondOptionDetailResponse(2001L, "검색창", 1))
+                        )
+                )
+        );
+        given(questionService.getQuestions(10L, 1L)).willReturn(response);
+
+        mockMvc.perform(get("/api/v1/tests/10/questions")
+                        .with(authenticationPrincipal()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.questions[0].objectiveId").value(201))
+                .andExpect(jsonPath("$.data.questions[0].isDuplicate").value(true))
+                .andExpect(jsonPath("$.data.questions[0].isOther").value(true))
+                .andExpect(jsonPath("$.data.questions[0].duplicate").doesNotExist())
+                .andExpect(jsonPath("$.data.questions[0].other").doesNotExist())
+                .andExpect(jsonPath("$.data.questions[1].fiveSecondId").value(202))
+                .andExpect(jsonPath("$.data.questions[1].isObjective").value(true))
+                .andExpect(jsonPath("$.data.questions[1].isDuplicate").value(true))
+                .andExpect(jsonPath("$.data.questions[1].objective").doesNotExist())
+                .andExpect(jsonPath("$.data.questions[1].duplicate").doesNotExist());
     }
 
     @Test

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceIntegrationTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceIntegrationTest.java
@@ -13,18 +13,33 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import server.MATE.domain.question.dto.request.ObjectiveCreateRequest;
 import server.MATE.domain.question.dto.request.ObjectiveOptionRequest;
 import server.MATE.domain.question.dto.request.QuestionCreateRequest;
+import server.MATE.domain.question.dto.request.AbTestCreateRequest;
+import server.MATE.domain.question.dto.request.CardSortingCreateRequest;
+import server.MATE.domain.question.dto.request.FiveSecondCreateRequest;
+import server.MATE.domain.question.dto.request.FiveSecondOptionRequest;
 import server.MATE.domain.question.dto.request.ScaleCreateRequest;
+import server.MATE.domain.question.dto.request.SubjectiveCreateRequest;
 import server.MATE.domain.question.dto.request.TreeTestCreateRequest;
+import server.MATE.domain.question.dto.response.AbTestDetailResponse;
+import server.MATE.domain.question.dto.response.CardSortingDetailResponse;
+import server.MATE.domain.question.dto.response.FiveSecondDetailResponse;
 import server.MATE.domain.question.dto.response.ObjectiveDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
 import server.MATE.domain.question.dto.response.QuestionDetailItem;
 import server.MATE.domain.question.dto.response.QuestionDetailResponse;
+import server.MATE.domain.question.dto.response.ScaleDetailResponse;
+import server.MATE.domain.question.dto.response.SubjectiveDetailResponse;
 import server.MATE.domain.question.dto.response.TreeTestDetailResponse;
+import server.MATE.domain.question.dto.response.TreeTestNodeDetailResponse;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.AbTestRepository;
+import server.MATE.domain.question.repository.CardSortingRepository;
+import server.MATE.domain.question.repository.FiveSecondRepository;
 import server.MATE.domain.question.repository.ObjectiveRepository;
 import server.MATE.domain.question.repository.QuestionRepository;
 import server.MATE.domain.question.repository.ScaleRepository;
+import server.MATE.domain.question.repository.SubjectiveRepository;
 import server.MATE.domain.question.repository.TreeTestRepository;
 import server.MATE.domain.question.service.handler.ScaleQuestionCreateHandler;
 import server.MATE.domain.test.repository.TestRepository;
@@ -65,6 +80,18 @@ class QuestionServiceIntegrationTest {
     @Autowired
     private TreeTestRepository treeTestRepository;
 
+    @Autowired
+    private SubjectiveRepository subjectiveRepository;
+
+    @Autowired
+    private FiveSecondRepository fiveSecondRepository;
+
+    @Autowired
+    private AbTestRepository abTestRepository;
+
+    @Autowired
+    private CardSortingRepository cardSortingRepository;
+
     @PersistenceContext
     private EntityManager entityManager;
 
@@ -77,40 +104,132 @@ class QuestionServiceIntegrationTest {
     @AfterEach
     void tearDown() {
         treeTestRepository.deleteAll();
+        cardSortingRepository.deleteAll();
+        abTestRepository.deleteAll();
+        fiveSecondRepository.deleteAll();
+        subjectiveRepository.deleteAll();
         objectiveRepository.deleteAll();
         scaleRepository.deleteAll();
         questionRepository.deleteAll();
         testRepository.deleteAll();
     }
 
+
+
+
+
     @Test
-    @DisplayName("문항 목록 조회는 루트 testId와 타입별 상세 sequence를 함께 반환한다")
-    void getsQuestionDetailsWithRootTestIdAndNestedSequences() {
+    @DisplayName("5초 테스트 주관식 조회는 객관식 전용 필드를 비워서 반환한다")
+    void getsSubjectiveFiveSecondDetailWithoutObjectiveFields() {
         server.MATE.domain.test.entity.Test savedTest = createTest();
 
         questionService.createQuestions(savedTest.getId(), 1L, new QuestionCreateRequest(List.of(
-                new ScaleCreateRequest(
-                        "척도 질문",
+                new FiveSecondCreateRequest(
+                        "5초 주관식 질문",
                         "설명",
+                        "five-second-image",
+                        false,
                         null,
-                        "낮음",
-                        "높음",
-                        5
-                ),
-                new ObjectiveCreateRequest(
-                        "객관식 질문",
+                        null,
+                        null,
+                        List.of()
+                )
+        )));
+
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+
+        FiveSecondDetailResponse fiveSecondResponse = (FiveSecondDetailResponse) response.questions().getFirst();
+        assertThat(fiveSecondResponse.fiveSecondId()).isNotNull();
+        assertThat(fiveSecondResponse.isObjective()).isFalse();
+        assertThat(fiveSecondResponse.isDuplicate()).isNull();
+        assertThat(fiveSecondResponse.minSelect()).isNull();
+        assertThat(fiveSecondResponse.maxSelect()).isNull();
+        assertThat(fiveSecondResponse.options()).isEmpty();
+        assertThat(fiveSecondResponse.imageKey()).isEqualTo("five-second-image");
+    }
+
+    @Test
+    @DisplayName("5초 테스트 객관식 조회는 선택지 구조와 선택 조건을 유지한다")
+    void getsObjectiveFiveSecondDetailWithOptionStructure() {
+        server.MATE.domain.test.entity.Test savedTest = createTest();
+
+        questionService.createQuestions(savedTest.getId(), 1L, new QuestionCreateRequest(List.of(
+                new FiveSecondCreateRequest(
+                        "5초 객관식 질문",
                         "설명",
+                        "five-second-image",
                         true,
-                        2,
+                        true,
                         1,
-                        true,
+                        2,
                         List.of(
-                                new ObjectiveOptionRequest("A", null),
-                                new ObjectiveOptionRequest("B", "image-b")
+                                new FiveSecondOptionRequest("검색창"),
+                                new FiveSecondOptionRequest("메인 배너")
                         )
-                ),
+                )
+        )));
+
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+
+        FiveSecondDetailResponse fiveSecondResponse = (FiveSecondDetailResponse) response.questions().getFirst();
+        assertThat(fiveSecondResponse.fiveSecondId()).isNotNull();
+        assertThat(fiveSecondResponse.isObjective()).isTrue();
+        assertThat(fiveSecondResponse.isDuplicate()).isTrue();
+        assertThat(fiveSecondResponse.minSelect()).isEqualTo(1);
+        assertThat(fiveSecondResponse.maxSelect()).isEqualTo(2);
+        assertThat(fiveSecondResponse.options()).extracting(option -> option.content(), option -> option.sequence())
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple("검색창", 1),
+                        org.assertj.core.groups.Tuple.tuple("메인 배너", 2)
+                );
+        assertThat(fiveSecondResponse.options()).allSatisfy(option -> assertThat(option.fiveSecondOptionId()).isNotNull());
+    }
+
+    @Test
+    @DisplayName("트리 테스트 조회는 다중 루트 feature 구조를 유지한다")
+    void getsTreeTestDetailWithMultipleRootFeatures() {
+        server.MATE.domain.test.entity.Test savedTest = createTest();
+
+        questionService.createQuestions(savedTest.getId(), 1L, new QuestionCreateRequest(List.of(
                 new TreeTestCreateRequest(
-                        "트리 테스트",
+                        "트리 질문",
+                        "설명",
+                        List.of(
+                                new TreeTestCreateRequest.Feature(
+                                        "마이페이지",
+                                        List.of(new TreeTestCreateRequest.TreeNode("설정", List.of()))
+                                ),
+                                new TreeTestCreateRequest.Feature(
+                                        "고객센터",
+                                        List.of(new TreeTestCreateRequest.TreeNode("문의하기", List.of()))
+                                )
+                        )
+                )
+        )));
+
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+
+        TreeTestDetailResponse treeResponse = (TreeTestDetailResponse) response.questions().getFirst();
+        assertThat(treeResponse.features()).hasSize(2);
+        assertThat(treeResponse.features()).extracting(TreeTestNodeDetailResponse::label)
+                .containsExactly("마이페이지", "고객센터");
+        assertThat(treeResponse.features()).allSatisfy(node -> assertThat(node.treeTestId()).isNotNull());
+        assertThat(treeResponse.features().get(0).children()).singleElement()
+                .extracting(TreeTestNodeDetailResponse::label)
+                .isEqualTo("설정");
+        assertThat(treeResponse.features().get(1).children()).singleElement()
+                .extracting(TreeTestNodeDetailResponse::label)
+                .isEqualTo("문의하기");
+    }
+
+    @Test
+    @DisplayName("트리 테스트 조회는 다단계 children 구조를 재귀적으로 복원한다")
+    void getsTreeTestDetailWithNestedChildren() {
+        server.MATE.domain.test.entity.Test savedTest = createTest();
+
+        questionService.createQuestions(savedTest.getId(), 1L, new QuestionCreateRequest(List.of(
+                new TreeTestCreateRequest(
+                        "트리 질문",
                         "설명",
                         List.of(
                                 new TreeTestCreateRequest.Feature(
@@ -118,7 +237,12 @@ class QuestionServiceIntegrationTest {
                                         List.of(
                                                 new TreeTestCreateRequest.TreeNode(
                                                         "설정",
-                                                        List.of(new TreeTestCreateRequest.TreeNode("알림 설정", List.of()))
+                                                        List.of(
+                                                                new TreeTestCreateRequest.TreeNode(
+                                                                        "알림 설정",
+                                                                        List.of(new TreeTestCreateRequest.TreeNode("푸시 알림", List.of()))
+                                                                )
+                                                        )
                                                 )
                                         )
                                 )
@@ -128,23 +252,104 @@ class QuestionServiceIntegrationTest {
 
         QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
 
-        assertThat(response.testId()).isEqualTo(savedTest.getId());
-        assertThat(response.questions()).extracting(QuestionDetailItem::type)
-                .containsExactly(QuestionType.SCALE, QuestionType.OBJECTIVE, QuestionType.TREE_TEST);
-        assertThat(response.questions()).extracting(QuestionDetailItem::sequence)
-                .containsExactly(1L, 2L, 3L);
+        TreeTestDetailResponse treeResponse = (TreeTestDetailResponse) response.questions().getFirst();
+        TreeTestNodeDetailResponse root = treeResponse.features().getFirst();
+        TreeTestNodeDetailResponse child = root.children().getFirst();
+        TreeTestNodeDetailResponse grandChild = child.children().getFirst();
+        TreeTestNodeDetailResponse leaf = grandChild.children().getFirst();
 
-        ObjectiveDetailResponse objectiveResponse = (ObjectiveDetailResponse) response.questions().get(1);
+        assertThat(root.treeTestId()).isNotNull();
+        assertThat(root.label()).isEqualTo("마이페이지");
+        assertThat(child.treeTestId()).isNotNull();
+        assertThat(child.label()).isEqualTo("설정");
+        assertThat(grandChild.treeTestId()).isNotNull();
+        assertThat(grandChild.label()).isEqualTo("알림 설정");
+        assertThat(leaf.treeTestId()).isNotNull();
+        assertThat(leaf.label()).isEqualTo("푸시 알림");
+        assertThat(leaf.children()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("문항 목록 조회는 각 타입별 상세 id 필드를 모두 반환한다")
+    void getsAllDetailIdsForEachQuestionType() {
+        server.MATE.domain.test.entity.Test savedTest = createTest();
+
+        questionService.createQuestions(savedTest.getId(), 1L, new QuestionCreateRequest(List.of(
+                new ObjectiveCreateRequest(
+                        "객관식 질문",
+                        "설명",
+                        false,
+                        null,
+                        null,
+                        true,
+                        List.of(
+                                new ObjectiveOptionRequest("A", null),
+                                new ObjectiveOptionRequest("B", "image-b")
+                        )
+                ),
+                new SubjectiveCreateRequest("주관식 질문", "설명", "subjective-image"),
+                new FiveSecondCreateRequest(
+                        "5초 질문",
+                        "설명",
+                        "five-second-image",
+                        true,
+                        true,
+                        1,
+                        2,
+                        List.of(
+                                new FiveSecondOptionRequest("검색창"),
+                                new FiveSecondOptionRequest("메인 배너")
+                        )
+                ),
+                new ScaleCreateRequest("척도 질문", "설명", null, "낮음", "높음", 5),
+                new AbTestCreateRequest("AB 질문", "설명", "a-image", "b-image"),
+                new CardSortingCreateRequest("카드 질문", "설명", List.of("A", "B", "C", "D"), List.of("cat1", "cat2")),
+                new TreeTestCreateRequest(
+                        "트리 질문",
+                        "설명",
+                        List.of(
+                                new TreeTestCreateRequest.Feature(
+                                        "마이페이지",
+                                        List.of(
+                                                new TreeTestCreateRequest.TreeNode("설정", List.of())
+                                        )
+                                )
+                        )
+                )
+        )));
+
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+
+        assertThat(response.questions()).hasSize(7);
+
+        ObjectiveDetailResponse objectiveResponse = (ObjectiveDetailResponse) response.questions().get(0);
         assertThat(objectiveResponse.objectiveId()).isNotNull();
-        assertThat(objectiveResponse.options()).extracting(option -> option.sequence())
-                .containsExactly(1, 2);
+        assertThat(objectiveResponse.options()).hasSize(2);
         assertThat(objectiveResponse.options()).allSatisfy(option -> assertThat(option.objectiveOptionId()).isNotNull());
 
-        TreeTestDetailResponse treeResponse = (TreeTestDetailResponse) response.questions().get(2);
+        SubjectiveDetailResponse subjectiveResponse = (SubjectiveDetailResponse) response.questions().get(1);
+        assertThat(subjectiveResponse.subjectiveId()).isNotNull();
+
+        FiveSecondDetailResponse fiveSecondResponse = (FiveSecondDetailResponse) response.questions().get(2);
+        assertThat(fiveSecondResponse.fiveSecondId()).isNotNull();
+        assertThat(fiveSecondResponse.options()).hasSize(2);
+        assertThat(fiveSecondResponse.options()).allSatisfy(option -> assertThat(option.fiveSecondOptionId()).isNotNull());
+
+        ScaleDetailResponse scaleResponse = (ScaleDetailResponse) response.questions().get(3);
+        assertThat(scaleResponse.scaleId()).isNotNull();
+
+        AbTestDetailResponse abTestResponse = (AbTestDetailResponse) response.questions().get(4);
+        assertThat(abTestResponse.abTestId()).isNotNull();
+
+        CardSortingDetailResponse cardSortingResponse = (CardSortingDetailResponse) response.questions().get(5);
+        assertThat(cardSortingResponse.cardSortingId()).isNotNull();
+
+        TreeTestDetailResponse treeResponse = (TreeTestDetailResponse) response.questions().get(6);
+        assertThat(treeResponse.features()).isNotEmpty();
         assertThat(treeResponse.features()).allSatisfy(node -> assertThat(node.treeTestId()).isNotNull());
-        assertThat(treeResponse.features().getFirst().label()).isEqualTo("마이페이지");
-        assertThat(treeResponse.features().getFirst().children().getFirst().label()).isEqualTo("설정");
+        assertThat(treeResponse.features().getFirst().children()).allSatisfy(node -> assertThat(node.treeTestId()).isNotNull());
     }
+
 
     @Test
     @DisplayName("혼합 요청이 성공하면 sequence와 세부 구조가 함께 저장되고 cleanup 삭제는 실행되지 않는다")

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceIntegrationTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceIntegrationTest.java
@@ -15,7 +15,11 @@ import server.MATE.domain.question.dto.request.ObjectiveOptionRequest;
 import server.MATE.domain.question.dto.request.QuestionCreateRequest;
 import server.MATE.domain.question.dto.request.ScaleCreateRequest;
 import server.MATE.domain.question.dto.request.TreeTestCreateRequest;
+import server.MATE.domain.question.dto.response.ObjectiveDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
+import server.MATE.domain.question.dto.response.QuestionDetailItem;
+import server.MATE.domain.question.dto.response.QuestionDetailResponse;
+import server.MATE.domain.question.dto.response.TreeTestDetailResponse;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.repository.ObjectiveRepository;
@@ -77,6 +81,69 @@ class QuestionServiceIntegrationTest {
         scaleRepository.deleteAll();
         questionRepository.deleteAll();
         testRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("문항 목록 조회는 루트 testId와 타입별 상세 sequence를 함께 반환한다")
+    void getsQuestionDetailsWithRootTestIdAndNestedSequences() {
+        server.MATE.domain.test.entity.Test savedTest = createTest();
+
+        questionService.createQuestions(savedTest.getId(), 1L, new QuestionCreateRequest(List.of(
+                new ScaleCreateRequest(
+                        "척도 질문",
+                        "설명",
+                        null,
+                        "낮음",
+                        "높음",
+                        5
+                ),
+                new ObjectiveCreateRequest(
+                        "객관식 질문",
+                        "설명",
+                        true,
+                        2,
+                        1,
+                        true,
+                        List.of(
+                                new ObjectiveOptionRequest("A", null),
+                                new ObjectiveOptionRequest("B", "image-b")
+                        )
+                ),
+                new TreeTestCreateRequest(
+                        "트리 테스트",
+                        "설명",
+                        List.of(
+                                new TreeTestCreateRequest.Feature(
+                                        "마이페이지",
+                                        List.of(
+                                                new TreeTestCreateRequest.TreeNode(
+                                                        "설정",
+                                                        List.of(new TreeTestCreateRequest.TreeNode("알림 설정", List.of()))
+                                                )
+                                        )
+                                )
+                        )
+                )
+        )));
+
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+
+        assertThat(response.testId()).isEqualTo(savedTest.getId());
+        assertThat(response.questions()).extracting(QuestionDetailItem::type)
+                .containsExactly(QuestionType.SCALE, QuestionType.OBJECTIVE, QuestionType.TREE_TEST);
+        assertThat(response.questions()).extracting(QuestionDetailItem::sequence)
+                .containsExactly(1L, 2L, 3L);
+
+        ObjectiveDetailResponse objectiveResponse = (ObjectiveDetailResponse) response.questions().get(1);
+        assertThat(objectiveResponse.objectiveId()).isNotNull();
+        assertThat(objectiveResponse.options()).extracting(option -> option.sequence())
+                .containsExactly(1, 2);
+        assertThat(objectiveResponse.options()).allSatisfy(option -> assertThat(option.objectiveOptionId()).isNotNull());
+
+        TreeTestDetailResponse treeResponse = (TreeTestDetailResponse) response.questions().get(2);
+        assertThat(treeResponse.features()).allSatisfy(node -> assertThat(node.treeTestId()).isNotNull());
+        assertThat(treeResponse.features().getFirst().label()).isEqualTo("마이페이지");
+        assertThat(treeResponse.features().getFirst().children().getFirst().label()).isEqualTo("설정");
     }
 
     @Test

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceIntegrationTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceIntegrationTest.java
@@ -48,6 +48,7 @@ import server.MATE.global.common.exception.BaseException;
 import server.MATE.global.image.ImageService;
 
 import java.util.Comparator;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -114,9 +115,114 @@ class QuestionServiceIntegrationTest {
         testRepository.deleteAll();
     }
 
+    @Test
+    @DisplayName("삭제된 테스트는 문항 목록 조회 시 TEST_004 예외가 발생한다")
+    void throwsTest004WhenGettingQuestionsForDeletedTest() {
+        server.MATE.domain.test.entity.Test savedTest = createTest();
+        savedTest.delete(LocalDateTime.now());
+        testRepository.saveAndFlush(savedTest);
 
+        assertThatThrownBy(() -> questionService.getQuestions(savedTest.getId(), 1L))
+                .isInstanceOf(BaseException.class)
+                .extracting(ex -> ((BaseException) ex).getErrorCode())
+                .isEqualTo(BaseErrorCode.TEST_004);
+    }
 
+    @Test
+    @DisplayName("객관식 조회는 선택지 sequence 순서를 유지한다")
+    void getsObjectiveOptionsInSequenceOrder() {
+        server.MATE.domain.test.entity.Test savedTest = createTest();
 
+        questionService.createQuestions(savedTest.getId(), 1L, new QuestionCreateRequest(List.of(
+                new ObjectiveCreateRequest(
+                        "객관식 질문",
+                        "설명",
+                        false,
+                        null,
+                        null,
+                        true,
+                        List.of(
+                                new ObjectiveOptionRequest("첫 번째", null),
+                                new ObjectiveOptionRequest("두 번째", null),
+                                new ObjectiveOptionRequest("세 번째", null)
+                        )
+                )
+        )));
+
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+
+        ObjectiveDetailResponse objectiveResponse = (ObjectiveDetailResponse) response.questions().getFirst();
+        assertThat(objectiveResponse.options()).extracting(option -> option.content(), option -> option.sequence())
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple("첫 번째", 1),
+                        org.assertj.core.groups.Tuple.tuple("두 번째", 2),
+                        org.assertj.core.groups.Tuple.tuple("세 번째", 3)
+                );
+    }
+
+    @Test
+    @DisplayName("5초 테스트 객관식 조회는 선택지 sequence 순서를 유지한다")
+    void getsFiveSecondOptionsInSequenceOrder() {
+        server.MATE.domain.test.entity.Test savedTest = createTest();
+
+        questionService.createQuestions(savedTest.getId(), 1L, new QuestionCreateRequest(List.of(
+                new FiveSecondCreateRequest(
+                        "5초 질문",
+                        "설명",
+                        "five-second-image",
+                        true,
+                        true,
+                        1,
+                        3,
+                        List.of(
+                                new FiveSecondOptionRequest("첫 번째"),
+                                new FiveSecondOptionRequest("두 번째"),
+                                new FiveSecondOptionRequest("세 번째")
+                        )
+                )
+        )));
+
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+
+        FiveSecondDetailResponse fiveSecondResponse = (FiveSecondDetailResponse) response.questions().getFirst();
+        assertThat(fiveSecondResponse.options()).extracting(option -> option.content(), option -> option.sequence())
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple("첫 번째", 1),
+                        org.assertj.core.groups.Tuple.tuple("두 번째", 2),
+                        org.assertj.core.groups.Tuple.tuple("세 번째", 3)
+                );
+    }
+
+    @Test
+    @DisplayName("트리 테스트 조회는 같은 depth의 children 순서를 유지한다")
+    void getsTreeChildrenInSequenceOrder() {
+        server.MATE.domain.test.entity.Test savedTest = createTest();
+
+        questionService.createQuestions(savedTest.getId(), 1L, new QuestionCreateRequest(List.of(
+                new TreeTestCreateRequest(
+                        "트리 질문",
+                        "설명",
+                        List.of(
+                                new TreeTestCreateRequest.Feature(
+                                        "마이페이지",
+                                        List.of(
+                                                new TreeTestCreateRequest.TreeNode("설정", List.of()),
+                                                new TreeTestCreateRequest.TreeNode("프로필", List.of()),
+                                                new TreeTestCreateRequest.TreeNode("보안", List.of())
+                                        )
+                                )
+                        )
+                )
+        )));
+
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+
+        TreeTestDetailResponse treeResponse = (TreeTestDetailResponse) response.questions().getFirst();
+        assertThat(treeResponse.features()).singleElement();
+        assertThat(treeResponse.features().getFirst().children())
+                .extracting(TreeTestNodeDetailResponse::label)
+                .containsExactly("설정", "프로필", "보안");
+    }
 
     @Test
     @DisplayName("5초 테스트 주관식 조회는 객관식 전용 필드를 비워서 반환한다")
@@ -350,6 +456,68 @@ class QuestionServiceIntegrationTest {
         assertThat(treeResponse.features().getFirst().children()).allSatisfy(node -> assertThat(node.treeTestId()).isNotNull());
     }
 
+    @Test
+    @DisplayName("문항 목록 조회는 루트 testId와 타입별 상세 sequence를 함께 반환한다")
+    void getsQuestionDetailsWithRootTestIdAndNestedSequences() {
+        server.MATE.domain.test.entity.Test savedTest = createTest();
+
+        questionService.createQuestions(savedTest.getId(), 1L, new QuestionCreateRequest(List.of(
+                new ScaleCreateRequest(
+                        "척도 질문",
+                        "설명",
+                        null,
+                        "낮음",
+                        "높음",
+                        5
+                ),
+                new ObjectiveCreateRequest(
+                        "객관식 질문",
+                        "설명",
+                        true,
+                        2,
+                        1,
+                        true,
+                        List.of(
+                                new ObjectiveOptionRequest("A", null),
+                                new ObjectiveOptionRequest("B", "image-b")
+                        )
+                ),
+                new TreeTestCreateRequest(
+                        "트리 테스트",
+                        "설명",
+                        List.of(
+                                new TreeTestCreateRequest.Feature(
+                                        "마이페이지",
+                                        List.of(
+                                                new TreeTestCreateRequest.TreeNode(
+                                                        "설정",
+                                                        List.of(new TreeTestCreateRequest.TreeNode("알림 설정", List.of()))
+                                                )
+                                        )
+                                )
+                        )
+                )
+        )));
+
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+
+        assertThat(response.testId()).isEqualTo(savedTest.getId());
+        assertThat(response.questions()).extracting(QuestionDetailItem::type)
+                .containsExactly(QuestionType.SCALE, QuestionType.OBJECTIVE, QuestionType.TREE_TEST);
+        assertThat(response.questions()).extracting(QuestionDetailItem::sequence)
+                .containsExactly(1L, 2L, 3L);
+
+        ObjectiveDetailResponse objectiveResponse = (ObjectiveDetailResponse) response.questions().get(1);
+        assertThat(objectiveResponse.objectiveId()).isNotNull();
+        assertThat(objectiveResponse.options()).extracting(option -> option.sequence())
+                .containsExactly(1, 2);
+        assertThat(objectiveResponse.options()).allSatisfy(option -> assertThat(option.objectiveOptionId()).isNotNull());
+
+        TreeTestDetailResponse treeResponse = (TreeTestDetailResponse) response.questions().get(2);
+        assertThat(treeResponse.features()).allSatisfy(node -> assertThat(node.treeTestId()).isNotNull());
+        assertThat(treeResponse.features().getFirst().label()).isEqualTo("마이페이지");
+        assertThat(treeResponse.features().getFirst().children().getFirst().label()).isEqualTo("설정");
+    }
 
     @Test
     @DisplayName("혼합 요청이 성공하면 sequence와 세부 구조가 함께 저장되고 cleanup 삭제는 실행되지 않는다")

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
@@ -13,10 +13,16 @@ import server.MATE.domain.question.dto.request.ObjectiveOptionRequest;
 import server.MATE.domain.question.dto.request.QuestionCreateRequest;
 import server.MATE.domain.question.dto.request.ScaleCreateRequest;
 import server.MATE.domain.question.dto.request.TreeTestCreateRequest;
+import server.MATE.domain.question.dto.response.ObjectiveOptionDetailResponse;
+import server.MATE.domain.question.dto.response.ObjectiveDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
+import server.MATE.domain.question.dto.response.QuestionDetailItem;
+import server.MATE.domain.question.dto.response.QuestionDetailResponse;
+import server.MATE.domain.question.dto.response.ScaleDetailResponse;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.repository.QuestionRepository;
+import server.MATE.domain.question.service.fetcher.QuestionDetailFetcher;
 import server.MATE.domain.question.service.handler.QuestionCreateHandler;
 import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
@@ -24,6 +30,7 @@ import server.MATE.global.common.exception.BaseException;
 import server.MATE.global.image.event.ImageCleanupEvent;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.List;
 import java.util.Optional;
 
@@ -58,6 +65,12 @@ class QuestionServiceTest {
     @Mock
     private QuestionCreateHandler treeTestHandler;
 
+    @Mock
+    private QuestionDetailFetcher objectiveFetcher;
+
+    @Mock
+    private QuestionDetailFetcher scaleFetcher;
+
     private QuestionService questionService;
 
     private static final Long TEST_ID = 10L;
@@ -78,14 +91,81 @@ class QuestionServiceTest {
         lenient().when(objectiveHandler.supports()).thenReturn(QuestionType.OBJECTIVE);
         lenient().when(scaleHandler.supports()).thenReturn(QuestionType.SCALE);
         lenient().when(treeTestHandler.supports()).thenReturn(QuestionType.TREE_TEST);
+        lenient().when(objectiveFetcher.supports()).thenReturn(QuestionType.OBJECTIVE);
+        lenient().when(scaleFetcher.supports()).thenReturn(QuestionType.SCALE);
         lenient().when(questionRepository.save(any(Question.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         questionService = new QuestionService(
                 testRepository,
                 questionRepository,
                 eventPublisher,
-                List.of(objectiveHandler, scaleHandler, treeTestHandler)
+                List.of(objectiveHandler, scaleHandler, treeTestHandler),
+                List.of(objectiveFetcher, scaleFetcher)
         );
+    }
+
+    @Test
+    @DisplayName("문항 목록 조회는 sequence 순서를 유지하면서 타입별 fetcher 결과를 조립한다")
+    void getQuestionsAssemblesFetcherResultsInSequenceOrder() {
+        Question objectiveQuestion = Question.builder()
+                .testId(TEST_ID)
+                .questionType(QuestionType.OBJECTIVE)
+                .title("객관식 질문")
+                .description("설명")
+                .sequence(2L)
+                .build();
+        Question scaleQuestion = Question.builder()
+                .testId(TEST_ID)
+                .questionType(QuestionType.SCALE)
+                .title("척도 질문")
+                .description("설명")
+                .sequence(1L)
+                .build();
+        setQuestionId(objectiveQuestion, 201L);
+        setQuestionId(scaleQuestion, 202L);
+
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID))
+                .willReturn(List.of(scaleQuestion, objectiveQuestion));
+        given(objectiveFetcher.fetch(List.of(objectiveQuestion))).willReturn(Map.of(
+                201L,
+                new ObjectiveDetailResponse(
+                        201L,
+                        201L,
+                        QuestionType.OBJECTIVE,
+                        2L,
+                        "객관식 질문",
+                        "설명",
+                        false,
+                        null,
+                        null,
+                        true,
+                        List.of(new ObjectiveOptionDetailResponse(1001L, "A", null, 1))
+                )
+        ));
+        given(scaleFetcher.fetch(List.of(scaleQuestion))).willReturn(Map.of(
+                202L,
+                new ScaleDetailResponse(
+                        202L,
+                        202L,
+                        QuestionType.SCALE,
+                        1L,
+                        "척도 질문",
+                        "설명",
+                        null,
+                        "낮음",
+                        "높음",
+                        5
+                )
+        ));
+
+        QuestionDetailResponse response = questionService.getQuestions(TEST_ID, MAKER_ID);
+
+        assertThat(response.testId()).isEqualTo(TEST_ID);
+        assertThat(response.questions()).extracting(QuestionDetailItem::questionId)
+                .containsExactly(202L, 201L);
+        assertThat(response.questions()).extracting(QuestionDetailItem::type)
+                .containsExactly(QuestionType.SCALE, QuestionType.OBJECTIVE);
     }
 
     @Test
@@ -424,5 +504,15 @@ class QuestionServiceTest {
                 .isSameAs(exception);
 
         verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    private void setQuestionId(Question question, Long id) {
+        try {
+            java.lang.reflect.Field field = Question.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(question, id);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
@@ -166,6 +167,52 @@ class QuestionServiceTest {
                 .containsExactly(202L, 201L);
         assertThat(response.questions()).extracting(QuestionDetailItem::type)
                 .containsExactly(QuestionType.SCALE, QuestionType.OBJECTIVE);
+    }
+
+    @Test
+    @DisplayName("질문이 없는 테스트 조회는 빈 questions 배열을 반환한다")
+    void returnsEmptyQuestionListWhenTestHasNoQuestions() {
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID))
+                .willReturn(List.of());
+
+        QuestionDetailResponse response = questionService.getQuestions(TEST_ID, MAKER_ID);
+
+        assertThat(response.testId()).isEqualTo(TEST_ID);
+        assertThat(response.questions()).isEmpty();
+        verify(objectiveFetcher, never()).fetch(anyList());
+        verify(scaleFetcher, never()).fetch(anyList());
+    }
+
+    @Test
+    @DisplayName("조회 대상 테스트가 없으면 TEST_004 예외가 발생한다")
+    void getQuestionsThrowsTest004WhenTestDoesNotExist() {
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> questionService.getQuestions(TEST_ID, MAKER_ID))
+                .isInstanceOf(BaseException.class)
+                .extracting(ex -> ((BaseException) ex).getErrorCode())
+                .isEqualTo(BaseErrorCode.TEST_004);
+
+        verify(questionRepository, never()).findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID);
+        verify(objectiveFetcher, never()).fetch(anyList());
+        verify(scaleFetcher, never()).fetch(anyList());
+    }
+
+
+    @Test
+    @DisplayName("조회 요청자가 제작자가 아니면 TEST_005 예외가 발생한다")
+    void getQuestionsThrowsTest005WhenMakerDoesNotMatch() {
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+
+        assertThatThrownBy(() -> questionService.getQuestions(TEST_ID, MAKER_ID + 1))
+                .isInstanceOf(BaseException.class)
+                .extracting(ex -> ((BaseException) ex).getErrorCode())
+                .isEqualTo(BaseErrorCode.TEST_005);
+
+        verify(questionRepository, never()).findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID);
+        verify(objectiveFetcher, never()).fetch(anyList());
+        verify(scaleFetcher, never()).fetch(anyList());
     }
 
     @Test

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
@@ -199,6 +199,20 @@ class QuestionServiceTest {
         verify(scaleFetcher, never()).fetch(anyList());
     }
 
+    @Test
+    @DisplayName("삭제된 테스트는 조회 시 TEST_004 예외가 발생한다")
+    void getQuestionsThrowsTest004WhenTestIsDeleted() {
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> questionService.getQuestions(TEST_ID, MAKER_ID))
+                .isInstanceOf(BaseException.class)
+                .extracting(ex -> ((BaseException) ex).getErrorCode())
+                .isEqualTo(BaseErrorCode.TEST_004);
+
+        verify(questionRepository, never()).findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID);
+        verify(objectiveFetcher, never()).fetch(anyList());
+        verify(scaleFetcher, never()).fetch(anyList());
+    }
 
     @Test
     @DisplayName("조회 요청자가 제작자가 아니면 TEST_005 예외가 발생한다")


### PR DESCRIPTION
## 📍 요약
- 테스트 질문 상세 조회 api를 구현, 타입별 상세 응답 구조 및 조회 규격을 검증

## 🔗 관련 이슈
- Closes #46 

## 📌 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- 테스트 질문 조회 api 추가
- 질문 조회 전략을 타입별 **fetcher** 구조로 분리
  - QuestionDetailFetcher 인터페이스 및 유형별 fetcher 구현 추가
  - service는 테스트/권한 검증, 질문 목록 조회, 타입별 fetcher 조립만 담당하도록 구성
- 조회용 repository 메서드와 정렬 보장 로직 추가
  - OBJECTIVE, FIVE_SECOND 옵션 sequence 순서 보장
  - TREE_TEST parent-child 재귀 복원

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `QuestionControllerTest`: 조회 응답 JSON 규격, 상세 id 필드, null/빈 리스트 직렬화, TREE_TEST 노드 계약 검증
  - `QuestionServiceTest`: 조회 예외 처리, 빈 리스트 정책, fetcher 재조립 순서 검증
  - `QuestionServiceIntegrationTest`: 유형별 상세 구조, 옵션/children 정렬, 삭제된 테스트 조회 예외 검증
