### PR TITLE
feat(infra): terraform acr keyvault identity 구현

### DIFF
--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -59,9 +59,12 @@ module "container_registry" {
 module "keyvault" {
   source = "../../modules/keyvault"
 
-  resource_group_name = module.resource_group.name
-  location            = var.location
-  key_vault_name      = var.key_vault_name
+  resource_group_name      = module.resource_group.name
+  location                 = var.location
+  key_vault_name           = var.key_vault_name
+  placeholder_secret_value = var.key_vault_placeholder_secret_value
+  secret_initial_values    = var.key_vault_secret_initial_values
+  deployer_object_id       = var.key_vault_deployer_object_id
 }
 
 module "user_assigned_identity" {

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -63,3 +63,11 @@ module "keyvault" {
   location            = var.location
   key_vault_name      = var.key_vault_name
 }
+
+module "user_assigned_identity" {
+  source = "../../modules/user_assigned_identity"
+
+  identity_name       = var.app_managed_identity_name
+  resource_group_name = module.resource_group.name
+  location            = var.location
+}

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -45,3 +45,13 @@ module "storage" {
   storage_account_name   = var.storage_account_name
   storage_container_name = var.storage_container_name
 }
+
+module "container_registry" {
+  source = "../../modules/container_registry"
+
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  acr_name            = var.acr_name
+  acr_sku             = var.acr_sku
+  admin_enabled       = var.acr_admin_enabled
+}

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -55,3 +55,11 @@ module "container_registry" {
   acr_sku             = var.acr_sku
   admin_enabled       = var.acr_admin_enabled
 }
+
+module "keyvault" {
+  source = "../../modules/keyvault"
+
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  key_vault_name      = var.key_vault_name
+}

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -74,3 +74,16 @@ module "user_assigned_identity" {
   resource_group_name = module.resource_group.name
   location            = var.location
 }
+
+module "identity_role_assignments" {
+  source = "../../modules/identity_role_assignments"
+
+  principal_id       = module.user_assigned_identity.principal_id
+  key_vault_id       = module.keyvault.id
+  storage_account_id = module.storage.storage_account_id
+
+  assign_key_vault_secrets_user        = var.app_identity_assign_key_vault_secrets_user
+  assign_storage_blob_data_contributor = var.app_identity_assign_storage_blob_data_contributor
+  acr_id                               = module.container_registry.id
+  assign_acr_pull                      = var.app_identity_assign_acr_pull
+}

--- a/infra/terraform/environments/prod/outputs.tf
+++ b/infra/terraform/environments/prod/outputs.tf
@@ -1,3 +1,19 @@
+locals {
+  # Spring(application-prod.yml)전용 — Key Vault 슬롯 이름 → 실행 시 넣어줄 환경 변수/설명
+  spring_keyvault_env_mapping = {
+    "jwt-secret"                      = "JWT_SECRET"
+    "db-url"                          = "DB_URL"
+    "db-username"                     = "DB_USERNAME"
+    "db-password"                     = "DB_PASSWORD"
+    "discord-webhook-url"             = "DISCORD_WEBHOOK_URL"
+    "azure-storage-connection-string" = "AZURE_CONNECTION"
+    "azure-container-name"            = "AZURE_CONTAINER_NAME"
+    # Spring ssl.bundle.pem.toss.keystore 는 파일 경로 전제 (KV PEM → 디스크 반영 후 path)
+    "toss-mtls-certificate" = "TOSS_MTLS_CERT_PATH (PEM file content from KV → write to disk → path here)"
+    "toss-mtls-private-key" = "TOSS_MTLS_KEY_PATH (PEM file content from KV → write to disk → path here)"
+  }
+}
+
 output "resource_group_id" {
   description = "Referenced existing Resource Group id."
   value       = module.resource_group.id
@@ -105,7 +121,10 @@ output "key_vault_secret_names" {
 
 output "key_vault_env_var_mapping" {
   description = "KV secret name -> Spring env (application-prod.yml)."
-  value       = module.keyvault.env_var_mapping
+  value = {
+    for k, v in local.spring_keyvault_env_mapping :
+    k => v if contains(module.keyvault.secret_names, k)
+  }
 }
 
 output "app_managed_identity_id" {

--- a/infra/terraform/environments/prod/outputs.tf
+++ b/infra/terraform/environments/prod/outputs.tf
@@ -82,3 +82,18 @@ output "acr_login_server" {
   description = "ACR login server (image host)."
   value       = module.container_registry.login_server
 }
+
+output "key_vault_id" {
+  description = "Key Vault resource id."
+  value       = module.keyvault.id
+}
+
+output "key_vault_name" {
+  description = "Key Vault name."
+  value       = module.keyvault.name
+}
+
+output "key_vault_uri" {
+  description = "Key Vault URI."
+  value       = module.keyvault.vault_uri
+}

--- a/infra/terraform/environments/prod/outputs.tf
+++ b/infra/terraform/environments/prod/outputs.tf
@@ -127,3 +127,23 @@ output "app_managed_identity_tenant_id" {
   description = "Tenant id for the managed identity."
   value       = module.user_assigned_identity.tenant_id
 }
+
+output "app_identity_kv_secrets_user_role_assignment_id" {
+  description = "Role assignment: MI -> Key Vault (Secrets User)."
+  value       = module.identity_role_assignments.key_vault_secrets_user_assignment_id
+}
+
+output "app_identity_storage_blob_contributor_role_assignment_id" {
+  description = "Role assignment: MI -> Storage Account (Blob Data Contributor)."
+  value       = module.identity_role_assignments.storage_blob_data_contributor_assignment_id
+}
+
+output "app_identity_acr_pull_role_assignment_id" {
+  description = "Role assignment: MI -> ACR (AcrPull)."
+  value       = module.identity_role_assignments.acr_pull_assignment_id
+}
+
+output "storage_account_id" {
+  description = "Referenced Storage Account id (RBAC scope)."
+  value       = module.storage.storage_account_id
+}

--- a/infra/terraform/environments/prod/outputs.tf
+++ b/infra/terraform/environments/prod/outputs.tf
@@ -67,3 +67,18 @@ output "storage_container_name" {
   description = "Blob container name used by the application."
   value       = module.storage.storage_container_name
 }
+
+output "acr_id" {
+  description = "Azure Container Registry resource id."
+  value       = module.container_registry.id
+}
+
+output "acr_name" {
+  description = "Azure Container Registry name."
+  value       = module.container_registry.name
+}
+
+output "acr_login_server" {
+  description = "ACR login server (image host)."
+  value       = module.container_registry.login_server
+}

--- a/infra/terraform/environments/prod/outputs.tf
+++ b/infra/terraform/environments/prod/outputs.tf
@@ -97,3 +97,23 @@ output "key_vault_uri" {
   description = "Key Vault URI."
   value       = module.keyvault.vault_uri
 }
+
+output "app_managed_identity_id" {
+  description = "User-assigned managed identity resource id."
+  value       = module.user_assigned_identity.id
+}
+
+output "app_managed_identity_principal_id" {
+  description = "User-assigned identity principal id (for RBAC role assignments)."
+  value       = module.user_assigned_identity.principal_id
+}
+
+output "app_managed_identity_client_id" {
+  description = "User-assigned identity client id (for SDK / federation)."
+  value       = module.user_assigned_identity.client_id
+}
+
+output "app_managed_identity_tenant_id" {
+  description = "Tenant id for the managed identity."
+  value       = module.user_assigned_identity.tenant_id
+}

--- a/infra/terraform/environments/prod/outputs.tf
+++ b/infra/terraform/environments/prod/outputs.tf
@@ -98,6 +98,16 @@ output "key_vault_uri" {
   value       = module.keyvault.vault_uri
 }
 
+output "key_vault_secret_names" {
+  description = "Created application secret slots (update values in Portal)."
+  value       = module.keyvault.secret_names
+}
+
+output "key_vault_env_var_mapping" {
+  description = "KV secret name -> Spring env (application-prod.yml)."
+  value       = module.keyvault.env_var_mapping
+}
+
 output "app_managed_identity_id" {
   description = "User-assigned managed identity resource id."
   value       = module.user_assigned_identity.id

--- a/infra/terraform/environments/prod/terraform.tfvars
+++ b/infra/terraform/environments/prod/terraform.tfvars
@@ -27,3 +27,6 @@ storage_container_name = "mate-images"
 # ACR 이름은 Azure 전역에서 유일하도록
 acr_name = "kusitmsmateacr"
 acr_sku  = "Basic"
+
+# Key Vault 이름
+key_vault_name = "kusitms-mate-keyvault"

--- a/infra/terraform/environments/prod/terraform.tfvars
+++ b/infra/terraform/environments/prod/terraform.tfvars
@@ -23,3 +23,7 @@ postgres_backup_retention_days = 7
 
 storage_account_name   = "matestoragedev"
 storage_container_name = "mate-images"
+
+# ACR 이름은 Azure 전역에서 유일하도록
+acr_name = "kusitmsmateacr"
+acr_sku  = "Basic"

--- a/infra/terraform/environments/prod/terraform.tfvars
+++ b/infra/terraform/environments/prod/terraform.tfvars
@@ -30,3 +30,7 @@ acr_sku  = "Basic"
 
 # Key Vault 이름
 key_vault_name = "kusitms-mate-keyvault"
+
+# 앱(VM)에 부착할 User-assigned MI 이름 
+app_managed_identity_name = "mate-app-identity"
+

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -98,3 +98,20 @@ variable "storage_container_name" {
   description = "Blob container name used by the application."
   type        = string
 }
+
+variable "acr_name" {
+  description = "Globally unique ACR name"
+  type        = string
+}
+
+variable "acr_sku" {
+  description = "Azure Container Registry SKU."
+  type        = string
+  default     = "Basic"
+}
+
+variable "acr_admin_enabled" {
+  description = "If true, enables admin credentials (prefer false when using AcrPull with AKS)."
+  type        = bool
+  default     = false
+}

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -111,7 +111,12 @@ variable "acr_sku" {
 }
 
 variable "acr_admin_enabled" {
-  description = "If true, enables admin credentials (prefer false when using AcrPull with AKS)."
+  description = "If true, enables admin credentials (prefer false when using AcrPull)."
   type        = bool
   default     = false
+}
+
+variable "key_vault_name" {
+  description = "Globally unique Key Vault name"
+  type        = string
 }

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -144,3 +144,21 @@ variable "app_managed_identity_name" {
   description = "User-assigned managed identity name (RG scope)."
   type        = string
 }
+
+variable "app_identity_assign_key_vault_secrets_user" {
+  description = "Assign Key Vault Secrets User to app managed identity."
+  type        = bool
+  default     = true
+}
+
+variable "app_identity_assign_storage_blob_data_contributor" {
+  description = "Assign Storage Blob Data Contributor to app managed identity."
+  type        = bool
+  default     = true
+}
+
+variable "app_identity_assign_acr_pull" {
+  description = "Assign AcrPull on ACR for app MI"
+  type        = bool
+  default     = true
+}

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -120,3 +120,8 @@ variable "key_vault_name" {
   description = "Globally unique Key Vault name"
   type        = string
 }
+
+variable "app_managed_identity_name" {
+  description = "User-assigned managed identity name (RG scope)."
+  type        = string
+}

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -121,6 +121,25 @@ variable "key_vault_name" {
   type        = string
 }
 
+variable "key_vault_placeholder_secret_value" {
+  description = "Placeholder for new secrets; replace real values in Portal (나중에 변경)."
+  type        = string
+  default     = "PLACEHOLDER-SET-MANUALLY"
+}
+
+variable "key_vault_secret_initial_values" {
+  description = "Optional: set real values on first apply only (sensitive). Omit to use placeholder for all slots."
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+}
+
+variable "key_vault_deployer_object_id" {
+  description = "Object ID to grant Key Vault Secrets Officer for Terraform (defaults to current login)."
+  type        = string
+  default     = null
+}
+
 variable "app_managed_identity_name" {
   description = "User-assigned managed identity name (RG scope)."
   type        = string

--- a/infra/terraform/modules/container_registry/main.tf
+++ b/infra/terraform/modules/container_registry/main.tf
@@ -1,0 +1,7 @@
+resource "azurerm_container_registry" "this" {
+  name                = var.acr_name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  sku                 = var.acr_sku
+  admin_enabled       = var.admin_enabled
+}

--- a/infra/terraform/modules/container_registry/outputs.tf
+++ b/infra/terraform/modules/container_registry/outputs.tf
@@ -1,0 +1,14 @@
+output "id" {
+  description = "ACR resource id."
+  value       = azurerm_container_registry.this.id
+}
+
+output "name" {
+  description = "ACR resource name."
+  value       = azurerm_container_registry.this.name
+}
+
+output "login_server" {
+  description = "Login server hostname (e.g. myregistry.azurecr.io)."
+  value       = azurerm_container_registry.this.login_server
+}

--- a/infra/terraform/modules/container_registry/variables.tf
+++ b/infra/terraform/modules/container_registry/variables.tf
@@ -1,0 +1,26 @@
+variable "resource_group_name" {
+  description = "Resource Group name for the registry."
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region for the registry."
+  type        = string
+}
+
+variable "acr_name" {
+  description = "Globally unique ACR name."
+  type        = string
+}
+
+variable "acr_sku" {
+  description = "ACR SKU: Basic (lowest cost), Standard, Premium."
+  type        = string
+  default     = "Basic"
+}
+
+variable "admin_enabled" {
+  description = "Enable admin account (prefer false; use Managed Identity / AcrPull for AKS)."
+  type        = bool
+  default     = false
+}

--- a/infra/terraform/modules/database/main.tf
+++ b/infra/terraform/modules/database/main.tf
@@ -25,6 +25,10 @@ resource "azurerm_postgresql_flexible_server" "this" {
 
   public_network_access_enabled = false
 
+  lifecycle {
+    ignore_changes = [zone]
+  }
+
   depends_on = [azurerm_private_dns_zone_virtual_network_link.postgres]
 }
 

--- a/infra/terraform/modules/identity_role_assignments/main.tf
+++ b/infra/terraform/modules/identity_role_assignments/main.tf
@@ -1,0 +1,38 @@
+resource "azurerm_role_assignment" "key_vault_secrets_user" {
+  count = var.assign_key_vault_secrets_user ? 1 : 0
+
+  scope                            = var.key_vault_id
+  role_definition_name             = "Key Vault Secrets User"
+  principal_id                     = var.principal_id
+  skip_service_principal_aad_check = true
+
+  timeouts {
+    create = "30m"
+  }
+}
+
+resource "azurerm_role_assignment" "storage_blob_data_contributor" {
+  count = var.assign_storage_blob_data_contributor ? 1 : 0
+
+  scope                            = var.storage_account_id
+  role_definition_name             = "Storage Blob Data Contributor"
+  principal_id                     = var.principal_id
+  skip_service_principal_aad_check = true
+
+  timeouts {
+    create = "30m"
+  }
+}
+
+resource "azurerm_role_assignment" "acr_pull" {
+  count = var.assign_acr_pull && var.acr_id != null ? 1 : 0
+
+  scope                            = var.acr_id
+  role_definition_name             = "AcrPull"
+  principal_id                     = var.principal_id
+  skip_service_principal_aad_check = true
+
+  timeouts {
+    create = "30m"
+  }
+}

--- a/infra/terraform/modules/identity_role_assignments/outputs.tf
+++ b/infra/terraform/modules/identity_role_assignments/outputs.tf
@@ -1,0 +1,14 @@
+output "key_vault_secrets_user_assignment_id" {
+  description = "Role assignment id for Key Vault Secrets User"
+  value       = try(azurerm_role_assignment.key_vault_secrets_user[0].id, null)
+}
+
+output "storage_blob_data_contributor_assignment_id" {
+  description = "Role assignment id for Storage Blob Data Contributor"
+  value       = try(azurerm_role_assignment.storage_blob_data_contributor[0].id, null)
+}
+
+output "acr_pull_assignment_id" {
+  description = "Role assignment id for AcrPull (if created)"
+  value       = try(azurerm_role_assignment.acr_pull[0].id, null)
+}

--- a/infra/terraform/modules/identity_role_assignments/variables.tf
+++ b/infra/terraform/modules/identity_role_assignments/variables.tf
@@ -1,0 +1,38 @@
+variable "principal_id" {
+  description = "Managed identity object (principal) id."
+  type        = string
+}
+
+variable "key_vault_id" {
+  description = "Key Vault resource id (scope for Secrets User)."
+  type        = string
+}
+
+variable "storage_account_id" {
+  description = "Storage Account resource id (scope for Blob Data Contributor)."
+  type        = string
+}
+
+variable "assign_key_vault_secrets_user" {
+  description = "Grant Key Vault Secrets User (list/get secrets)."
+  type        = bool
+  default     = true
+}
+
+variable "assign_storage_blob_data_contributor" {
+  description = "Grant Storage Blob Data Contributor on the storage account."
+  type        = bool
+  default     = true
+}
+
+variable "acr_id" {
+  description = "Azure Container Registry resource id (scope for AcrPull). Set null to skip."
+  type        = string
+  default     = null
+}
+
+variable "assign_acr_pull" {
+  description = "Grant AcrPull on acr_id scope to the managed identity (required when ACR admin user is disabled)."
+  type        = bool
+  default     = true
+}

--- a/infra/terraform/modules/keyvault/main.tf
+++ b/infra/terraform/modules/keyvault/main.tf
@@ -1,17 +1,7 @@
 data "azurerm_client_config" "current" {}
 
 locals {
-  secret_slots = toset([
-    "jwt-secret",
-    "db-url",
-    "db-username",
-    "db-password",
-    "discord-webhook-url",
-    "azure-storage-connection-string",
-    "azure-container-name",
-    "toss-mtls-certificate",
-    "toss-mtls-private-key",
-  ])
+  secret_names_set = toset(var.secret_names)
 }
 
 resource "azurerm_key_vault" "this" {
@@ -36,7 +26,7 @@ resource "azurerm_role_assignment" "deployer_secrets_officer" {
 }
 
 resource "azurerm_key_vault_secret" "app" {
-  for_each = local.secret_slots
+  for_each = local.secret_names_set
 
   name         = each.key
   value        = lookup(var.secret_initial_values, each.key, var.placeholder_secret_value)

--- a/infra/terraform/modules/keyvault/main.tf
+++ b/infra/terraform/modules/keyvault/main.tf
@@ -1,0 +1,13 @@
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "this" {
+  name                          = var.key_vault_name
+  location                      = var.location
+  resource_group_name           = var.resource_group_name
+  tenant_id                     = data.azurerm_client_config.current.tenant_id
+  sku_name                      = lower(var.sku_name)
+  soft_delete_retention_days    = var.soft_delete_retention_days
+  purge_protection_enabled      = var.purge_protection_enabled
+  public_network_access_enabled = var.public_network_access_enabled
+  rbac_authorization_enabled    = true
+}

--- a/infra/terraform/modules/keyvault/main.tf
+++ b/infra/terraform/modules/keyvault/main.tf
@@ -9,6 +9,8 @@ locals {
     "discord-webhook-url",
     "azure-storage-connection-string",
     "azure-container-name",
+    "toss-mtls-certificate",
+    "toss-mtls-private-key",
   ])
 }
 

--- a/infra/terraform/modules/keyvault/main.tf
+++ b/infra/terraform/modules/keyvault/main.tf
@@ -1,5 +1,17 @@
 data "azurerm_client_config" "current" {}
 
+locals {
+  secret_slots = toset([
+    "jwt-secret",
+    "db-url",
+    "db-username",
+    "db-password",
+    "discord-webhook-url",
+    "azure-storage-connection-string",
+    "azure-container-name",
+  ])
+}
+
 resource "azurerm_key_vault" "this" {
   name                          = var.key_vault_name
   location                      = var.location
@@ -10,4 +22,27 @@ resource "azurerm_key_vault" "this" {
   purge_protection_enabled      = var.purge_protection_enabled
   public_network_access_enabled = var.public_network_access_enabled
   rbac_authorization_enabled    = true
+}
+
+resource "azurerm_role_assignment" "deployer_secrets_officer" {
+  scope                            = azurerm_key_vault.this.id
+  role_definition_name             = "Key Vault Secrets Officer"
+  principal_id                     = coalesce(var.deployer_object_id, data.azurerm_client_config.current.object_id)
+  skip_service_principal_aad_check = true
+
+  depends_on = [azurerm_key_vault.this]
+}
+
+resource "azurerm_key_vault_secret" "app" {
+  for_each = local.secret_slots
+
+  name         = each.key
+  value        = lookup(var.secret_initial_values, each.key, var.placeholder_secret_value)
+  key_vault_id = azurerm_key_vault.this.id
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  depends_on = [azurerm_role_assignment.deployer_secrets_officer]
 }

--- a/infra/terraform/modules/keyvault/outputs.tf
+++ b/infra/terraform/modules/keyvault/outputs.tf
@@ -1,0 +1,14 @@
+output "id" {
+  description = "Key Vault resource id."
+  value       = azurerm_key_vault.this.id
+}
+
+output "name" {
+  description = "Key Vault name."
+  value       = azurerm_key_vault.this.name
+}
+
+output "vault_uri" {
+  description = "DNS URI for the vault."
+  value       = azurerm_key_vault.this.vault_uri
+}

--- a/infra/terraform/modules/keyvault/outputs.tf
+++ b/infra/terraform/modules/keyvault/outputs.tf
@@ -12,3 +12,21 @@ output "vault_uri" {
   description = "DNS URI for the vault."
   value       = azurerm_key_vault.this.vault_uri
 }
+
+output "secret_names" {
+  description = "Application secret slots created in Key Vault."
+  value       = sort(keys(azurerm_key_vault_secret.app))
+}
+
+output "env_var_mapping" {
+  description = "Key Vault secret name -> Spring env (application-prod.yml)."
+  value = {
+    "jwt-secret"                      = "JWT_SECRET"
+    "db-url"                          = "DB_URL"
+    "db-username"                     = "DB_USERNAME"
+    "db-password"                     = "DB_PASSWORD"
+    "discord-webhook-url"             = "DISCORD_WEBHOOK_URL"
+    "azure-storage-connection-string" = "AZURE_CONNECTION"
+    "azure-container-name"            = "AZURE_CONTAINER_NAME"
+  }
+}

--- a/infra/terraform/modules/keyvault/outputs.tf
+++ b/infra/terraform/modules/keyvault/outputs.tf
@@ -28,5 +28,8 @@ output "env_var_mapping" {
     "discord-webhook-url"             = "DISCORD_WEBHOOK_URL"
     "azure-storage-connection-string" = "AZURE_CONNECTION"
     "azure-container-name"            = "AZURE_CONTAINER_NAME"
+    # Spring ssl.bundle.pem.toss.keystore file paths
+    "toss-mtls-certificate" = "TOSS_MTLS_CERT_PATH (PEM file content from KV → write to disk → path here)"
+    "toss-mtls-private-key" = "TOSS_MTLS_KEY_PATH (PEM file content from KV → write to disk → path here)"
   }
 }

--- a/infra/terraform/modules/keyvault/outputs.tf
+++ b/infra/terraform/modules/keyvault/outputs.tf
@@ -17,8 +17,3 @@ output "secret_names" {
   description = "Application secret slots created in Key Vault."
   value       = sort(keys(azurerm_key_vault_secret.app))
 }
-
-output "env_var_mapping" {
-  description = "Key Vault secret name -> Spring env (application-prod.yml)."
-  value       = { for k, v in var.env_var_mapping : k => v if contains(local.secret_names_set, k) }
-}

--- a/infra/terraform/modules/keyvault/outputs.tf
+++ b/infra/terraform/modules/keyvault/outputs.tf
@@ -20,16 +20,5 @@ output "secret_names" {
 
 output "env_var_mapping" {
   description = "Key Vault secret name -> Spring env (application-prod.yml)."
-  value = {
-    "jwt-secret"                      = "JWT_SECRET"
-    "db-url"                          = "DB_URL"
-    "db-username"                     = "DB_USERNAME"
-    "db-password"                     = "DB_PASSWORD"
-    "discord-webhook-url"             = "DISCORD_WEBHOOK_URL"
-    "azure-storage-connection-string" = "AZURE_CONNECTION"
-    "azure-container-name"            = "AZURE_CONTAINER_NAME"
-    # Spring ssl.bundle.pem.toss.keystore file paths
-    "toss-mtls-certificate" = "TOSS_MTLS_CERT_PATH (PEM file content from KV → write to disk → path here)"
-    "toss-mtls-private-key" = "TOSS_MTLS_KEY_PATH (PEM file content from KV → write to disk → path here)"
-  }
+  value       = { for k, v in var.env_var_mapping : k => v if contains(local.secret_names_set, k) }
 }

--- a/infra/terraform/modules/keyvault/variables.tf
+++ b/infra/terraform/modules/keyvault/variables.tf
@@ -1,0 +1,43 @@
+variable "resource_group_name" {
+  description = "Resource Group for Key Vault."
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region."
+  type        = string
+}
+
+variable "key_vault_name" {
+  description = "Globally unique vault name"
+  type        = string
+}
+
+variable "sku_name" {
+  description = "Key Vault SKU"
+  type        = string
+  default     = "standard"
+
+  validation {
+    condition     = contains(["standard", "premium"], lower(var.sku_name))
+    error_message = "sku_name must be standard or premium."
+  }
+}
+
+variable "soft_delete_retention_days" {
+  description = "Soft-delete retention in days."
+  type        = number
+  default     = 90
+}
+
+variable "purge_protection_enabled" {
+  description = "true: a soft-deleted vault cannot be permanently purged (stricter)."
+  type        = bool
+  default     = false
+}
+
+variable "public_network_access_enabled" {
+  description = "Allow public network access (set false when using private endpoints)."
+  type        = bool
+  default     = true
+}

--- a/infra/terraform/modules/keyvault/variables.tf
+++ b/infra/terraform/modules/keyvault/variables.tf
@@ -41,3 +41,22 @@ variable "public_network_access_enabled" {
   type        = bool
   default     = true
 }
+
+variable "placeholder_secret_value" {
+  description = "Initial secret value until replaced in Portal/CLI (나중에 변경 필요)."
+  type        = string
+  default     = "PLACEHOLDER-SET-MANUALLY"
+}
+
+variable "secret_initial_values" {
+  description = "Optional map secret name -> value for first apply; later updates must be Portal/CLI (ignored by Terraform)."
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+}
+
+variable "deployer_object_id" {
+  description = "Object ID for Key Vault Secrets Officer on this vault (default: terraform az login principal)."
+  type        = string
+  default     = null
+}

--- a/infra/terraform/modules/keyvault/variables.tf
+++ b/infra/terraform/modules/keyvault/variables.tf
@@ -48,6 +48,38 @@ variable "placeholder_secret_value" {
   default     = "PLACEHOLDER-SET-MANUALLY"
 }
 
+variable "secret_names" {
+  description = "Key Vault에 만들 시크릿 이름 목록(슬롯). 환경·프로젝트별로 모듈 호출 시 주입(중복 없이)."
+  type        = list(string)
+  default = [
+    "jwt-secret",
+    "db-url",
+    "db-username",
+    "db-password",
+    "discord-webhook-url",
+    "azure-storage-connection-string",
+    "azure-container-name",
+    "toss-mtls-certificate",
+    "toss-mtls-private-key",
+  ]
+}
+
+variable "env_var_mapping" {
+  description = "시크릿 이름 → Spring env 등 설명 출력용 맵(secret_names에 있는 항목만 출력에 노출)."
+  type        = map(string)
+  default = {
+    "jwt-secret"                      = "JWT_SECRET"
+    "db-url"                          = "DB_URL"
+    "db-username"                     = "DB_USERNAME"
+    "db-password"                     = "DB_PASSWORD"
+    "discord-webhook-url"             = "DISCORD_WEBHOOK_URL"
+    "azure-storage-connection-string" = "AZURE_CONNECTION"
+    "azure-container-name"            = "AZURE_CONTAINER_NAME"
+    "toss-mtls-certificate"           = "TOSS_MTLS_CERT_PATH (PEM file content from KV → write to disk → path here)"
+    "toss-mtls-private-key"           = "TOSS_MTLS_KEY_PATH (PEM file content from KV → write to disk → path here)"
+  }
+}
+
 variable "secret_initial_values" {
   description = "Optional map secret name -> value for first apply; later updates must be Portal/CLI (ignored by Terraform)."
   type        = map(string)

--- a/infra/terraform/modules/keyvault/variables.tf
+++ b/infra/terraform/modules/keyvault/variables.tf
@@ -49,7 +49,7 @@ variable "placeholder_secret_value" {
 }
 
 variable "secret_names" {
-  description = "Key Vault에 만들 시크릿 이름 목록(슬롯). 환경·프로젝트별로 모듈 호출 시 주입(중복 없이)."
+  description = "Key Vault에 만들 시크릿 이름 목록(슬롯), 환경·프로젝트별로 모듈 호출 시 주입(중복 없이)"
   type        = list(string)
   default = [
     "jwt-secret",
@@ -62,22 +62,6 @@ variable "secret_names" {
     "toss-mtls-certificate",
     "toss-mtls-private-key",
   ]
-}
-
-variable "env_var_mapping" {
-  description = "시크릿 이름 → Spring env 등 설명 출력용 맵(secret_names에 있는 항목만 출력에 노출)."
-  type        = map(string)
-  default = {
-    "jwt-secret"                      = "JWT_SECRET"
-    "db-url"                          = "DB_URL"
-    "db-username"                     = "DB_USERNAME"
-    "db-password"                     = "DB_PASSWORD"
-    "discord-webhook-url"             = "DISCORD_WEBHOOK_URL"
-    "azure-storage-connection-string" = "AZURE_CONNECTION"
-    "azure-container-name"            = "AZURE_CONTAINER_NAME"
-    "toss-mtls-certificate"           = "TOSS_MTLS_CERT_PATH (PEM file content from KV → write to disk → path here)"
-    "toss-mtls-private-key"           = "TOSS_MTLS_KEY_PATH (PEM file content from KV → write to disk → path here)"
-  }
 }
 
 variable "secret_initial_values" {

--- a/infra/terraform/modules/storage/outputs.tf
+++ b/infra/terraform/modules/storage/outputs.tf
@@ -3,6 +3,11 @@ output "storage_account_name" {
   value       = data.azurerm_storage_account.this.name
 }
 
+output "storage_account_id" {
+  description = "Referenced Storage Account resource id."
+  value       = data.azurerm_storage_account.this.id
+}
+
 output "primary_blob_endpoint" {
   description = "Blob endpoint for the referenced Storage Account."
   value       = data.azurerm_storage_account.this.primary_blob_endpoint

--- a/infra/terraform/modules/user_assigned_identity/main.tf
+++ b/infra/terraform/modules/user_assigned_identity/main.tf
@@ -1,0 +1,5 @@
+resource "azurerm_user_assigned_identity" "this" {
+  name                = var.identity_name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+}

--- a/infra/terraform/modules/user_assigned_identity/outputs.tf
+++ b/infra/terraform/modules/user_assigned_identity/outputs.tf
@@ -1,0 +1,24 @@
+output "id" {
+  description = "Managed identity resource id."
+  value       = azurerm_user_assigned_identity.this.id
+}
+
+output "name" {
+  description = "Managed identity name."
+  value       = azurerm_user_assigned_identity.this.name
+}
+
+output "principal_id" {
+  description = "Object (principal) id — use with azurerm_role_assignment."
+  value       = azurerm_user_assigned_identity.this.principal_id
+}
+
+output "client_id" {
+  description = "Client id — use for DefaultAzureCredential / workload apps."
+  value       = azurerm_user_assigned_identity.this.client_id
+}
+
+output "tenant_id" {
+  description = "Entra tenant id."
+  value       = azurerm_user_assigned_identity.this.tenant_id
+}

--- a/infra/terraform/modules/user_assigned_identity/variables.tf
+++ b/infra/terraform/modules/user_assigned_identity/variables.tf
@@ -1,0 +1,14 @@
+variable "identity_name" {
+  description = "User-assigned managed identity name."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource Group for the identity."
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region."
+  type        = string
+}


### PR DESCRIPTION
## 📍 요약
- ACR·Key Vault·UAMI와 RBAC(AcrPull·KV·Blob)을 Terraform으로 추가
- Toss mTLS용 KeyVault 슬롯을 포함해 앱의 이미지, 비밀 보안 확보

## 🔗 관련 이슈
- Closes #51

## 📌 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타 (인프라/IaC)

## ✅ 작업 내용
- **`container_registry` 모듈**: Azure Container Registry 생성 및 prod 연결(login server 등 출력)
- **`keyvault` 모듈**: RBAC 기반 Key Vault, 배포 주체 Secrets Officer, 앱용 시크릿 슬롯(jwt/db/discord/azure/toss-mtls 등)·`ignore_changes = [value]` 로 Portal/수동 값 유지
- **`user_assigned_identity` 모듈**: 앱용 User-assigned 관리 ID 및 client/tenant 등 출력
- **`identity_role_assignments` 모듈**: UAMI에 Key Vault Secrets User·Storage Blob Data Contributor·**AcrPull**(ACR 연동) 부여(토글 변수)
- **`storage`**: Storage Account `id` 출력(위 RBAC 스코프용)
- **`database`**: PostgreSQL Flexible Server **`zone` 드리프트 방지**용 `lifecycle.ignore_changes`
- **`environments/prod`**: 위 모듈 통합, 변수·출력(KV URI, MI, 역할 할당 id, `env_var_mapping` 등)·`terraform.tfvars` 샘플 추가

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법:
  - `cd infra/terraform/environments/prod && terraform init && terraform validate`
  - 적용 전 `terraform plan`으로 생성/변경 범위 확인