### PR TITLE
feat: 객관식 응답 등록 API 구현

### DIFF
--- a/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
+++ b/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import server.MATE.domain.answer.dto.request.ObjectiveAnswerCreateRequest;
 import server.MATE.domain.answer.dto.request.SubjectiveAnswerCreateRequest;
 import server.MATE.domain.answer.dto.response.AnswerCreateResponse;
 import server.MATE.domain.answer.service.AnswerService;
@@ -36,6 +37,35 @@ public class AnswerController {
             @RequestBody @Valid SubjectiveAnswerCreateRequest request
     ) {
         AnswerCreateResponse response = answerService.createSubjectiveAnswer(participationId, authenticatedUser.getId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created("응답이 등록되었습니다.", response));
+    }
+
+    @Operation(summary = "객관식 응답 등록", description = """
+            객관식 질문에 대한 응답을 등록합니다.
+            - questionId는 OBJECTIVE 타입이어야 합니다.
+            - 질문은 해당 참여 세션의 테스트에 속해야 합니다.
+            - selectedOptionIds는 해당 질문의 선택지 ID만 허용됩니다.
+            - 단일 선택(isDuplicate=false)이면 selectedOptionIds는 정확히 1개여야 합니다.
+            - 복수 선택(isDuplicate=true)이면 minSelect 이상 maxSelect 이하로 선택해야 합니다.
+            - isOther=true인 질문에서만 otherText를 입력할 수 있습니다.
+
+            **[에러 코드]**
+            | 코드 | HTTP | 설명 |
+            |------|------|------|
+            | ANSWER_001 | 400 | questionId가 OBJECTIVE 타입이 아님 |
+            | ANSWER_002 | 400 | 질문이 해당 테스트에 속하지 않음 |
+            | ANSWER_003 | 400 | 이미 응답한 질문 |
+            | ANSWER_004 | 400 | selectedOptionIds에 유효하지 않은 선택지 포함 |
+            | ANSWER_005 | 400 | 선택 개수가 허용 범위를 벗어남 |
+            """)
+    @PostMapping("/objective")
+    public ResponseEntity<ApiResponse<AnswerCreateResponse>> createObjectiveAnswer(
+            @PathVariable Long participationId,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @RequestBody @Valid ObjectiveAnswerCreateRequest request
+    ) {
+        AnswerCreateResponse response = answerService.createObjectiveAnswer(participationId, authenticatedUser.getId(), request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("응답이 등록되었습니다.", response));
     }

--- a/src/main/java/server/MATE/domain/answer/dto/request/ObjectiveAnswerCreateRequest.java
+++ b/src/main/java/server/MATE/domain/answer/dto/request/ObjectiveAnswerCreateRequest.java
@@ -1,0 +1,12 @@
+package server.MATE.domain.answer.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record ObjectiveAnswerCreateRequest(
+        @NotNull Long questionId,
+        @NotNull List<Long> selectedOptionIds,
+        String otherText
+) {
+}

--- a/src/main/java/server/MATE/domain/answer/entity/Answer.java
+++ b/src/main/java/server/MATE/domain/answer/entity/Answer.java
@@ -11,6 +11,7 @@ import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.global.common.entity.BaseEntity;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Getter
 @Entity
@@ -33,13 +34,13 @@ public class Answer extends BaseEntity {
     private QuestionType questionType;
 
     @JdbcTypeCode(SqlTypes.JSON)
-    @Column(nullable = false, columnDefinition = "jsonb")
-    private String answer;
+    @Column(nullable = false, updatable = false, columnDefinition = "jsonb")
+    private Map<String, Object> answer;
 
     private LocalDateTime deletedAt;
 
     @Builder
-    public Answer(Long participationId, Long questionId, QuestionType questionType, String answer) {
+    public Answer(Long participationId, Long questionId, QuestionType questionType, Map<String, Object> answer) {
         this.participationId = participationId;
         this.questionId = questionId;
         this.questionType = questionType;

--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -91,7 +91,7 @@ public class AnswerService {
             }
         } else {
             int min = objective.getMinSelect() != null ? objective.getMinSelect() : 1;
-            int max = objective.getMaxSelect() != null ? objective.getMaxSelect() : validOptionIds.size();
+            int max = objective.getMaxSelect() != null ? objective.getMaxSelect() : validOptionIds.size() + (objective.isOther() ? 1 : 0);
             int effectiveCount = selectedCount + (hasOtherText ? 1 : 0);
             if (effectiveCount < min || effectiveCount > max) {
                 throw new BaseException(BaseErrorCode.ANSWER_005);

--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -1,23 +1,29 @@
 package server.MATE.domain.answer.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.answer.dto.request.ObjectiveAnswerCreateRequest;
 import server.MATE.domain.answer.dto.request.SubjectiveAnswerCreateRequest;
 import server.MATE.domain.answer.dto.response.AnswerCreateResponse;
 import server.MATE.domain.answer.entity.Answer;
 import server.MATE.domain.answer.repository.AnswerRepository;
 import server.MATE.domain.participation.entity.Participation;
 import server.MATE.domain.participation.repository.ParticipationRepository;
+import server.MATE.domain.question.entity.Objective;
+import server.MATE.domain.question.entity.ObjectiveOption;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.ObjectiveRepository;
 import server.MATE.domain.question.repository.QuestionRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
 
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -26,51 +32,107 @@ public class AnswerService {
 
     private final ParticipationRepository participationRepository;
     private final QuestionRepository questionRepository;
+    private final ObjectiveRepository objectiveRepository;
     private final AnswerRepository answerRepository;
-    private final ObjectMapper objectMapper;
 
     @Transactional
     public AnswerCreateResponse createSubjectiveAnswer(Long participationId, Long testerId, SubjectiveAnswerCreateRequest request) {
-        Participation participation = participationRepository.findByIdAndDeletedAtIsNull(participationId)
-                .orElseThrow(() -> new BaseException(BaseErrorCode.PARTICIPATION_001));
-
-        if (!participation.getTesterId().equals(testerId)) {
-            throw new BaseException(BaseErrorCode.COMMON_009);
-        }
-
-        Question question = questionRepository.findByIdAndDeletedAtIsNull(request.questionId())
-                .orElseThrow(() -> new BaseException(BaseErrorCode.QUESTION_005));
-
-        if (question.getQuestionType() != QuestionType.SUBJECTIVE) {
-            throw new BaseException(BaseErrorCode.ANSWER_001);
-        }
-
-        if (!question.getTestId().equals(participation.getTestId())) {
-            throw new BaseException(BaseErrorCode.ANSWER_002);
-        }
-
-        if (answerRepository.existsByParticipationIdAndQuestionIdAndDeletedAtIsNull(participationId, request.questionId())) {
-            throw new BaseException(BaseErrorCode.ANSWER_003);
-        }
-
-        String answerJson = toJson(Map.of("text", request.text()));
+        validateAnswerRequest(participationId, testerId, request.questionId(), QuestionType.SUBJECTIVE);
 
         Answer answer = Answer.builder()
                 .participationId(participationId)
                 .questionId(request.questionId())
                 .questionType(QuestionType.SUBJECTIVE)
-                .answer(answerJson)
+                .answer(Map.of("text", request.text()))
                 .build();
 
         answerRepository.save(answer);
         return AnswerCreateResponse.from(answer);
     }
 
-    private String toJson(Object value) {
-        try {
-            return objectMapper.writeValueAsString(value);
-        } catch (JsonProcessingException e) {
-            throw new BaseException(BaseErrorCode.COMMON_999);
+    @Transactional
+    public AnswerCreateResponse createObjectiveAnswer(Long participationId, Long testerId, ObjectiveAnswerCreateRequest request) {
+        validateAnswerRequest(participationId, testerId, request.questionId(), QuestionType.OBJECTIVE);
+
+        Objective objective = objectiveRepository.findWithOptionsById(request.questionId())
+                .orElseThrow(() -> new BaseException(BaseErrorCode.QUESTION_005));
+
+        Set<Long> validOptionIds = objective.getOptions().stream()
+                .map(ObjectiveOption::getId)
+                .collect(Collectors.toSet());
+
+        List<Long> selectedOptionIds = request.selectedOptionIds();
+        boolean hasOtherText = objective.isOther() && request.otherText() != null && !request.otherText().isBlank();
+
+        if (selectedOptionIds.isEmpty() && !hasOtherText) {
+            throw new BaseException(BaseErrorCode.ANSWER_005);
+        }
+
+        if (!objective.isOther() && request.otherText() != null && !request.otherText().isBlank()) {
+            throw new BaseException(BaseErrorCode.ANSWER_004);
+        }
+
+        if (selectedOptionIds.size() != Set.copyOf(selectedOptionIds).size()) {
+            throw new BaseException(BaseErrorCode.ANSWER_004);
+        }
+
+        if (!validOptionIds.containsAll(selectedOptionIds)) {
+            throw new BaseException(BaseErrorCode.ANSWER_004);
+        }
+
+        int selectedCount = selectedOptionIds.size();
+        if (!objective.isDuplicate()) {
+            // 단일 선택: 일반 선택지 1개 또는 기타만 선택 가능
+            if (hasOtherText && selectedCount > 0) {
+                throw new BaseException(BaseErrorCode.ANSWER_005);
+            }
+            if (!hasOtherText && selectedCount != 1) {
+                throw new BaseException(BaseErrorCode.ANSWER_005);
+            }
+        } else {
+            int min = objective.getMinSelect() != null ? objective.getMinSelect() : 1;
+            int max = objective.getMaxSelect() != null ? objective.getMaxSelect() : validOptionIds.size();
+            int effectiveCount = selectedCount + (hasOtherText ? 1 : 0);
+            if (effectiveCount < min || effectiveCount > max) {
+                throw new BaseException(BaseErrorCode.ANSWER_005);
+            }
+        }
+
+        Map<String, Object> answerMap = new LinkedHashMap<>();
+        answerMap.put("selectedOptionIds", selectedOptionIds);
+        if (hasOtherText) {
+            answerMap.put("otherText", request.otherText().trim());
+        }
+
+        Answer answer = Answer.builder()
+                .participationId(participationId)
+                .questionId(request.questionId())
+                .questionType(QuestionType.OBJECTIVE)
+                .answer(answerMap)
+                .build();
+
+        answerRepository.save(answer);
+        return AnswerCreateResponse.from(answer);
+    }
+
+    private void validateAnswerRequest(Long participationId, Long testerId, Long questionId, QuestionType expectedType) {
+        Participation participation = participationRepository.findByIdAndDeletedAtIsNull(participationId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.PARTICIPATION_001));
+
+        participation.validateTester(testerId);
+
+        Question question = questionRepository.findByIdAndDeletedAtIsNull(questionId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.QUESTION_005));
+
+        if (question.getQuestionType() != expectedType) {
+            throw new BaseException(BaseErrorCode.ANSWER_001);
+        }
+
+        question.validateTestBelonging(participation.getTestId());
+
+        if (answerRepository.existsByParticipationIdAndQuestionIdAndDeletedAtIsNull(participationId, questionId)) {
+            throw new BaseException(BaseErrorCode.ANSWER_003);
         }
     }
+
 }

--- a/src/main/java/server/MATE/domain/participation/entity/Participation.java
+++ b/src/main/java/server/MATE/domain/participation/entity/Participation.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import server.MATE.global.common.entity.BaseEntity;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
 
 import java.time.LocalDateTime;
 
@@ -34,5 +36,11 @@ public class Participation extends BaseEntity {
     public Participation(Long testId, Long testerId) {
         this.testId = testId;
         this.testerId = testerId;
+    }
+
+    public void validateTester(Long testerId) {
+        if (!this.testerId.equals(testerId)) {
+            throw new BaseException(BaseErrorCode.COMMON_009);
+        }
     }
 }

--- a/src/main/java/server/MATE/domain/question/entity/Question.java
+++ b/src/main/java/server/MATE/domain/question/entity/Question.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import server.MATE.global.common.entity.BaseEntity;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
 
 import java.time.LocalDateTime;
 
@@ -47,5 +49,11 @@ public class Question extends BaseEntity {
         this.title = title;
         this.description = description;
         this.sequence = sequence == null ? 0L : sequence;
+    }
+
+    public void validateTestBelonging(Long testId) {
+        if (!this.testId.equals(testId)) {
+            throw new BaseException(BaseErrorCode.ANSWER_002);
+        }
     }
 }

--- a/src/main/java/server/MATE/domain/question/repository/ObjectiveRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/ObjectiveRepository.java
@@ -2,12 +2,19 @@ package server.MATE.domain.question.repository;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import server.MATE.domain.question.entity.Objective;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ObjectiveRepository extends JpaRepository<Objective, Long> {
 
     @EntityGraph(attributePaths = "options")
     List<Objective> findAllByIdIn(Iterable<Long> ids);
+
+    @EntityGraph(attributePaths = "options")
+    @Query("SELECT o FROM Objective o WHERE o.id = :id")
+    Optional<Objective> findWithOptionsById(@Param("id") Long id);
 }

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -54,6 +54,8 @@ public enum BaseErrorCode implements ErrorCode {
     ANSWER_001(HttpStatus.BAD_REQUEST, "ANSWER_001", "해당 질문 유형에 대한 응답을 등록할 수 없습니다."),
     ANSWER_002(HttpStatus.BAD_REQUEST, "ANSWER_002", "질문이 해당 테스트에 속하지 않습니다."),
     ANSWER_003(HttpStatus.BAD_REQUEST, "ANSWER_003", "이미 응답한 질문입니다."),
+    ANSWER_004(HttpStatus.BAD_REQUEST, "ANSWER_004", "유효하지 않은 선택지입니다."),
+    ANSWER_005(HttpStatus.BAD_REQUEST, "ANSWER_005", "선택 개수가 허용 범위를 벗어났습니다."),
 
     // File
     FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_001", "파일 업로드에 실패했습니다."),


### PR DESCRIPTION
  ## 📍 요약
  객관식 질문에 대한 응답 등록 API를 구현합니다.

  ## 🔗 관련 이슈
  Closes #59

  ## 📌 변경 사항
  기능

  ## ✅ 작업 내용
  - `POST /api/v1/participations/{participationId}/answers/objective` 엔드포인트 추가
  - 단일 선택 / 복수 선택(minSelect~maxSelect) / 기타(otherText) 검증 로직 구현
  - 유효하지 않은 선택지 및 중복 optionId 검증
  - ANSWER_004, ANSWER_005 에러 코드 추가
  - 응답 등록 공통 검증 로직 추출 및 도메인 위임 (Participation, Question)
  - Answer answer 필드 JSONB 타입 매핑 개선 (String → Map, ObjectMapper 제거)

  ## 테스트
  로컬 테스트 완료
  - 단일 선택 / 복수 선택 / 기타만 선택 / 복수+기타 정상 케이스 확인
  - 유효하지 않은 optionId, 중복 optionId, 선택 개수 초과/미달, 중복 응답, 타입 불일치, 테스트 미속 질문 에러 케이스 확인