### PR TITLE
feat: AB 테스트 응답 등록 API 구현 및 응답 DTO 필드명 통일

### DIFF
--- a/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
+++ b/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
@@ -29,7 +29,7 @@ public class AnswerController {
 
     @Operation(summary = "응답 등록", description = """
             질문에 대한 응답을 등록합니다.
-            - `type` 필드로 응답 유형을 구분합니다: `SUBJECTIVE`, `OBJECTIVE`, `FIVE_SECOND`, `SCALE`
+            - `type` 필드로 응답 유형을 구분합니다: `SUBJECTIVE`, `OBJECTIVE`, `FIVE_SECOND`, `SCALE`, `AB_TEST`
             - questionId는 type과 일치하는 질문 타입이어야 합니다.
             - 질문은 해당 참여 세션의 테스트에 속해야 합니다.
 
@@ -37,16 +37,19 @@ public class AnswerController {
             - `text` 필수
 
             **OBJECTIVE**
-            - `selectedOptionIds`: 선택지 ID 목록 (단일 선택이면 1개, 복수 선택이면 minSelect~maxSelect 범위)
+            - `optionIds`: 선택지 ID 목록 (단일 선택이면 1개, 복수 선택이면 minSelect~maxSelect 범위)
             - `otherText`: isOther=true인 질문에서만 입력 가능
-            - 기타만 선택하는 경우 selectedOptionIds는 빈 배열, otherText 입력
+            - 기타만 선택하는 경우 optionIds 빈 배열, otherText 입력
 
             **FIVE_SECOND**
-            - isObjective=false(주관식 모드): `text` 필수, selectedOptionIds 불필요
-            - isObjective=true(객관식 모드): `selectedOptionIds` 필수, text 불필요
+            - isObjective=false(주관식 모드): `text` 필수, optionIds 불필요
+            - isObjective=true(객관식 모드): `optionIds` 필수, text 불필요
 
             **SCALE**
             - `score` 필수: 1 이상 척도 범위(5점 또는 7점) 이하의 정수
+
+            **AB_TEST**
+            - `selected` 필수: `"A"` 또는 `"B"`
             """)
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -91,7 +94,7 @@ public class AnswerController {
                                             {
                                               "type": "OBJECTIVE",
                                               "questionId": 2,
-                                              "selectedOptionIds": [1001, 1002],
+                                              "optionIds": [1001, 1002],
                                               "otherText": null
                                             }
                                             """
@@ -104,7 +107,7 @@ public class AnswerController {
                                               "type": "FIVE_SECOND",
                                               "questionId": 3,
                                               "text": "가장 먼저 검색창이 눈에 들어왔습니다.",
-                                              "selectedOptionIds": null
+                                              "optionIds": null
                                             }
                                             """
                             ),
@@ -116,7 +119,7 @@ public class AnswerController {
                                               "type": "FIVE_SECOND",
                                               "questionId": 3,
                                               "text": null,
-                                              "selectedOptionIds": [2001]
+                                              "optionIds": [2001]
                                             }
                                             """
                             ),
@@ -127,7 +130,18 @@ public class AnswerController {
                                             {
                                               "type": "SCALE",
                                               "questionId": 4,
-                                              "score": 4
+                                              "value": 4
+                                            }
+                                            """
+                            ),
+                            @ExampleObject(
+                                    name = "AB 테스트",
+                                    summary = "AB_TEST 예시",
+                                    value = """
+                                            {
+                                              "type": "AB_TEST",
+                                              "questionId": 5,
+                                              "selected": "A"
                                             }
                                             """
                             )

--- a/src/main/java/server/MATE/domain/answer/dto/request/AbTestAnswerCreateRequest.java
+++ b/src/main/java/server/MATE/domain/answer/dto/request/AbTestAnswerCreateRequest.java
@@ -1,0 +1,17 @@
+package server.MATE.domain.answer.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import jakarta.validation.constraints.NotNull;
+import server.MATE.domain.question.entity.QuestionType;
+
+@JsonTypeName("AB_TEST")
+public record AbTestAnswerCreateRequest(
+        @NotNull Long questionId,
+        String selected
+) implements AnswerCreateItem {
+
+    @Override
+    public QuestionType type() {
+        return QuestionType.AB_TEST;
+    }
+}

--- a/src/main/java/server/MATE/domain/answer/dto/request/AnswerCreateItem.java
+++ b/src/main/java/server/MATE/domain/answer/dto/request/AnswerCreateItem.java
@@ -9,13 +9,15 @@ import server.MATE.domain.question.entity.QuestionType;
         @JsonSubTypes.Type(value = SubjectiveAnswerCreateRequest.class, name = "SUBJECTIVE"),
         @JsonSubTypes.Type(value = ObjectiveAnswerCreateRequest.class, name = "OBJECTIVE"),
         @JsonSubTypes.Type(value = FiveSecondAnswerCreateRequest.class, name = "FIVE_SECOND"),
-        @JsonSubTypes.Type(value = ScaleAnswerCreateRequest.class, name = "SCALE")
+        @JsonSubTypes.Type(value = ScaleAnswerCreateRequest.class, name = "SCALE"),
+        @JsonSubTypes.Type(value = AbTestAnswerCreateRequest.class, name = "AB_TEST")
 })
 public sealed interface AnswerCreateItem permits
         SubjectiveAnswerCreateRequest,
         ObjectiveAnswerCreateRequest,
         FiveSecondAnswerCreateRequest,
-        ScaleAnswerCreateRequest {
+        ScaleAnswerCreateRequest,
+        AbTestAnswerCreateRequest {
 
     Long questionId();
 

--- a/src/main/java/server/MATE/domain/answer/dto/request/FiveSecondAnswerCreateRequest.java
+++ b/src/main/java/server/MATE/domain/answer/dto/request/FiveSecondAnswerCreateRequest.java
@@ -10,7 +10,7 @@ import java.util.List;
 public record FiveSecondAnswerCreateRequest(
         @NotNull Long questionId,
         String text,
-        List<Long> selectedOptionIds
+        List<Long> optionIds
 ) implements AnswerCreateItem {
 
     @Override

--- a/src/main/java/server/MATE/domain/answer/dto/request/ObjectiveAnswerCreateRequest.java
+++ b/src/main/java/server/MATE/domain/answer/dto/request/ObjectiveAnswerCreateRequest.java
@@ -9,7 +9,7 @@ import java.util.List;
 @JsonTypeName("OBJECTIVE")
 public record ObjectiveAnswerCreateRequest(
         @NotNull Long questionId,
-        @NotNull List<Long> selectedOptionIds,
+        @NotNull List<Long> optionIds,
         String otherText
 ) implements AnswerCreateItem {
 

--- a/src/main/java/server/MATE/domain/answer/dto/request/ScaleAnswerCreateRequest.java
+++ b/src/main/java/server/MATE/domain/answer/dto/request/ScaleAnswerCreateRequest.java
@@ -7,7 +7,7 @@ import server.MATE.domain.question.entity.QuestionType;
 @JsonTypeName("SCALE")
 public record ScaleAnswerCreateRequest(
         @NotNull Long questionId,
-        Integer score
+        Integer value
 ) implements AnswerCreateItem {
 
     @Override

--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -3,6 +3,7 @@ package server.MATE.domain.answer.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.answer.dto.request.AbTestAnswerCreateRequest;
 import server.MATE.domain.answer.dto.request.AnswerCreateItem;
 import server.MATE.domain.answer.dto.request.FiveSecondAnswerCreateRequest;
 import server.MATE.domain.answer.dto.request.ObjectiveAnswerCreateRequest;
@@ -52,6 +53,7 @@ public class AnswerService {
             case ObjectiveAnswerCreateRequest r -> createObjectiveAnswer(participationId, testerId, r);
             case FiveSecondAnswerCreateRequest r -> createFiveSecondAnswer(participationId, testerId, r);
             case ScaleAnswerCreateRequest r -> createScaleAnswer(participationId, testerId, r);
+            case AbTestAnswerCreateRequest r -> createAbTestAnswer(participationId, testerId, r);
         };
     }
 
@@ -79,7 +81,7 @@ public class AnswerService {
                 .map(ObjectiveOption::getId)
                 .collect(Collectors.toSet());
 
-        List<Long> selectedOptionIds = request.selectedOptionIds();
+        List<Long> selectedOptionIds = request.optionIds();
         boolean hasOtherText = objective.isOther() && request.otherText() != null && !request.otherText().isBlank();
 
         if (selectedOptionIds.isEmpty() && !hasOtherText) {
@@ -110,7 +112,7 @@ public class AnswerService {
         }
 
         Map<String, Object> answerMap = new LinkedHashMap<>();
-        answerMap.put("selectedOptionIds", selectedOptionIds);
+        answerMap.put("optionIds", selectedOptionIds);
         if (hasOtherText) {
             answerMap.put("otherText", request.otherText().trim());
         }
@@ -138,7 +140,7 @@ public class AnswerService {
             if (request.text() == null || request.text().isBlank()) {
                 throw new BaseException(BaseErrorCode.ANSWER_005);
             }
-            if (request.selectedOptionIds() != null && !request.selectedOptionIds().isEmpty()) {
+            if (request.optionIds() != null && !request.optionIds().isEmpty()) {
                 throw new BaseException(BaseErrorCode.ANSWER_004);
             }
             answerMap = Map.of("text", request.text().trim());
@@ -146,7 +148,7 @@ public class AnswerService {
             if (request.text() != null && !request.text().isBlank()) {
                 throw new BaseException(BaseErrorCode.ANSWER_004);
             }
-            List<Long> selectedOptionIds = request.selectedOptionIds() != null ? request.selectedOptionIds() : List.of();
+            List<Long> selectedOptionIds = request.optionIds() != null ? request.optionIds() : List.of();
 
             Set<Long> validOptionIds = fiveSecond.getOptions().stream()
                     .map(FiveSecondOption::getId)
@@ -171,7 +173,7 @@ public class AnswerService {
                 }
             }
 
-            answerMap = Map.of("selectedOptionIds", selectedOptionIds);
+            answerMap = Map.of("optionIds", selectedOptionIds);
         }
 
         Answer answer = Answer.builder()
@@ -188,14 +190,14 @@ public class AnswerService {
     private AnswerCreateResponse createScaleAnswer(Long participationId, Long testerId, ScaleAnswerCreateRequest request) {
         validateAnswerRequest(participationId, testerId, request.questionId(), QuestionType.SCALE);
 
-        if (request.score() == null) {
+        if (request.value() == null) {
             throw new BaseException(BaseErrorCode.ANSWER_005);
         }
 
         Scale scale = scaleRepository.findById(request.questionId())
                 .orElseThrow(() -> new BaseException(BaseErrorCode.QUESTION_005));
 
-        if (request.score() < 1 || request.score() > scale.getRange()) {
+        if (request.value() < 1 || request.value() > scale.getRange()) {
             throw new BaseException(BaseErrorCode.ANSWER_007);
         }
 
@@ -203,7 +205,29 @@ public class AnswerService {
                 .participationId(participationId)
                 .questionId(request.questionId())
                 .questionType(QuestionType.SCALE)
-                .answer(Map.of("score", request.score()))
+                .answer(Map.of("value", request.value()))
+                .build();
+
+        answerRepository.save(answer);
+        return AnswerCreateResponse.from(answer);
+    }
+
+    private AnswerCreateResponse createAbTestAnswer(Long participationId, Long testerId, AbTestAnswerCreateRequest request) {
+        validateAnswerRequest(participationId, testerId, request.questionId(), QuestionType.AB_TEST);
+
+        if (request.selected() == null) {
+            throw new BaseException(BaseErrorCode.ANSWER_005);
+        }
+
+        if (!request.selected().equals("A") && !request.selected().equals("B")) {
+            throw new BaseException(BaseErrorCode.ANSWER_004);
+        }
+
+        Answer answer = Answer.builder()
+                .participationId(participationId)
+                .questionId(request.questionId())
+                .questionType(QuestionType.AB_TEST)
+                .answer(Map.of("selected", request.selected()))
                 .build();
 
         answerRepository.save(answer);


### PR DESCRIPTION
  ## 📍 요약                                                                                                            
  - AB 테스트(AB_TEST) 질문 응답 등록 기능 구현                                                                    
  - 기존 응답 타입의 DTO 필드명을 일관성 있게 통일                                                               
                                                                                                                        
  ## 🔗 관련 이슈 
  - Closes #74                                                                                          
                                                                                                                        
  ## 📌 변경 사항 
  - [x] 기능
  - [x] 리팩토링                                                                                      

                                                                                                                        
  ## ✅ 작업 내용
  - `AbTestAnswerCreateRequest` 추가 및 `AnswerCreateItem` sealed interface 확장                                        
  - `AnswerService`에 `createAbTestAnswer` 메서드 추가                                                                
    - selected null 시 ANSWER_005                                                                                       
    - "A" / "B" 외 값 입력 시 ANSWER_004                                                                                
  - 응답 DTO 필드명 통일 (프론트 연동 전 사전 정리)                                                                     
    - `selectedOptionIds` → `optionIds` (OBJECTIVE, FIVE_SECOND)                                                        
    - `score` → `value` (SCALE)                                                                                         
    - `selectedOption` → `selected` (AB_TEST)                                                                           
  - Swagger 설명 및 예시 업데이트                                                                                       
                                                                                                                        
  ## 테스트                                                                                                             
  - [x] 로컬 테스트 완료                                                                                                    
  - 정상 응답 (selected: "A") → 201                                                                                     
  - selected null → ANSWER_005                                                                                        
  - selected "C" → ANSWER_004