### PR TITLE
feat: 트리 테스트 응답 등록 API 구현

### DIFF
--- a/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
+++ b/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
@@ -29,7 +29,7 @@ public class AnswerController {
 
     @Operation(summary = "응답 등록", description = """
             질문에 대한 응답을 등록합니다.
-            - `type` 필드로 응답 유형을 구분합니다: `SUBJECTIVE`, `OBJECTIVE`, `FIVE_SECOND`, `SCALE`, `AB_TEST`, `CARD_SORTING`
+            - `type` 필드로 응답 유형을 구분합니다: `SUBJECTIVE`, `OBJECTIVE`, `FIVE_SECOND`, `SCALE`, `AB_TEST`, `CARD_SORTING`, `TREE_TEST`
             - questionId는 type과 일치하는 질문 타입이어야 합니다.
             - 질문은 해당 참여 세션의 테스트에 속해야 합니다.
 
@@ -55,6 +55,10 @@ public class AnswerController {
             - `groups` 필수: 카테고리별 카드 이름(cardNames) 목록
             - 모든 카드를 빠짐없이 하나의 카테고리에 배치해야 합니다
             - 카드 중복 배치 불가, 카테고리 중복 불가
+
+            **TREE_TEST**
+            - `nodeId` 필수: 선택한 리프 노드의 ID
+            - 리프 노드(자식이 없는 노드)만 선택 가능
             """)
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -161,6 +165,17 @@ public class AnswerController {
                                                 { "category": "쇼핑", "cardNames": ["홈", "장바구니"] },
                                                 { "category": "정보", "cardNames": ["검색", "공지사항"] }
                                               ]
+                                            }
+                                            """
+                            ),
+                            @ExampleObject(
+                                    name = "트리 테스트",
+                                    summary = "TREE_TEST 예시",
+                                    value = """
+                                            {
+                                              "type": "TREE_TEST",
+                                              "questionId": 7,
+                                              "nodeId": 301
                                             }
                                             """
                             )

--- a/src/main/java/server/MATE/domain/answer/dto/request/AnswerCreateItem.java
+++ b/src/main/java/server/MATE/domain/answer/dto/request/AnswerCreateItem.java
@@ -11,7 +11,8 @@ import server.MATE.domain.question.entity.QuestionType;
         @JsonSubTypes.Type(value = FiveSecondAnswerCreateRequest.class, name = "FIVE_SECOND"),
         @JsonSubTypes.Type(value = ScaleAnswerCreateRequest.class, name = "SCALE"),
         @JsonSubTypes.Type(value = AbTestAnswerCreateRequest.class, name = "AB_TEST"),
-        @JsonSubTypes.Type(value = CardSortingAnswerCreateRequest.class, name = "CARD_SORTING")
+        @JsonSubTypes.Type(value = CardSortingAnswerCreateRequest.class, name = "CARD_SORTING"),
+        @JsonSubTypes.Type(value = TreeTestAnswerCreateRequest.class, name = "TREE_TEST")
 })
 public sealed interface AnswerCreateItem permits
         SubjectiveAnswerCreateRequest,
@@ -19,7 +20,8 @@ public sealed interface AnswerCreateItem permits
         FiveSecondAnswerCreateRequest,
         ScaleAnswerCreateRequest,
         AbTestAnswerCreateRequest,
-        CardSortingAnswerCreateRequest {
+        CardSortingAnswerCreateRequest,
+        TreeTestAnswerCreateRequest {
 
     Long questionId();
 

--- a/src/main/java/server/MATE/domain/answer/dto/request/TreeTestAnswerCreateRequest.java
+++ b/src/main/java/server/MATE/domain/answer/dto/request/TreeTestAnswerCreateRequest.java
@@ -1,0 +1,17 @@
+package server.MATE.domain.answer.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import jakarta.validation.constraints.NotNull;
+import server.MATE.domain.question.entity.QuestionType;
+
+@JsonTypeName("TREE_TEST")
+public record TreeTestAnswerCreateRequest(
+        @NotNull Long questionId,
+        Long nodeId
+) implements AnswerCreateItem {
+
+    @Override
+    public QuestionType type() {
+        return QuestionType.TREE_TEST;
+    }
+}

--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -10,6 +10,7 @@ import server.MATE.domain.answer.dto.request.FiveSecondAnswerCreateRequest;
 import server.MATE.domain.answer.dto.request.ObjectiveAnswerCreateRequest;
 import server.MATE.domain.answer.dto.request.ScaleAnswerCreateRequest;
 import server.MATE.domain.answer.dto.request.SubjectiveAnswerCreateRequest;
+import server.MATE.domain.answer.dto.request.TreeTestAnswerCreateRequest;
 import server.MATE.domain.answer.dto.response.AnswerCreateResponse;
 import server.MATE.domain.answer.entity.Answer;
 import server.MATE.domain.answer.repository.AnswerRepository;
@@ -23,11 +24,13 @@ import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.entity.CardSorting;
 import server.MATE.domain.question.entity.Scale;
+import server.MATE.domain.question.entity.TreeTest;
 import server.MATE.domain.question.repository.CardSortingRepository;
 import server.MATE.domain.question.repository.FiveSecondRepository;
 import server.MATE.domain.question.repository.ObjectiveRepository;
 import server.MATE.domain.question.repository.QuestionRepository;
 import server.MATE.domain.question.repository.ScaleRepository;
+import server.MATE.domain.question.repository.TreeTestRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
 
@@ -49,6 +52,7 @@ public class AnswerService {
     private final FiveSecondRepository fiveSecondRepository;
     private final ScaleRepository scaleRepository;
     private final CardSortingRepository cardSortingRepository;
+    private final TreeTestRepository treeTestRepository;
     private final AnswerRepository answerRepository;
 
     @Transactional
@@ -60,6 +64,7 @@ public class AnswerService {
             case ScaleAnswerCreateRequest r -> createScaleAnswer(participationId, testerId, r);
             case AbTestAnswerCreateRequest r -> createAbTestAnswer(participationId, testerId, r);
             case CardSortingAnswerCreateRequest r -> createCardSortingAnswer(participationId, testerId, r);
+            case TreeTestAnswerCreateRequest r -> createTreeTestAnswer(participationId, testerId, r);
         };
     }
 
@@ -284,6 +289,31 @@ public class AnswerService {
                 .questionId(request.questionId())
                 .questionType(QuestionType.CARD_SORTING)
                 .answer(Map.of("groups", request.groups()))
+                .build();
+
+        answerRepository.save(answer);
+        return AnswerCreateResponse.from(answer);
+    }
+
+    private AnswerCreateResponse createTreeTestAnswer(Long participationId, Long testerId, TreeTestAnswerCreateRequest request) {
+        validateAnswerRequest(participationId, testerId, request.questionId(), QuestionType.TREE_TEST);
+
+        if (request.nodeId() == null) {
+            throw new BaseException(BaseErrorCode.ANSWER_005);
+        }
+
+        TreeTest node = treeTestRepository.findByIdAndQuestion_Id(request.nodeId(), request.questionId())
+                .orElseThrow(() -> new BaseException(BaseErrorCode.ANSWER_004));
+
+        if (treeTestRepository.existsByParent_Id(node.getId())) {
+            throw new BaseException(BaseErrorCode.ANSWER_004);
+        }
+
+        Answer answer = Answer.builder()
+                .participationId(participationId)
+                .questionId(request.questionId())
+                .questionType(QuestionType.TREE_TEST)
+                .answer(Map.of("nodeId", request.nodeId()))
                 .build();
 
         answerRepository.save(answer);

--- a/src/main/java/server/MATE/domain/question/repository/TreeTestRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/TreeTestRepository.java
@@ -5,8 +5,13 @@ import org.springframework.data.jpa.repository.Query;
 import server.MATE.domain.question.entity.TreeTest;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TreeTestRepository extends JpaRepository<TreeTest, Long> {
+
+    Optional<TreeTest> findByIdAndQuestion_Id(Long id, Long questionId);
+
+    boolean existsByParent_Id(Long parentId);
 
     @Query("""
             select node


### PR DESCRIPTION
  ## 📍 요약                                                                                                            
  - 트리 테스트 질문 유형에 대한 응답 등록 API 구현                                                                     
  
  ## 🔗 관련 이슈                                                                                                       
  - Closes #62                                                                                                        
                                                                                                                        
  ## 📌 변경 사항                                                                                                     
  - [x] 기능

  ## ✅ 작업 내용
  - `TreeTestAnswerCreateRequest` DTO 추가 (nodeId 필드)
  - `AnswerCreateItem` sealed interface에 TREE_TEST 타입 등록                                                           
  - `TreeTestRepository`에 노드 조회 및 자식 존재 여부 확인 메서드 추가                                                 
  - `AnswerService`에 `createTreeTestAnswer` 구현                                                                       
    - nodeId 미입력 시 ANSWER_005                                                                                       
    - 해당 질문에 속하지 않는 노드 선택 시 ANSWER_004                                                                   
    - 리프 노드가 아닌 중간 노드 선택 시 ANSWER_004                                                                     
  - Swagger 설명 및 요청 예시 추가                                                                                      
                                                                                                                        
  ## 테스트                                                                                                             
  - [x] 로컬 테스트 완료                                                                                              
  - 테스트 방법:
    - DBeaver로 TREE_TEST 질문 및 노드 삽입 후 Swagger에서 각 케이스 검증