### PR TITLE
feat: 5초 테스트 응답 등록 API 구현 및 단일 엔드포인트 통합 (#60)

### DIFF
--- a/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
+++ b/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
@@ -1,6 +1,9 @@
 package server.MATE.domain.answer.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -9,8 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import server.MATE.domain.answer.dto.request.ObjectiveAnswerCreateRequest;
-import server.MATE.domain.answer.dto.request.SubjectiveAnswerCreateRequest;
+import server.MATE.domain.answer.dto.request.AnswerCreateItem;
 import server.MATE.domain.answer.dto.response.AnswerCreateResponse;
 import server.MATE.domain.answer.service.AnswerService;
 import server.MATE.global.common.response.ApiResponse;
@@ -25,47 +27,106 @@ public class AnswerController {
 
     private final AnswerService answerService;
 
-    @Operation(summary = "주관식 응답 등록", description = """
-            주관식 질문에 대한 응답을 등록합니다.
-            - questionId는 SUBJECTIVE 타입이어야 합니다.
+    @Operation(summary = "응답 등록", description = """
+            질문에 대한 응답을 등록합니다.
+            - `type` 필드로 응답 유형을 구분합니다: `SUBJECTIVE`, `OBJECTIVE`, `FIVE_SECOND`
+            - questionId는 type과 일치하는 질문 타입이어야 합니다.
             - 질문은 해당 참여 세션의 테스트에 속해야 합니다.
+
+            **SUBJECTIVE**
+            - `text` 필수
+
+            **OBJECTIVE**
+            - `selectedOptionIds`: 선택지 ID 목록 (단일 선택이면 1개, 복수 선택이면 minSelect~maxSelect 범위)
+            - `otherText`: isOther=true인 질문에서만 입력 가능
+            - 기타만 선택하는 경우 selectedOptionIds는 빈 배열, otherText 입력
+
+            **FIVE_SECOND**
+            - isObjective=false(주관식 모드): `text` 필수, selectedOptionIds 불필요
+            - isObjective=true(객관식 모드): `selectedOptionIds` 필수, text 불필요
             """)
-    @PostMapping("/subjective")
-    public ResponseEntity<ApiResponse<AnswerCreateResponse>> createSubjectiveAnswer(
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201", description = "응답 등록 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "success": true,
+                                              "code": "201",
+                                              "message": "응답이 등록되었습니다.",
+                                              "data": {
+                                                "answerId": 1
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = {
+                            @ExampleObject(
+                                    name = "주관식",
+                                    summary = "SUBJECTIVE 예시",
+                                    value = """
+                                            {
+                                              "type": "SUBJECTIVE",
+                                              "questionId": 1,
+                                              "text": "UI가 직관적이고 사용하기 편했습니다."
+                                            }
+                                            """
+                            ),
+                            @ExampleObject(
+                                    name = "객관식",
+                                    summary = "OBJECTIVE 예시",
+                                    value = """
+                                            {
+                                              "type": "OBJECTIVE",
+                                              "questionId": 2,
+                                              "selectedOptionIds": [1001, 1002],
+                                              "otherText": null
+                                            }
+                                            """
+                            ),
+                            @ExampleObject(
+                                    name = "5초 테스트 (주관식)",
+                                    summary = "FIVE_SECOND 주관식 모드(isObjective=false) 예시",
+                                    value = """
+                                            {
+                                              "type": "FIVE_SECOND",
+                                              "questionId": 3,
+                                              "text": "가장 먼저 검색창이 눈에 들어왔습니다.",
+                                              "selectedOptionIds": null
+                                            }
+                                            """
+                            ),
+                            @ExampleObject(
+                                    name = "5초 테스트 (객관식)",
+                                    summary = "FIVE_SECOND 객관식 모드(isObjective=true) 예시",
+                                    value = """
+                                            {
+                                              "type": "FIVE_SECOND",
+                                              "questionId": 3,
+                                              "text": null,
+                                              "selectedOptionIds": [2001]
+                                            }
+                                            """
+                            )
+                    }
+            )
+    )
+    @PostMapping
+    public ResponseEntity<ApiResponse<AnswerCreateResponse>> createAnswer(
             @PathVariable Long participationId,
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
-            @RequestBody @Valid SubjectiveAnswerCreateRequest request
+            @RequestBody @Valid AnswerCreateItem request
     ) {
-        AnswerCreateResponse response = answerService.createSubjectiveAnswer(participationId, authenticatedUser.getId(), request);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.created("응답이 등록되었습니다.", response));
-    }
-
-    @Operation(summary = "객관식 응답 등록", description = """
-            객관식 질문에 대한 응답을 등록합니다.
-            - questionId는 OBJECTIVE 타입이어야 합니다.
-            - 질문은 해당 참여 세션의 테스트에 속해야 합니다.
-            - selectedOptionIds는 해당 질문의 선택지 ID만 허용됩니다.
-            - 단일 선택(isDuplicate=false)이면 selectedOptionIds는 정확히 1개여야 합니다.
-            - 복수 선택(isDuplicate=true)이면 minSelect 이상 maxSelect 이하로 선택해야 합니다.
-            - isOther=true인 질문에서만 otherText를 입력할 수 있습니다.
-
-            **[에러 코드]**
-            | 코드 | HTTP | 설명 |
-            |------|------|------|
-            | ANSWER_001 | 400 | questionId가 OBJECTIVE 타입이 아님 |
-            | ANSWER_002 | 400 | 질문이 해당 테스트에 속하지 않음 |
-            | ANSWER_003 | 400 | 이미 응답한 질문 |
-            | ANSWER_004 | 400 | selectedOptionIds에 유효하지 않은 선택지 포함 |
-            | ANSWER_005 | 400 | 선택 개수가 허용 범위를 벗어남 |
-            """)
-    @PostMapping("/objective")
-    public ResponseEntity<ApiResponse<AnswerCreateResponse>> createObjectiveAnswer(
-            @PathVariable Long participationId,
-            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
-            @RequestBody @Valid ObjectiveAnswerCreateRequest request
-    ) {
-        AnswerCreateResponse response = answerService.createObjectiveAnswer(participationId, authenticatedUser.getId(), request);
+        AnswerCreateResponse response = answerService.createAnswer(participationId, authenticatedUser.getId(), request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("응답이 등록되었습니다.", response));
     }

--- a/src/main/java/server/MATE/domain/answer/dto/request/AnswerCreateItem.java
+++ b/src/main/java/server/MATE/domain/answer/dto/request/AnswerCreateItem.java
@@ -1,0 +1,21 @@
+package server.MATE.domain.answer.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import server.MATE.domain.question.entity.QuestionType;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = SubjectiveAnswerCreateRequest.class, name = "SUBJECTIVE"),
+        @JsonSubTypes.Type(value = ObjectiveAnswerCreateRequest.class, name = "OBJECTIVE"),
+        @JsonSubTypes.Type(value = FiveSecondAnswerCreateRequest.class, name = "FIVE_SECOND")
+})
+public sealed interface AnswerCreateItem permits
+        SubjectiveAnswerCreateRequest,
+        ObjectiveAnswerCreateRequest,
+        FiveSecondAnswerCreateRequest {
+
+    Long questionId();
+
+    QuestionType type();
+}

--- a/src/main/java/server/MATE/domain/answer/dto/request/FiveSecondAnswerCreateRequest.java
+++ b/src/main/java/server/MATE/domain/answer/dto/request/FiveSecondAnswerCreateRequest.java
@@ -1,18 +1,20 @@
 package server.MATE.domain.answer.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import server.MATE.domain.question.entity.QuestionType;
 
-@JsonTypeName("SUBJECTIVE")
-public record SubjectiveAnswerCreateRequest(
+import java.util.List;
+
+@JsonTypeName("FIVE_SECOND")
+public record FiveSecondAnswerCreateRequest(
         @NotNull Long questionId,
-        @NotBlank String text
+        String text,
+        List<Long> selectedOptionIds
 ) implements AnswerCreateItem {
 
     @Override
     public QuestionType type() {
-        return QuestionType.SUBJECTIVE;
+        return QuestionType.FIVE_SECOND;
     }
 }

--- a/src/main/java/server/MATE/domain/answer/dto/request/ObjectiveAnswerCreateRequest.java
+++ b/src/main/java/server/MATE/domain/answer/dto/request/ObjectiveAnswerCreateRequest.java
@@ -1,12 +1,20 @@
 package server.MATE.domain.answer.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.NotNull;
+import server.MATE.domain.question.entity.QuestionType;
 
 import java.util.List;
 
+@JsonTypeName("OBJECTIVE")
 public record ObjectiveAnswerCreateRequest(
         @NotNull Long questionId,
         @NotNull List<Long> selectedOptionIds,
         String otherText
-) {
+) implements AnswerCreateItem {
+
+    @Override
+    public QuestionType type() {
+        return QuestionType.OBJECTIVE;
+    }
 }

--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -3,6 +3,8 @@ package server.MATE.domain.answer.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.answer.dto.request.AnswerCreateItem;
+import server.MATE.domain.answer.dto.request.FiveSecondAnswerCreateRequest;
 import server.MATE.domain.answer.dto.request.ObjectiveAnswerCreateRequest;
 import server.MATE.domain.answer.dto.request.SubjectiveAnswerCreateRequest;
 import server.MATE.domain.answer.dto.response.AnswerCreateResponse;
@@ -10,10 +12,13 @@ import server.MATE.domain.answer.entity.Answer;
 import server.MATE.domain.answer.repository.AnswerRepository;
 import server.MATE.domain.participation.entity.Participation;
 import server.MATE.domain.participation.repository.ParticipationRepository;
+import server.MATE.domain.question.entity.FiveSecond;
+import server.MATE.domain.question.entity.FiveSecondOption;
 import server.MATE.domain.question.entity.Objective;
 import server.MATE.domain.question.entity.ObjectiveOption;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.FiveSecondRepository;
 import server.MATE.domain.question.repository.ObjectiveRepository;
 import server.MATE.domain.question.repository.QuestionRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
@@ -33,10 +38,19 @@ public class AnswerService {
     private final ParticipationRepository participationRepository;
     private final QuestionRepository questionRepository;
     private final ObjectiveRepository objectiveRepository;
+    private final FiveSecondRepository fiveSecondRepository;
     private final AnswerRepository answerRepository;
 
     @Transactional
-    public AnswerCreateResponse createSubjectiveAnswer(Long participationId, Long testerId, SubjectiveAnswerCreateRequest request) {
+    public AnswerCreateResponse createAnswer(Long participationId, Long testerId, AnswerCreateItem request) {
+        return switch (request) {
+            case SubjectiveAnswerCreateRequest r -> createSubjectiveAnswer(participationId, testerId, r);
+            case ObjectiveAnswerCreateRequest r -> createObjectiveAnswer(participationId, testerId, r);
+            case FiveSecondAnswerCreateRequest r -> createFiveSecondAnswer(participationId, testerId, r);
+        };
+    }
+
+    private AnswerCreateResponse createSubjectiveAnswer(Long participationId, Long testerId, SubjectiveAnswerCreateRequest request) {
         validateAnswerRequest(participationId, testerId, request.questionId(), QuestionType.SUBJECTIVE);
 
         Answer answer = Answer.builder()
@@ -50,8 +64,7 @@ public class AnswerService {
         return AnswerCreateResponse.from(answer);
     }
 
-    @Transactional
-    public AnswerCreateResponse createObjectiveAnswer(Long participationId, Long testerId, ObjectiveAnswerCreateRequest request) {
+    private AnswerCreateResponse createObjectiveAnswer(Long participationId, Long testerId, ObjectiveAnswerCreateRequest request) {
         validateAnswerRequest(participationId, testerId, request.questionId(), QuestionType.OBJECTIVE);
 
         Objective objective = objectiveRepository.findWithOptionsById(request.questionId())
@@ -72,29 +85,22 @@ public class AnswerService {
             throw new BaseException(BaseErrorCode.ANSWER_004);
         }
 
-        if (selectedOptionIds.size() != Set.copyOf(selectedOptionIds).size()) {
-            throw new BaseException(BaseErrorCode.ANSWER_004);
-        }
-
-        if (!validOptionIds.containsAll(selectedOptionIds)) {
-            throw new BaseException(BaseErrorCode.ANSWER_004);
-        }
+        validateSelectedOptions(selectedOptionIds, validOptionIds);
 
         int selectedCount = selectedOptionIds.size();
         if (!objective.isDuplicate()) {
-            // 단일 선택: 일반 선택지 1개 또는 기타만 선택 가능
             if (hasOtherText && selectedCount > 0) {
-                throw new BaseException(BaseErrorCode.ANSWER_005);
+                throw new BaseException(BaseErrorCode.ANSWER_006);
             }
             if (!hasOtherText && selectedCount != 1) {
-                throw new BaseException(BaseErrorCode.ANSWER_005);
+                throw new BaseException(BaseErrorCode.ANSWER_006);
             }
         } else {
             int min = objective.getMinSelect() != null ? objective.getMinSelect() : 1;
             int max = objective.getMaxSelect() != null ? objective.getMaxSelect() : validOptionIds.size() + (objective.isOther() ? 1 : 0);
             int effectiveCount = selectedCount + (hasOtherText ? 1 : 0);
             if (effectiveCount < min || effectiveCount > max) {
-                throw new BaseException(BaseErrorCode.ANSWER_005);
+                throw new BaseException(BaseErrorCode.ANSWER_006);
             }
         }
 
@@ -113,6 +119,71 @@ public class AnswerService {
 
         answerRepository.save(answer);
         return AnswerCreateResponse.from(answer);
+    }
+
+    private AnswerCreateResponse createFiveSecondAnswer(Long participationId, Long testerId, FiveSecondAnswerCreateRequest request) {
+        validateAnswerRequest(participationId, testerId, request.questionId(), QuestionType.FIVE_SECOND);
+
+        FiveSecond fiveSecond = fiveSecondRepository.findWithOptionsById(request.questionId())
+                .orElseThrow(() -> new BaseException(BaseErrorCode.QUESTION_005));
+
+        Map<String, Object> answerMap;
+
+        if (!fiveSecond.isObjective()) {
+            if (request.text() == null || request.text().isBlank()) {
+                throw new BaseException(BaseErrorCode.ANSWER_005);
+            }
+            if (request.selectedOptionIds() != null && !request.selectedOptionIds().isEmpty()) {
+                throw new BaseException(BaseErrorCode.ANSWER_004);
+            }
+            answerMap = Map.of("text", request.text().trim());
+        } else {
+            List<Long> selectedOptionIds = request.selectedOptionIds() != null ? request.selectedOptionIds() : List.of();
+
+            Set<Long> validOptionIds = fiveSecond.getOptions().stream()
+                    .map(FiveSecondOption::getId)
+                    .collect(Collectors.toSet());
+
+            if (selectedOptionIds.isEmpty()) {
+                throw new BaseException(BaseErrorCode.ANSWER_005);
+            }
+
+            validateSelectedOptions(selectedOptionIds, validOptionIds);
+
+            int selectedCount = selectedOptionIds.size();
+            if (!Boolean.TRUE.equals(fiveSecond.getIsDuplicate())) {
+                if (selectedCount != 1) {
+                    throw new BaseException(BaseErrorCode.ANSWER_006);
+                }
+            } else {
+                int min = fiveSecond.getMinSelect() != null ? fiveSecond.getMinSelect() : 1;
+                int max = fiveSecond.getMaxSelect() != null ? fiveSecond.getMaxSelect() : validOptionIds.size();
+                if (selectedCount < min || selectedCount > max) {
+                    throw new BaseException(BaseErrorCode.ANSWER_006);
+                }
+            }
+
+            answerMap = Map.of("selectedOptionIds", selectedOptionIds);
+        }
+
+        Answer answer = Answer.builder()
+                .participationId(participationId)
+                .questionId(request.questionId())
+                .questionType(QuestionType.FIVE_SECOND)
+                .answer(answerMap)
+                .build();
+
+        answerRepository.save(answer);
+        return AnswerCreateResponse.from(answer);
+    }
+
+    private void validateSelectedOptions(List<Long> selectedOptionIds, Set<Long> validOptionIds) {
+        if (selectedOptionIds.size() != Set.copyOf(selectedOptionIds).size()) {
+            throw new BaseException(BaseErrorCode.ANSWER_004);
+        }
+        if (!validOptionIds.containsAll(selectedOptionIds)) {
+            throw new BaseException(BaseErrorCode.ANSWER_004);
+        }
     }
 
     private void validateAnswerRequest(Long participationId, Long testerId, Long questionId, QuestionType expectedType) {

--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -138,6 +138,9 @@ public class AnswerService {
             }
             answerMap = Map.of("text", request.text().trim());
         } else {
+            if (request.text() != null && !request.text().isBlank()) {
+                throw new BaseException(BaseErrorCode.ANSWER_004);
+            }
             List<Long> selectedOptionIds = request.selectedOptionIds() != null ? request.selectedOptionIds() : List.of();
 
             Set<Long> validOptionIds = fiveSecond.getOptions().stream()

--- a/src/main/java/server/MATE/domain/question/repository/FiveSecondRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/FiveSecondRepository.java
@@ -2,12 +2,19 @@ package server.MATE.domain.question.repository;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import server.MATE.domain.question.entity.FiveSecond;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FiveSecondRepository extends JpaRepository<FiveSecond, Long> {
 
     @EntityGraph(attributePaths = "options")
     List<FiveSecond> findAllByIdIn(Iterable<Long> ids);
+
+    @EntityGraph(attributePaths = "options")
+    @Query("SELECT f FROM FiveSecond f WHERE f.id = :id")
+    Optional<FiveSecond> findWithOptionsById(@Param("id") Long id);
 }

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -56,7 +56,8 @@ public enum BaseErrorCode implements ErrorCode {
     ANSWER_002(HttpStatus.BAD_REQUEST, "ANSWER_002", "질문이 해당 테스트에 속하지 않습니다."),
     ANSWER_003(HttpStatus.BAD_REQUEST, "ANSWER_003", "이미 응답한 질문입니다."),
     ANSWER_004(HttpStatus.BAD_REQUEST, "ANSWER_004", "유효하지 않은 선택지입니다."),
-    ANSWER_005(HttpStatus.BAD_REQUEST, "ANSWER_005", "선택 개수가 허용 범위를 벗어났습니다."),
+    ANSWER_005(HttpStatus.BAD_REQUEST, "ANSWER_005", "응답이 입력되지 않았습니다."),
+    ANSWER_006(HttpStatus.BAD_REQUEST, "ANSWER_006", "선택 개수가 허용 범위를 벗어났습니다."),
 
     // File
     FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_001", "파일 업로드에 실패했습니다."),


### PR DESCRIPTION
  ## 📍 요약                                                                                                            
  - SUBJECTIVE / OBJECTIVE / FIVE_SECOND 응답을 단일 `POST /answers` 엔드포인트로 통합하고 5초 테스트 응답 등록을       
  구현합니다.                                                                                                           
  
  ## 🔗 관련 이슈                                                                                                       
  - Closes #60                                                                                                        
  ## 📌 변경 사항
  - [x] 기능     
  - [ ] 버그 수정
  - [x] 리팩토링                                                                                                        
  - [ ] 문서    
  - [ ] 테스트                                                                                                          
  - [ ] 기타                                                                                                          
            
  ## ✅ 작업 내용
  - `AnswerCreateItem` sealed interface 추가 — Jackson `@JsonTypeInfo` 기반 다형성 역직렬화
  - `FiveSecondAnswerCreateRequest` 추가 — 주관식/객관식 모드 분기 처리                                                 
  - `POST /answers` 단일 엔드포인트로 통합 (기존 `/subjective`, `/objective`, `/five-second` 제거)                      
  - `AnswerService` dispatch 메서드 추가 및 유형별 메서드 `private` 전환                                                
  - `validateSelectedOptions` private 메서드 추출로 중복 검증 로직 제거                                                 
  - `ANSWER_005`(응답 미입력) / `ANSWER_006`(선택 개수 범위 초과) 에러 코드 분리                                        
                                                                                                                        
  ## 테스트                                                                                                             
  - [x] 로컬 테스트 완료                                                                                                
  - 테스트 방법:                                                                                                        
    - Swagger `POST /api/v1/participations/{participationId}/answers`                                                 
    - SUBJECTIVE: text 입력                                          
    - OBJECTIVE: 단일/복수/기타 선택                                                                                    
    - FIVE_SECOND: 주관식 모드(text), 객관식 모드(selectedOptionIds)                                                    
    - 에러 케이스: ANSWER_005(미입력), ANSWER_006(범위 초과)