### PR TITLE
feat: 테스트 참여 등록 API 구현

### DIFF
--- a/src/main/java/server/MATE/domain/participation/controller/ParticipationController.java
+++ b/src/main/java/server/MATE/domain/participation/controller/ParticipationController.java
@@ -1,0 +1,38 @@
+package server.MATE.domain.participation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import server.MATE.domain.participation.dto.response.ParticipationCreateResponse;
+import server.MATE.domain.participation.service.ParticipationService;
+import server.MATE.global.common.response.ApiResponse;
+import server.MATE.global.security.principal.AuthenticatedUser;
+
+@Tag(name = "[PARTICIPATION] 참여 API", description = "테스트 참여 관련 API")
+@RestController
+@RequestMapping("/api/v1/tests/{testId}/participations")
+@SecurityRequirement(name = "JWT")
+@RequiredArgsConstructor
+public class ParticipationController {
+
+    private final ParticipationService participationService;
+
+    @Operation(summary = "테스트 참여 등록", description = """
+            테스트에 참여하는 유저의 참여 세션을 생성합니다.
+            - Request Body 없음. testId는 Path Variable, 테스터 ID는 JWT에서 추출합니다.
+            """)
+    @PostMapping
+    public ResponseEntity<ApiResponse<ParticipationCreateResponse>> createParticipation(
+            @PathVariable Long testId,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        ParticipationCreateResponse response = participationService.createParticipation(testId, authenticatedUser.getId());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created("테스트 참여가 등록되었습니다.", response));
+    }
+}

--- a/src/main/java/server/MATE/domain/participation/dto/response/ParticipationCreateResponse.java
+++ b/src/main/java/server/MATE/domain/participation/dto/response/ParticipationCreateResponse.java
@@ -1,0 +1,10 @@
+package server.MATE.domain.participation.dto.response;
+
+import server.MATE.domain.participation.entity.Participation;
+
+public record ParticipationCreateResponse(Long participationId) {
+
+    public static ParticipationCreateResponse from(Participation participation) {
+        return new ParticipationCreateResponse(participation.getId());
+    }
+}

--- a/src/main/java/server/MATE/domain/participation/entity/Participation.java
+++ b/src/main/java/server/MATE/domain/participation/entity/Participation.java
@@ -1,0 +1,38 @@
+package server.MATE.domain.participation.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.MATE.global.common.entity.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(
+        name = "participation",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"test_id", "tester_id"})
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Participation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, updatable = false)
+    private Long testId;
+
+    @Column(nullable = false, updatable = false)
+    private Long testerId;
+
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public Participation(Long testId, Long testerId) {
+        this.testId = testId;
+        this.testerId = testerId;
+    }
+}

--- a/src/main/java/server/MATE/domain/participation/repository/ParticipationRepository.java
+++ b/src/main/java/server/MATE/domain/participation/repository/ParticipationRepository.java
@@ -1,0 +1,13 @@
+package server.MATE.domain.participation.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.MATE.domain.participation.entity.Participation;
+
+import java.util.Optional;
+
+public interface ParticipationRepository extends JpaRepository<Participation, Long> {
+
+    Optional<Participation> findByIdAndDeletedAtIsNull(Long id);
+
+    boolean existsByTestIdAndTesterIdAndDeletedAtIsNull(Long testId, Long testerId);
+}

--- a/src/main/java/server/MATE/domain/participation/service/ParticipationService.java
+++ b/src/main/java/server/MATE/domain/participation/service/ParticipationService.java
@@ -1,0 +1,41 @@
+package server.MATE.domain.participation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.participation.dto.response.ParticipationCreateResponse;
+import server.MATE.domain.participation.entity.Participation;
+import server.MATE.domain.participation.repository.ParticipationRepository;
+import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ParticipationService {
+
+    private final TestRepository testRepository;
+    private final ParticipationRepository participationRepository;
+
+    @Transactional
+    public ParticipationCreateResponse createParticipation(Long testId, Long testerId) {
+        Test test = testRepository.findByIdAndDeletedAtIsNull(testId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        test.validateCanParticipate();
+
+        if (participationRepository.existsByTestIdAndTesterIdAndDeletedAtIsNull(testId, testerId)) {
+            throw new BaseException(BaseErrorCode.PARTICIPATION_003);
+        }
+
+        Participation participation = Participation.builder()
+                .testId(testId)
+                .testerId(testerId)
+                .build();
+
+        participationRepository.save(participation);
+        return ParticipationCreateResponse.from(participation);
+    }
+}

--- a/src/main/java/server/MATE/domain/participation/service/ParticipationService.java
+++ b/src/main/java/server/MATE/domain/participation/service/ParticipationService.java
@@ -21,7 +21,7 @@ public class ParticipationService {
 
     @Transactional
     public ParticipationCreateResponse createParticipation(Long testId, Long testerId) {
-        Test test = testRepository.findByIdAndDeletedAtIsNull(testId)
+        Test test = testRepository.findByIdAndDeletedAtIsNullForUpdate(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
         test.validateCanParticipate();
@@ -36,6 +36,7 @@ public class ParticipationService {
                 .build();
 
         participationRepository.save(participation);
+        test.incrementPplCount();
         return ParticipationCreateResponse.from(participation);
     }
 }

--- a/src/main/java/server/MATE/domain/test/entity/Test.java
+++ b/src/main/java/server/MATE/domain/test/entity/Test.java
@@ -97,7 +97,7 @@ public class Test extends BaseEntity {
         if (this.approvalStatus != ApprovalStatus.ACCEPTED || this.testStatus != TestStatus.IN_PROGRESS) {
             throw new BaseException(BaseErrorCode.PARTICIPATION_002);
         }
-        if (this.pplCount >= this.goalPpl) {
+        if (this.pplCount >= this.goalPpl.longValue()) {
             throw new BaseException(BaseErrorCode.PARTICIPATION_004);
         }
     }

--- a/src/main/java/server/MATE/domain/test/entity/Test.java
+++ b/src/main/java/server/MATE/domain/test/entity/Test.java
@@ -97,6 +97,13 @@ public class Test extends BaseEntity {
         if (this.approvalStatus != ApprovalStatus.ACCEPTED || this.testStatus != TestStatus.IN_PROGRESS) {
             throw new BaseException(BaseErrorCode.PARTICIPATION_002);
         }
+        if (this.pplCount >= this.goalPpl) {
+            throw new BaseException(BaseErrorCode.PARTICIPATION_004);
+        }
+    }
+
+    public void incrementPplCount() {
+        this.pplCount++;
     }
 
     public void delete(LocalDateTime deletedAt) {

--- a/src/main/java/server/MATE/domain/test/entity/Test.java
+++ b/src/main/java/server/MATE/domain/test/entity/Test.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
 import server.MATE.global.common.entity.BaseEntity;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -88,6 +90,12 @@ public class Test extends BaseEntity {
         if (imageKeys != null) {
             this.imageKeys.clear();
             this.imageKeys.addAll(imageKeys);
+        }
+    }
+
+    public void validateCanParticipate() {
+        if (this.approvalStatus != ApprovalStatus.ACCEPTED || this.testStatus != TestStatus.IN_PROGRESS) {
+            throw new BaseException(BaseErrorCode.PARTICIPATION_002);
         }
     }
 

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -49,6 +49,7 @@ public enum BaseErrorCode implements ErrorCode {
     PARTICIPATION_001(HttpStatus.NOT_FOUND, "PARTICIPATION_001", "참여 정보를 찾을 수 없습니다."),
     PARTICIPATION_002(HttpStatus.BAD_REQUEST, "PARTICIPATION_002", "참여할 수 없는 테스트입니다."),
     PARTICIPATION_003(HttpStatus.BAD_REQUEST, "PARTICIPATION_003", "이미 참여한 테스트입니다."),
+    PARTICIPATION_004(HttpStatus.BAD_REQUEST, "PARTICIPATION_004", "테스트 참여 인원이 마감되었습니다."),
 
     // File
     FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_001", "파일 업로드에 실패했습니다."),

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -45,6 +45,11 @@ public enum BaseErrorCode implements ErrorCode {
     QUESTION_008(HttpStatus.BAD_REQUEST, "QUESTION_008", "주관식 5초 테스트에는 객관식 설정을 입력할 수 없습니다."),
     QUESTION_009(HttpStatus.BAD_REQUEST, "QUESTION_009", "단일 선택 객관식에는 최소/최대 선택 개수를 입력할 수 없습니다."),
 
+    // Participation
+    PARTICIPATION_001(HttpStatus.NOT_FOUND, "PARTICIPATION_001", "참여 정보를 찾을 수 없습니다."),
+    PARTICIPATION_002(HttpStatus.BAD_REQUEST, "PARTICIPATION_002", "참여할 수 없는 테스트입니다."),
+    PARTICIPATION_003(HttpStatus.BAD_REQUEST, "PARTICIPATION_003", "이미 참여한 테스트입니다."),
+
     // File
     FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_001", "파일 업로드에 실패했습니다."),
 


### PR DESCRIPTION
  ## 📍 요약
  테스트 참여 세션을 생성하는 API 구현                                                                    
                                                                                                                      
  ## 🔗 관련 이슈                                                                                                       
  Closes #64     
                                                                                                                        
  ## 📌 변경 사항                                                                                                     
  - [x] 기능                                                                                                              

      
  ## ✅ 작업 내용                                                                                                       
  - Participation 엔티티 및 레포지토리 생성                                                                           
  - POST /api/v1/tests/{testId}/participations 엔드포인트 구현
  - 참여 가능 상태 검증 (ACCEPTED + IN_PROGRESS)              
  - 중복 참여 방지 (DB Unique Constraint + 서비스 레벨 검증)                                                            
  - 참여 가능 상태 검증 로직을 Test 도메인으로 이동                                                                      

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew test
  - Swagger
    - 정상 참여 등록 (201)                                                                                              
    - 존재하지 않는 테스트 (TEST_004)                                                                                     
    - 참여 불가 상태 테스트 (PARTICIPATION_002)                                                                           
    - 중복 참여 (PARTICIPATION_003) 
