### PR TITLE
feat: 주관식 응답 등록 API 구현

### DIFF
--- a/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
+++ b/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
@@ -1,0 +1,39 @@
+package server.MATE.domain.answer.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import server.MATE.domain.answer.dto.request.SubjectiveAnswerCreateRequest;
+import server.MATE.domain.answer.dto.response.AnswerCreateResponse;
+import server.MATE.domain.answer.service.AnswerService;
+import server.MATE.global.common.response.ApiResponse;
+
+@Tag(name = "[ANSWER] 응답 API", description = "테스트 응답 관련 API")
+@RestController
+@RequestMapping("/api/v1/participations/{participationId}/answers")
+@SecurityRequirement(name = "JWT")
+@RequiredArgsConstructor
+public class AnswerController {
+
+    private final AnswerService answerService;
+
+    @Operation(summary = "주관식 응답 등록", description = """
+            주관식 질문에 대한 응답을 등록합니다.
+            - questionId는 SUBJECTIVE 타입이어야 합니다.
+            - 질문은 해당 참여 세션의 테스트에 속해야 합니다.
+            """)
+    @PostMapping("/subjective")
+    public ResponseEntity<ApiResponse<AnswerCreateResponse>> createSubjectiveAnswer(
+            @PathVariable Long participationId,
+            @RequestBody @Valid SubjectiveAnswerCreateRequest request
+    ) {
+        AnswerCreateResponse response = answerService.createSubjectiveAnswer(participationId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created("응답이 등록되었습니다.", response));
+    }
+}

--- a/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
+++ b/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
@@ -7,11 +7,13 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import server.MATE.domain.answer.dto.request.SubjectiveAnswerCreateRequest;
 import server.MATE.domain.answer.dto.response.AnswerCreateResponse;
 import server.MATE.domain.answer.service.AnswerService;
 import server.MATE.global.common.response.ApiResponse;
+import server.MATE.global.security.principal.AuthenticatedUser;
 
 @Tag(name = "[ANSWER] 응답 API", description = "테스트 응답 관련 API")
 @RestController
@@ -30,9 +32,10 @@ public class AnswerController {
     @PostMapping("/subjective")
     public ResponseEntity<ApiResponse<AnswerCreateResponse>> createSubjectiveAnswer(
             @PathVariable Long participationId,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
             @RequestBody @Valid SubjectiveAnswerCreateRequest request
     ) {
-        AnswerCreateResponse response = answerService.createSubjectiveAnswer(participationId, request);
+        AnswerCreateResponse response = answerService.createSubjectiveAnswer(participationId, authenticatedUser.getId(), request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("응답이 등록되었습니다.", response));
     }

--- a/src/main/java/server/MATE/domain/answer/dto/request/SubjectiveAnswerCreateRequest.java
+++ b/src/main/java/server/MATE/domain/answer/dto/request/SubjectiveAnswerCreateRequest.java
@@ -1,0 +1,10 @@
+package server.MATE.domain.answer.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record SubjectiveAnswerCreateRequest(
+        @NotNull Long questionId,
+        @NotBlank String text
+) {
+}

--- a/src/main/java/server/MATE/domain/answer/dto/response/AnswerCreateResponse.java
+++ b/src/main/java/server/MATE/domain/answer/dto/response/AnswerCreateResponse.java
@@ -1,0 +1,10 @@
+package server.MATE.domain.answer.dto.response;
+
+import server.MATE.domain.answer.entity.Answer;
+
+public record AnswerCreateResponse(Long answerId) {
+
+    public static AnswerCreateResponse from(Answer answer) {
+        return new AnswerCreateResponse(answer.getId());
+    }
+}

--- a/src/main/java/server/MATE/domain/answer/entity/Answer.java
+++ b/src/main/java/server/MATE/domain/answer/entity/Answer.java
@@ -1,0 +1,48 @@
+package server.MATE.domain.answer.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.global.common.entity.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "answer")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Answer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, updatable = false)
+    private Long participationId;
+
+    @Column(nullable = false, updatable = false)
+    private Long questionId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, updatable = false)
+    private QuestionType questionType;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(nullable = false, columnDefinition = "jsonb")
+    private String answer;
+
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public Answer(Long participationId, Long questionId, QuestionType questionType, String answer) {
+        this.participationId = participationId;
+        this.questionId = questionId;
+        this.questionType = questionType;
+        this.answer = answer;
+    }
+}

--- a/src/main/java/server/MATE/domain/answer/entity/Answer.java
+++ b/src/main/java/server/MATE/domain/answer/entity/Answer.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Entity
-@Table(name = "answer")
+@Table(name = "answer", uniqueConstraints = @UniqueConstraint(columnNames = {"participation_id", "question_id"}))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Answer extends BaseEntity {
 

--- a/src/main/java/server/MATE/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/server/MATE/domain/answer/repository/AnswerRepository.java
@@ -1,0 +1,7 @@
+package server.MATE.domain.answer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.MATE.domain.answer.entity.Answer;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+}

--- a/src/main/java/server/MATE/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/server/MATE/domain/answer/repository/AnswerRepository.java
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import server.MATE.domain.answer.entity.Answer;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
+    boolean existsByParticipationIdAndQuestionIdAndDeletedAtIsNull(Long participationId, Long questionId);
 }

--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -30,9 +30,13 @@ public class AnswerService {
     private final ObjectMapper objectMapper;
 
     @Transactional
-    public AnswerCreateResponse createSubjectiveAnswer(Long participationId, SubjectiveAnswerCreateRequest request) {
+    public AnswerCreateResponse createSubjectiveAnswer(Long participationId, Long testerId, SubjectiveAnswerCreateRequest request) {
         Participation participation = participationRepository.findByIdAndDeletedAtIsNull(participationId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.PARTICIPATION_001));
+
+        if (!participation.getTesterId().equals(testerId)) {
+            throw new BaseException(BaseErrorCode.COMMON_009);
+        }
 
         Question question = questionRepository.findByIdAndDeletedAtIsNull(request.questionId())
                 .orElseThrow(() -> new BaseException(BaseErrorCode.QUESTION_005));
@@ -43,6 +47,10 @@ public class AnswerService {
 
         if (!question.getTestId().equals(participation.getTestId())) {
             throw new BaseException(BaseErrorCode.ANSWER_002);
+        }
+
+        if (answerRepository.existsByParticipationIdAndQuestionIdAndDeletedAtIsNull(participationId, request.questionId())) {
+            throw new BaseException(BaseErrorCode.ANSWER_003);
         }
 
         String answerJson = toJson(Map.of("text", request.text()));

--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -1,0 +1,68 @@
+package server.MATE.domain.answer.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.answer.dto.request.SubjectiveAnswerCreateRequest;
+import server.MATE.domain.answer.dto.response.AnswerCreateResponse;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.answer.repository.AnswerRepository;
+import server.MATE.domain.participation.entity.Participation;
+import server.MATE.domain.participation.repository.ParticipationRepository;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.QuestionRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.util.Map;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AnswerService {
+
+    private final ParticipationRepository participationRepository;
+    private final QuestionRepository questionRepository;
+    private final AnswerRepository answerRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public AnswerCreateResponse createSubjectiveAnswer(Long participationId, SubjectiveAnswerCreateRequest request) {
+        Participation participation = participationRepository.findByIdAndDeletedAtIsNull(participationId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.PARTICIPATION_001));
+
+        Question question = questionRepository.findByIdAndDeletedAtIsNull(request.questionId())
+                .orElseThrow(() -> new BaseException(BaseErrorCode.QUESTION_005));
+
+        if (question.getQuestionType() != QuestionType.SUBJECTIVE) {
+            throw new BaseException(BaseErrorCode.ANSWER_001);
+        }
+
+        if (!question.getTestId().equals(participation.getTestId())) {
+            throw new BaseException(BaseErrorCode.ANSWER_002);
+        }
+
+        String answerJson = toJson(Map.of("text", request.text()));
+
+        Answer answer = Answer.builder()
+                .participationId(participationId)
+                .questionId(request.questionId())
+                .questionType(QuestionType.SUBJECTIVE)
+                .answer(answerJson)
+                .build();
+
+        answerRepository.save(answer);
+        return AnswerCreateResponse.from(answer);
+    }
+
+    private String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new BaseException(BaseErrorCode.COMMON_999);
+        }
+    }
+}

--- a/src/main/java/server/MATE/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/QuestionRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.Query;
 import server.MATE.domain.question.entity.Question;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
@@ -11,4 +12,6 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     Long findMaxSequenceByTestId(Long testId);
 
     List<Question> findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(Long testId);
+
+    Optional<Question> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -53,6 +53,7 @@ public enum BaseErrorCode implements ErrorCode {
     // Answer
     ANSWER_001(HttpStatus.BAD_REQUEST, "ANSWER_001", "해당 질문 유형에 대한 응답을 등록할 수 없습니다."),
     ANSWER_002(HttpStatus.BAD_REQUEST, "ANSWER_002", "질문이 해당 테스트에 속하지 않습니다."),
+    ANSWER_003(HttpStatus.BAD_REQUEST, "ANSWER_003", "이미 응답한 질문입니다."),
 
     // File
     FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_001", "파일 업로드에 실패했습니다."),

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -50,6 +50,10 @@ public enum BaseErrorCode implements ErrorCode {
     PARTICIPATION_002(HttpStatus.BAD_REQUEST, "PARTICIPATION_002", "참여할 수 없는 테스트입니다."),
     PARTICIPATION_003(HttpStatus.BAD_REQUEST, "PARTICIPATION_003", "이미 참여한 테스트입니다."),
 
+    // Answer
+    ANSWER_001(HttpStatus.BAD_REQUEST, "ANSWER_001", "해당 질문 유형에 대한 응답을 등록할 수 없습니다."),
+    ANSWER_002(HttpStatus.BAD_REQUEST, "ANSWER_002", "질문이 해당 테스트에 속하지 않습니다."),
+
     // File
     FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_001", "파일 업로드에 실패했습니다."),
 


### PR DESCRIPTION
  ## 📍 요약
  테스트 참여 세션에서 주관식 질문에 대한 응답을 등록하는 API 구현.                                           
                                                                             
  ## 🔗 관련 이슈                                                                                                       
  Closes #58      
                                                                                                                        
  ## 📌 변경 사항 
  - [x] 기능           

      
  ## ✅ 작업 내용                                                                                                       
  - Answer 엔티티 생성 (answer 필드 JSONB 타입)
  - POST /api/v1/participations/{participationId}/answers/subjective 엔드포인트 구현                                    
  - participation 존재 여부 검증                                                                                        
  - question 존재 여부 및 SUBJECTIVE 타입 검증                                                                          
  - question이 해당 테스트에 속하는지 검증                                                                              
                                                                                                                        
  ## 테스트             
  - [x] 로컬 테스트 완료    
    -  ./gradlew test                                                                                             
    - Swagger                                                                                               
      - 정상 응답 등록 (201)                                                                                                
      - 존재하지 않는 participation (PARTICIPATION_001)
      - 존재하지 않는 question (QUESTION_005)                                                                               
      - SUBJECTIVE 아닌 질문 타입 (ANSWER_001)                                                                              
      - 다른 테스트 소속 질문 (ANSWER_002)                                
