### PR TITLE
feat: 테스트 통합 응답 등록 API 구현

### DIFF
--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -1,332 +1,49 @@
 package server.MATE.domain.answer.service;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import server.MATE.domain.answer.dto.request.AbTestAnswerCreateRequest;
 import server.MATE.domain.answer.dto.request.AnswerCreateItem;
-import server.MATE.domain.answer.dto.request.CardSortingAnswerCreateRequest;
-import server.MATE.domain.answer.dto.request.FiveSecondAnswerCreateRequest;
-import server.MATE.domain.answer.dto.request.ObjectiveAnswerCreateRequest;
-import server.MATE.domain.answer.dto.request.ScaleAnswerCreateRequest;
-import server.MATE.domain.answer.dto.request.SubjectiveAnswerCreateRequest;
-import server.MATE.domain.answer.dto.request.TreeTestAnswerCreateRequest;
 import server.MATE.domain.answer.dto.response.AnswerCreateResponse;
 import server.MATE.domain.answer.entity.Answer;
 import server.MATE.domain.answer.repository.AnswerRepository;
+import server.MATE.domain.answer.service.handler.AnswerCreateHandler;
 import server.MATE.domain.participation.entity.Participation;
 import server.MATE.domain.participation.repository.ParticipationRepository;
-import server.MATE.domain.question.entity.FiveSecond;
-import server.MATE.domain.question.entity.FiveSecondOption;
-import server.MATE.domain.question.entity.Objective;
-import server.MATE.domain.question.entity.ObjectiveOption;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
-import server.MATE.domain.question.entity.CardSorting;
-import server.MATE.domain.question.entity.Scale;
-import server.MATE.domain.question.entity.TreeTest;
-import server.MATE.domain.question.repository.CardSortingRepository;
-import server.MATE.domain.question.repository.FiveSecondRepository;
-import server.MATE.domain.question.repository.ObjectiveRepository;
 import server.MATE.domain.question.repository.QuestionRepository;
-import server.MATE.domain.question.repository.ScaleRepository;
-import server.MATE.domain.question.repository.TreeTestRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
 
-import java.util.HashSet;
-import java.util.LinkedHashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
-@RequiredArgsConstructor
 public class AnswerService {
 
     private final ParticipationRepository participationRepository;
     private final QuestionRepository questionRepository;
-    private final ObjectiveRepository objectiveRepository;
-    private final FiveSecondRepository fiveSecondRepository;
-    private final ScaleRepository scaleRepository;
-    private final CardSortingRepository cardSortingRepository;
-    private final TreeTestRepository treeTestRepository;
     private final AnswerRepository answerRepository;
+    private final Map<QuestionType, AnswerCreateHandler> handlerMap;
+
+    public AnswerService(ParticipationRepository participationRepository,
+                         QuestionRepository questionRepository,
+                         AnswerRepository answerRepository,
+                         List<AnswerCreateHandler> handlers) {
+        this.participationRepository = participationRepository;
+        this.questionRepository = questionRepository;
+        this.answerRepository = answerRepository;
+        this.handlerMap = buildHandlerMap(handlers);
+    }
 
     @Transactional
     public AnswerCreateResponse createAnswer(Long participationId, Long testerId, AnswerCreateItem request) {
-        return switch (request) {
-            case SubjectiveAnswerCreateRequest r -> createSubjectiveAnswer(participationId, testerId, r);
-            case ObjectiveAnswerCreateRequest r -> createObjectiveAnswer(participationId, testerId, r);
-            case FiveSecondAnswerCreateRequest r -> createFiveSecondAnswer(participationId, testerId, r);
-            case ScaleAnswerCreateRequest r -> createScaleAnswer(participationId, testerId, r);
-            case AbTestAnswerCreateRequest r -> createAbTestAnswer(participationId, testerId, r);
-            case CardSortingAnswerCreateRequest r -> createCardSortingAnswer(participationId, testerId, r);
-            case TreeTestAnswerCreateRequest r -> createTreeTestAnswer(participationId, testerId, r);
-        };
-    }
-
-    private AnswerCreateResponse createSubjectiveAnswer(Long participationId, Long testerId, SubjectiveAnswerCreateRequest request) {
-        validateAnswerRequest(participationId, testerId, request.questionId(), QuestionType.SUBJECTIVE);
-
-        Answer answer = Answer.builder()
-                .participationId(participationId)
-                .questionId(request.questionId())
-                .questionType(QuestionType.SUBJECTIVE)
-                .answer(Map.of("text", request.text()))
-                .build();
-
-        answerRepository.save(answer);
+        validateAnswerRequest(participationId, testerId, request.questionId(), request.type());
+        AnswerCreateHandler handler = handlerMap.get(request.type());
+        Answer answer = handler.save(participationId, request);
         return AnswerCreateResponse.from(answer);
-    }
-
-    private AnswerCreateResponse createObjectiveAnswer(Long participationId, Long testerId, ObjectiveAnswerCreateRequest request) {
-        validateAnswerRequest(participationId, testerId, request.questionId(), QuestionType.OBJECTIVE);
-
-        Objective objective = objectiveRepository.findWithOptionsById(request.questionId())
-                .orElseThrow(() -> new BaseException(BaseErrorCode.QUESTION_005));
-
-        Set<Long> validOptionIds = objective.getOptions().stream()
-                .map(ObjectiveOption::getId)
-                .collect(Collectors.toSet());
-
-        List<Long> selectedOptionIds = request.optionIds();
-        boolean hasOtherText = objective.isOther() && request.otherText() != null && !request.otherText().isBlank();
-
-        if (selectedOptionIds.isEmpty() && !hasOtherText) {
-            throw new BaseException(BaseErrorCode.ANSWER_005);
-        }
-
-        if (!objective.isOther() && request.otherText() != null && !request.otherText().isBlank()) {
-            throw new BaseException(BaseErrorCode.ANSWER_004);
-        }
-
-        validateSelectedOptions(selectedOptionIds, validOptionIds);
-
-        int selectedCount = selectedOptionIds.size();
-        if (!objective.isDuplicate()) {
-            if (hasOtherText && selectedCount > 0) {
-                throw new BaseException(BaseErrorCode.ANSWER_006);
-            }
-            if (!hasOtherText && selectedCount != 1) {
-                throw new BaseException(BaseErrorCode.ANSWER_006);
-            }
-        } else {
-            int min = objective.getMinSelect() != null ? objective.getMinSelect() : 1;
-            int max = objective.getMaxSelect() != null ? objective.getMaxSelect() : validOptionIds.size() + (objective.isOther() ? 1 : 0);
-            int effectiveCount = selectedCount + (hasOtherText ? 1 : 0);
-            if (effectiveCount < min || effectiveCount > max) {
-                throw new BaseException(BaseErrorCode.ANSWER_006);
-            }
-        }
-
-        Map<String, Object> answerMap = new LinkedHashMap<>();
-        answerMap.put("optionIds", selectedOptionIds);
-        if (hasOtherText) {
-            answerMap.put("otherText", request.otherText().trim());
-        }
-
-        Answer answer = Answer.builder()
-                .participationId(participationId)
-                .questionId(request.questionId())
-                .questionType(QuestionType.OBJECTIVE)
-                .answer(answerMap)
-                .build();
-
-        answerRepository.save(answer);
-        return AnswerCreateResponse.from(answer);
-    }
-
-    private AnswerCreateResponse createFiveSecondAnswer(Long participationId, Long testerId, FiveSecondAnswerCreateRequest request) {
-        validateAnswerRequest(participationId, testerId, request.questionId(), QuestionType.FIVE_SECOND);
-
-        FiveSecond fiveSecond = fiveSecondRepository.findWithOptionsById(request.questionId())
-                .orElseThrow(() -> new BaseException(BaseErrorCode.QUESTION_005));
-
-        Map<String, Object> answerMap;
-
-        if (!fiveSecond.isObjective()) {
-            if (request.text() == null || request.text().isBlank()) {
-                throw new BaseException(BaseErrorCode.ANSWER_005);
-            }
-            if (request.optionIds() != null && !request.optionIds().isEmpty()) {
-                throw new BaseException(BaseErrorCode.ANSWER_004);
-            }
-            answerMap = Map.of("text", request.text().trim());
-        } else {
-            if (request.text() != null && !request.text().isBlank()) {
-                throw new BaseException(BaseErrorCode.ANSWER_004);
-            }
-            List<Long> selectedOptionIds = request.optionIds() != null ? request.optionIds() : List.of();
-
-            Set<Long> validOptionIds = fiveSecond.getOptions().stream()
-                    .map(FiveSecondOption::getId)
-                    .collect(Collectors.toSet());
-
-            if (selectedOptionIds.isEmpty()) {
-                throw new BaseException(BaseErrorCode.ANSWER_005);
-            }
-
-            validateSelectedOptions(selectedOptionIds, validOptionIds);
-
-            int selectedCount = selectedOptionIds.size();
-            if (!Boolean.TRUE.equals(fiveSecond.getIsDuplicate())) {
-                if (selectedCount != 1) {
-                    throw new BaseException(BaseErrorCode.ANSWER_006);
-                }
-            } else {
-                int min = fiveSecond.getMinSelect() != null ? fiveSecond.getMinSelect() : 1;
-                int max = fiveSecond.getMaxSelect() != null ? fiveSecond.getMaxSelect() : validOptionIds.size();
-                if (selectedCount < min || selectedCount > max) {
-                    throw new BaseException(BaseErrorCode.ANSWER_006);
-                }
-            }
-
-            answerMap = Map.of("optionIds", selectedOptionIds);
-        }
-
-        Answer answer = Answer.builder()
-                .participationId(participationId)
-                .questionId(request.questionId())
-                .questionType(QuestionType.FIVE_SECOND)
-                .answer(answerMap)
-                .build();
-
-        answerRepository.save(answer);
-        return AnswerCreateResponse.from(answer);
-    }
-
-    private AnswerCreateResponse createScaleAnswer(Long participationId, Long testerId, ScaleAnswerCreateRequest request) {
-        validateAnswerRequest(participationId, testerId, request.questionId(), QuestionType.SCALE);
-
-        if (request.value() == null) {
-            throw new BaseException(BaseErrorCode.ANSWER_005);
-        }
-
-        Scale scale = scaleRepository.findById(request.questionId())
-                .orElseThrow(() -> new BaseException(BaseErrorCode.QUESTION_005));
-
-        if (request.value() < 1 || request.value() > scale.getRange()) {
-            throw new BaseException(BaseErrorCode.ANSWER_007);
-        }
-
-        Answer answer = Answer.builder()
-                .participationId(participationId)
-                .questionId(request.questionId())
-                .questionType(QuestionType.SCALE)
-                .answer(Map.of("value", request.value()))
-                .build();
-
-        answerRepository.save(answer);
-        return AnswerCreateResponse.from(answer);
-    }
-
-    private AnswerCreateResponse createAbTestAnswer(Long participationId, Long testerId, AbTestAnswerCreateRequest request) {
-        validateAnswerRequest(participationId, testerId, request.questionId(), QuestionType.AB_TEST);
-
-        if (request.selected() == null) {
-            throw new BaseException(BaseErrorCode.ANSWER_005);
-        }
-
-        if (!request.selected().equals("A") && !request.selected().equals("B")) {
-            throw new BaseException(BaseErrorCode.ANSWER_004);
-        }
-
-        Answer answer = Answer.builder()
-                .participationId(participationId)
-                .questionId(request.questionId())
-                .questionType(QuestionType.AB_TEST)
-                .answer(Map.of("selected", request.selected()))
-                .build();
-
-        answerRepository.save(answer);
-        return AnswerCreateResponse.from(answer);
-    }
-
-    private AnswerCreateResponse createCardSortingAnswer(Long participationId, Long testerId, CardSortingAnswerCreateRequest request) {
-        validateAnswerRequest(participationId, testerId, request.questionId(), QuestionType.CARD_SORTING);
-
-        if (request.groups() == null || request.groups().isEmpty()) {
-            throw new BaseException(BaseErrorCode.ANSWER_005);
-        }
-
-        CardSorting cardSorting = cardSortingRepository.findById(request.questionId())
-                .orElseThrow(() -> new BaseException(BaseErrorCode.QUESTION_005));
-
-        Set<String> validCategories = new HashSet<>(cardSorting.getCategories());
-        Set<String> validCards = new HashSet<>(cardSorting.getCards());
-
-        Set<String> assignedCards = new HashSet<>();
-        Set<String> usedCategories = new HashSet<>();
-        for (CardSortingAnswerCreateRequest.GroupItem group : request.groups()) {
-            if (group == null || group.category() == null || !validCategories.contains(group.category())) {
-                throw new BaseException(BaseErrorCode.ANSWER_004);
-            }
-            if (!usedCategories.add(group.category())) {
-                throw new BaseException(BaseErrorCode.ANSWER_004);
-            }
-            if (group.cardNames() == null) {
-                throw new BaseException(BaseErrorCode.ANSWER_004);
-            }
-            for (String cardName : group.cardNames()) {
-                if (!validCards.contains(cardName)) {
-                    throw new BaseException(BaseErrorCode.ANSWER_004);
-                }
-                if (!assignedCards.add(cardName)) {
-                    throw new BaseException(BaseErrorCode.ANSWER_004);
-                }
-            }
-        }
-
-        if (assignedCards.size() != validCards.size()) {
-            throw new BaseException(BaseErrorCode.ANSWER_005);
-        }
-
-        Answer answer = Answer.builder()
-                .participationId(participationId)
-                .questionId(request.questionId())
-                .questionType(QuestionType.CARD_SORTING)
-                .answer(Map.of("groups", request.groups()))
-                .build();
-
-        answerRepository.save(answer);
-        return AnswerCreateResponse.from(answer);
-    }
-
-    private AnswerCreateResponse createTreeTestAnswer(Long participationId, Long testerId, TreeTestAnswerCreateRequest request) {
-        validateAnswerRequest(participationId, testerId, request.questionId(), QuestionType.TREE_TEST);
-
-        if (request.nodeId() == null) {
-            throw new BaseException(BaseErrorCode.ANSWER_005);
-        }
-
-        TreeTest node = treeTestRepository.findByIdAndQuestion_Id(request.nodeId(), request.questionId())
-                .orElseThrow(() -> new BaseException(BaseErrorCode.ANSWER_004));
-
-        if (treeTestRepository.existsByParent_Id(node.getId())) {
-            throw new BaseException(BaseErrorCode.ANSWER_004);
-        }
-
-        Answer answer = Answer.builder()
-                .participationId(participationId)
-                .questionId(request.questionId())
-                .questionType(QuestionType.TREE_TEST)
-                .answer(Map.of("nodeId", request.nodeId()))
-                .build();
-
-        answerRepository.save(answer);
-        return AnswerCreateResponse.from(answer);
-    }
-
-    private void validateSelectedOptions(List<Long> selectedOptionIds, Set<Long> validOptionIds) {
-        if (selectedOptionIds.size() != Set.copyOf(selectedOptionIds).size()) {
-            throw new BaseException(BaseErrorCode.ANSWER_004);
-        }
-        if (!validOptionIds.containsAll(selectedOptionIds)) {
-            throw new BaseException(BaseErrorCode.ANSWER_004);
-        }
     }
 
     private void validateAnswerRequest(Long participationId, Long testerId, Long questionId, QuestionType expectedType) {
@@ -349,4 +66,11 @@ public class AnswerService {
         }
     }
 
+    private Map<QuestionType, AnswerCreateHandler> buildHandlerMap(List<AnswerCreateHandler> handlers) {
+        Map<QuestionType, AnswerCreateHandler> map = new EnumMap<>(QuestionType.class);
+        for (AnswerCreateHandler handler : handlers) {
+            map.put(handler.supports(), handler);
+        }
+        return map;
+    }
 }

--- a/src/main/java/server/MATE/domain/answer/service/handler/AbTestAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/AbTestAnswerCreateHandler.java
@@ -1,0 +1,43 @@
+package server.MATE.domain.answer.service.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.answer.dto.request.AbTestAnswerCreateRequest;
+import server.MATE.domain.answer.dto.request.AnswerCreateItem;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.answer.repository.AnswerRepository;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class AbTestAnswerCreateHandler implements AnswerCreateHandler {
+
+    private final AnswerRepository answerRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.AB_TEST;
+    }
+
+    @Override
+    public Answer save(Long participationId, AnswerCreateItem item) {
+        AbTestAnswerCreateRequest request = (AbTestAnswerCreateRequest) item;
+
+        if (request.selected() == null) throw new BaseException(BaseErrorCode.ANSWER_005);
+        if (!request.selected().equals("A") && !request.selected().equals("B")) {
+            throw new BaseException(BaseErrorCode.ANSWER_004);
+        }
+
+        Answer answer = Answer.builder()
+                .participationId(participationId)
+                .questionId(request.questionId())
+                .questionType(QuestionType.AB_TEST)
+                .answer(Map.of("selected", request.selected()))
+                .build();
+        return answerRepository.save(answer);
+    }
+}

--- a/src/main/java/server/MATE/domain/answer/service/handler/AnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/AnswerCreateHandler.java
@@ -1,0 +1,12 @@
+package server.MATE.domain.answer.service.handler;
+
+import server.MATE.domain.answer.dto.request.AnswerCreateItem;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.question.entity.QuestionType;
+
+public interface AnswerCreateHandler {
+
+    QuestionType supports();
+
+    Answer save(Long participationId, AnswerCreateItem item);
+}

--- a/src/main/java/server/MATE/domain/answer/service/handler/CardSortingAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/CardSortingAnswerCreateHandler.java
@@ -1,0 +1,67 @@
+package server.MATE.domain.answer.service.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.answer.dto.request.AnswerCreateItem;
+import server.MATE.domain.answer.dto.request.CardSortingAnswerCreateRequest;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.answer.repository.AnswerRepository;
+import server.MATE.domain.question.entity.CardSorting;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.CardSortingRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class CardSortingAnswerCreateHandler implements AnswerCreateHandler {
+
+    private final CardSortingRepository cardSortingRepository;
+    private final AnswerRepository answerRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.CARD_SORTING;
+    }
+
+    @Override
+    public Answer save(Long participationId, AnswerCreateItem item) {
+        CardSortingAnswerCreateRequest request = (CardSortingAnswerCreateRequest) item;
+
+        if (request.groups() == null || request.groups().isEmpty()) throw new BaseException(BaseErrorCode.ANSWER_005);
+
+        CardSorting cardSorting = cardSortingRepository.findById(request.questionId())
+                .orElseThrow(() -> new BaseException(BaseErrorCode.QUESTION_005));
+
+        Set<String> validCategories = new HashSet<>(cardSorting.getCategories());
+        Set<String> validCards = new HashSet<>(cardSorting.getCards());
+
+        Set<String> assignedCards = new HashSet<>();
+        Set<String> usedCategories = new HashSet<>();
+        for (CardSortingAnswerCreateRequest.GroupItem group : request.groups()) {
+            if (group == null || group.category() == null || !validCategories.contains(group.category())) {
+                throw new BaseException(BaseErrorCode.ANSWER_004);
+            }
+            if (!usedCategories.add(group.category())) throw new BaseException(BaseErrorCode.ANSWER_004);
+            if (group.cardNames() == null) throw new BaseException(BaseErrorCode.ANSWER_004);
+            for (String cardName : group.cardNames()) {
+                if (!validCards.contains(cardName)) throw new BaseException(BaseErrorCode.ANSWER_004);
+                if (!assignedCards.add(cardName)) throw new BaseException(BaseErrorCode.ANSWER_004);
+            }
+        }
+
+        if (assignedCards.size() != validCards.size()) throw new BaseException(BaseErrorCode.ANSWER_005);
+
+        Answer answer = Answer.builder()
+                .participationId(participationId)
+                .questionId(request.questionId())
+                .questionType(QuestionType.CARD_SORTING)
+                .answer(Map.of("groups", request.groups()))
+                .build();
+        return answerRepository.save(answer);
+    }
+}

--- a/src/main/java/server/MATE/domain/answer/service/handler/FiveSecondAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/FiveSecondAnswerCreateHandler.java
@@ -1,0 +1,87 @@
+package server.MATE.domain.answer.service.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.answer.dto.request.AnswerCreateItem;
+import server.MATE.domain.answer.dto.request.FiveSecondAnswerCreateRequest;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.answer.repository.AnswerRepository;
+import server.MATE.domain.question.entity.FiveSecond;
+import server.MATE.domain.question.entity.FiveSecondOption;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.FiveSecondRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class FiveSecondAnswerCreateHandler implements AnswerCreateHandler {
+
+    private final FiveSecondRepository fiveSecondRepository;
+    private final AnswerRepository answerRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.FIVE_SECOND;
+    }
+
+    @Override
+    public Answer save(Long participationId, AnswerCreateItem item) {
+        FiveSecondAnswerCreateRequest request = (FiveSecondAnswerCreateRequest) item;
+
+        FiveSecond fiveSecond = fiveSecondRepository.findWithOptionsById(request.questionId())
+                .orElseThrow(() -> new BaseException(BaseErrorCode.QUESTION_005));
+
+        Map<String, Object> answerMap;
+
+        if (!fiveSecond.isObjective()) {
+            if (request.text() == null || request.text().isBlank()) throw new BaseException(BaseErrorCode.ANSWER_005);
+            if (request.optionIds() != null && !request.optionIds().isEmpty()) throw new BaseException(BaseErrorCode.ANSWER_004);
+            answerMap = Map.of("text", request.text().trim());
+        } else {
+            if (request.text() != null && !request.text().isBlank()) throw new BaseException(BaseErrorCode.ANSWER_004);
+            List<Long> selectedOptionIds = request.optionIds() != null ? request.optionIds() : List.of();
+
+            Set<Long> validOptionIds = fiveSecond.getOptions().stream()
+                    .map(FiveSecondOption::getId)
+                    .collect(Collectors.toSet());
+
+            if (selectedOptionIds.isEmpty()) throw new BaseException(BaseErrorCode.ANSWER_005);
+
+            validateSelectedOptions(selectedOptionIds, validOptionIds);
+
+            int selectedCount = selectedOptionIds.size();
+            if (!Boolean.TRUE.equals(fiveSecond.getIsDuplicate())) {
+                if (selectedCount != 1) throw new BaseException(BaseErrorCode.ANSWER_006);
+            } else {
+                int min = fiveSecond.getMinSelect() != null ? fiveSecond.getMinSelect() : 1;
+                int max = fiveSecond.getMaxSelect() != null ? fiveSecond.getMaxSelect() : validOptionIds.size();
+                if (selectedCount < min || selectedCount > max) throw new BaseException(BaseErrorCode.ANSWER_006);
+            }
+
+            answerMap = Map.of("optionIds", selectedOptionIds);
+        }
+
+        Answer answer = Answer.builder()
+                .participationId(participationId)
+                .questionId(request.questionId())
+                .questionType(QuestionType.FIVE_SECOND)
+                .answer(answerMap)
+                .build();
+        return answerRepository.save(answer);
+    }
+
+    private void validateSelectedOptions(List<Long> selectedOptionIds, Set<Long> validOptionIds) {
+        if (selectedOptionIds.size() != Set.copyOf(selectedOptionIds).size()) {
+            throw new BaseException(BaseErrorCode.ANSWER_004);
+        }
+        if (!validOptionIds.containsAll(selectedOptionIds)) {
+            throw new BaseException(BaseErrorCode.ANSWER_004);
+        }
+    }
+}

--- a/src/main/java/server/MATE/domain/answer/service/handler/ObjectiveAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/ObjectiveAnswerCreateHandler.java
@@ -1,0 +1,90 @@
+package server.MATE.domain.answer.service.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.answer.dto.request.AnswerCreateItem;
+import server.MATE.domain.answer.dto.request.ObjectiveAnswerCreateRequest;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.answer.repository.AnswerRepository;
+import server.MATE.domain.question.entity.Objective;
+import server.MATE.domain.question.entity.ObjectiveOption;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.ObjectiveRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ObjectiveAnswerCreateHandler implements AnswerCreateHandler {
+
+    private final ObjectiveRepository objectiveRepository;
+    private final AnswerRepository answerRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.OBJECTIVE;
+    }
+
+    @Override
+    public Answer save(Long participationId, AnswerCreateItem item) {
+        ObjectiveAnswerCreateRequest request = (ObjectiveAnswerCreateRequest) item;
+
+        Objective objective = objectiveRepository.findWithOptionsById(request.questionId())
+                .orElseThrow(() -> new BaseException(BaseErrorCode.QUESTION_005));
+
+        Set<Long> validOptionIds = objective.getOptions().stream()
+                .map(ObjectiveOption::getId)
+                .collect(Collectors.toSet());
+
+        List<Long> selectedOptionIds = request.optionIds();
+        boolean hasOtherText = objective.isOther() && request.otherText() != null && !request.otherText().isBlank();
+
+        if (selectedOptionIds.isEmpty() && !hasOtherText) {
+            throw new BaseException(BaseErrorCode.ANSWER_005);
+        }
+
+        if (!objective.isOther() && request.otherText() != null && !request.otherText().isBlank()) {
+            throw new BaseException(BaseErrorCode.ANSWER_004);
+        }
+
+        validateSelectedOptions(selectedOptionIds, validOptionIds);
+
+        int selectedCount = selectedOptionIds.size();
+        if (!objective.isDuplicate()) {
+            if (hasOtherText && selectedCount > 0) throw new BaseException(BaseErrorCode.ANSWER_006);
+            if (!hasOtherText && selectedCount != 1) throw new BaseException(BaseErrorCode.ANSWER_006);
+        } else {
+            int min = objective.getMinSelect() != null ? objective.getMinSelect() : 1;
+            int max = objective.getMaxSelect() != null ? objective.getMaxSelect() : validOptionIds.size() + (objective.isOther() ? 1 : 0);
+            int effectiveCount = selectedCount + (hasOtherText ? 1 : 0);
+            if (effectiveCount < min || effectiveCount > max) throw new BaseException(BaseErrorCode.ANSWER_006);
+        }
+
+        Map<String, Object> answerMap = new LinkedHashMap<>();
+        answerMap.put("optionIds", selectedOptionIds);
+        if (hasOtherText) answerMap.put("otherText", request.otherText().trim());
+
+        Answer answer = Answer.builder()
+                .participationId(participationId)
+                .questionId(request.questionId())
+                .questionType(QuestionType.OBJECTIVE)
+                .answer(answerMap)
+                .build();
+        return answerRepository.save(answer);
+    }
+
+    private void validateSelectedOptions(List<Long> selectedOptionIds, Set<Long> validOptionIds) {
+        if (selectedOptionIds.size() != Set.copyOf(selectedOptionIds).size()) {
+            throw new BaseException(BaseErrorCode.ANSWER_004);
+        }
+        if (!validOptionIds.containsAll(selectedOptionIds)) {
+            throw new BaseException(BaseErrorCode.ANSWER_004);
+        }
+    }
+}

--- a/src/main/java/server/MATE/domain/answer/service/handler/ScaleAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/ScaleAnswerCreateHandler.java
@@ -1,0 +1,50 @@
+package server.MATE.domain.answer.service.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.answer.dto.request.AnswerCreateItem;
+import server.MATE.domain.answer.dto.request.ScaleAnswerCreateRequest;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.answer.repository.AnswerRepository;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.entity.Scale;
+import server.MATE.domain.question.repository.ScaleRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class ScaleAnswerCreateHandler implements AnswerCreateHandler {
+
+    private final ScaleRepository scaleRepository;
+    private final AnswerRepository answerRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.SCALE;
+    }
+
+    @Override
+    public Answer save(Long participationId, AnswerCreateItem item) {
+        ScaleAnswerCreateRequest request = (ScaleAnswerCreateRequest) item;
+
+        if (request.value() == null) throw new BaseException(BaseErrorCode.ANSWER_005);
+
+        Scale scale = scaleRepository.findById(request.questionId())
+                .orElseThrow(() -> new BaseException(BaseErrorCode.QUESTION_005));
+
+        if (request.value() < 1 || request.value() > scale.getRange()) {
+            throw new BaseException(BaseErrorCode.ANSWER_007);
+        }
+
+        Answer answer = Answer.builder()
+                .participationId(participationId)
+                .questionId(request.questionId())
+                .questionType(QuestionType.SCALE)
+                .answer(Map.of("value", request.value()))
+                .build();
+        return answerRepository.save(answer);
+    }
+}

--- a/src/main/java/server/MATE/domain/answer/service/handler/SubjectiveAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/SubjectiveAnswerCreateHandler.java
@@ -1,0 +1,35 @@
+package server.MATE.domain.answer.service.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.answer.dto.request.AnswerCreateItem;
+import server.MATE.domain.answer.dto.request.SubjectiveAnswerCreateRequest;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.answer.repository.AnswerRepository;
+import server.MATE.domain.question.entity.QuestionType;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class SubjectiveAnswerCreateHandler implements AnswerCreateHandler {
+
+    private final AnswerRepository answerRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.SUBJECTIVE;
+    }
+
+    @Override
+    public Answer save(Long participationId, AnswerCreateItem item) {
+        SubjectiveAnswerCreateRequest request = (SubjectiveAnswerCreateRequest) item;
+        Answer answer = Answer.builder()
+                .participationId(participationId)
+                .questionId(request.questionId())
+                .questionType(QuestionType.SUBJECTIVE)
+                .answer(Map.of("text", request.text()))
+                .build();
+        return answerRepository.save(answer);
+    }
+}

--- a/src/main/java/server/MATE/domain/answer/service/handler/TreeTestAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/TreeTestAnswerCreateHandler.java
@@ -1,0 +1,50 @@
+package server.MATE.domain.answer.service.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.answer.dto.request.AnswerCreateItem;
+import server.MATE.domain.answer.dto.request.TreeTestAnswerCreateRequest;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.answer.repository.AnswerRepository;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.entity.TreeTest;
+import server.MATE.domain.question.repository.TreeTestRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class TreeTestAnswerCreateHandler implements AnswerCreateHandler {
+
+    private final TreeTestRepository treeTestRepository;
+    private final AnswerRepository answerRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.TREE_TEST;
+    }
+
+    @Override
+    public Answer save(Long participationId, AnswerCreateItem item) {
+        TreeTestAnswerCreateRequest request = (TreeTestAnswerCreateRequest) item;
+
+        if (request.nodeId() == null) throw new BaseException(BaseErrorCode.ANSWER_005);
+
+        TreeTest node = treeTestRepository.findByIdAndQuestion_Id(request.nodeId(), request.questionId())
+                .orElseThrow(() -> new BaseException(BaseErrorCode.ANSWER_004));
+
+        if (treeTestRepository.existsByParent_Id(node.getId())) {
+            throw new BaseException(BaseErrorCode.ANSWER_004);
+        }
+
+        Answer answer = Answer.builder()
+                .participationId(participationId)
+                .questionId(request.questionId())
+                .questionType(QuestionType.TREE_TEST)
+                .answer(Map.of("nodeId", request.nodeId()))
+                .build();
+        return answerRepository.save(answer);
+    }
+}

--- a/src/main/java/server/MATE/domain/test/controller/TestResponseController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestResponseController.java
@@ -1,0 +1,59 @@
+package server.MATE.domain.test.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import server.MATE.domain.test.dto.request.TestResponseRequest;
+import server.MATE.domain.test.dto.response.TestResponseCreateResponse;
+import server.MATE.domain.test.service.TestResponseService;
+import server.MATE.global.common.response.ApiResponse;
+import server.MATE.global.security.principal.AuthenticatedUser;
+
+@Tag(name = "[TEST] 테스트 API", description = "테스트 등록 관련 API")
+@RestController
+@RequestMapping("/api/v1/tests/{testId}/responses")
+@SecurityRequirement(name = "JWT")
+@RequiredArgsConstructor
+public class TestResponseController {
+
+    private final TestResponseService testResponseService;
+
+    @Operation(summary = "테스트 통합 응답 등록", description = """
+            참여자가 테스트의 모든 문항에 대한 응답을 한 번에 제출합니다.
+
+            - 테스트가 진행 중(IN_PROGRESS)이고 승인(ACCEPTED) 상태여야 합니다.
+            - 목표 인원(goalPpl)이 초과된 경우 참여 불가합니다.
+            - 이미 참여한 테스트에 중복 제출 불가합니다.
+            - `answers` 배열의 각 항목은 기존 응답 등록 API와 동일한 형식입니다.
+            - 모든 응답이 정상 저장된 후 pplCount가 증가합니다.
+
+            **[에러 코드]**
+            | 코드 | HTTP | 설명 |
+            |------|------|------|
+            | TEST_004 | 404 | 테스트를 찾을 수 없습니다 |
+            | PARTICIPATION_002 | 400 | 참여할 수 없는 테스트입니다 |
+            | PARTICIPATION_003 | 400 | 이미 참여한 테스트입니다 |
+            | PARTICIPATION_004 | 400 | 테스트 참여 인원이 마감되었습니다 |
+            | ANSWER_001 | 400 | 질문 타입과 응답 타입 불일치 |
+            | ANSWER_002 | 400 | 질문이 해당 테스트에 속하지 않습니다 |
+            | ANSWER_003 | 400 | 동일 질문에 대한 응답이 중복되었습니다 |
+            | ANSWER_004 | 400 | 유효하지 않은 입력입니다 |
+            | ANSWER_005 | 400 | 응답이 입력되지 않았습니다 |
+            """)
+    @PostMapping
+    public ResponseEntity<ApiResponse<TestResponseCreateResponse>> submitResponse(
+            @PathVariable Long testId,
+            @RequestBody @Valid TestResponseRequest request,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        TestResponseCreateResponse response = testResponseService.submitResponse(testId, authenticatedUser.getId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created("응답이 등록되었습니다.", response));
+    }
+}

--- a/src/main/java/server/MATE/domain/test/dto/request/TestResponseRequest.java
+++ b/src/main/java/server/MATE/domain/test/dto/request/TestResponseRequest.java
@@ -1,0 +1,11 @@
+package server.MATE.domain.test.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import server.MATE.domain.answer.dto.request.AnswerCreateItem;
+
+import java.util.List;
+
+public record TestResponseRequest(
+        @NotEmpty List<@Valid AnswerCreateItem> answers
+) {}

--- a/src/main/java/server/MATE/domain/test/dto/response/TestResponseCreateResponse.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/TestResponseCreateResponse.java
@@ -1,0 +1,10 @@
+package server.MATE.domain.test.dto.response;
+
+import server.MATE.domain.participation.entity.Participation;
+
+public record TestResponseCreateResponse(Long participationId) {
+
+    public static TestResponseCreateResponse from(Participation participation) {
+        return new TestResponseCreateResponse(participation.getId());
+    }
+}

--- a/src/main/java/server/MATE/domain/test/service/TestResponseService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestResponseService.java
@@ -1,0 +1,104 @@
+package server.MATE.domain.test.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.answer.dto.request.AnswerCreateItem;
+import server.MATE.domain.answer.service.handler.AnswerCreateHandler;
+import server.MATE.domain.participation.entity.Participation;
+import server.MATE.domain.participation.repository.ParticipationRepository;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.QuestionRepository;
+import server.MATE.domain.test.dto.request.TestResponseRequest;
+import server.MATE.domain.test.dto.response.TestResponseCreateResponse;
+import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class TestResponseService {
+
+    private final TestRepository testRepository;
+    private final ParticipationRepository participationRepository;
+    private final QuestionRepository questionRepository;
+    private final Map<QuestionType, AnswerCreateHandler> handlerMap;
+
+    public TestResponseService(TestRepository testRepository,
+                               ParticipationRepository participationRepository,
+                               QuestionRepository questionRepository,
+                               List<AnswerCreateHandler> handlers) {
+        this.testRepository = testRepository;
+        this.participationRepository = participationRepository;
+        this.questionRepository = questionRepository;
+        this.handlerMap = buildHandlerMap(handlers);
+    }
+
+    @Transactional
+    public TestResponseCreateResponse submitResponse(Long testId, Long testerId, TestResponseRequest request) {
+        Test test = testRepository.findByIdAndDeletedAtIsNullForUpdate(testId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        test.validateCanParticipate();
+
+        if (participationRepository.existsByTestIdAndTesterIdAndDeletedAtIsNull(testId, testerId)) {
+            throw new BaseException(BaseErrorCode.PARTICIPATION_003);
+        }
+
+        Map<Long, Question> questionMap = questionRepository
+                .findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId)
+                .stream()
+                .collect(Collectors.toMap(Question::getId, q -> q));
+
+        if (questionMap.size() != request.answers().size()) {
+            throw new BaseException(BaseErrorCode.ANSWER_008);
+        }
+
+        Participation participation = Participation.builder()
+                .testId(testId)
+                .testerId(testerId)
+                .build();
+        participationRepository.save(participation);
+
+        Set<Long> processedQuestionIds = new HashSet<>();
+        for (AnswerCreateItem item : request.answers()) {
+            if (!processedQuestionIds.add(item.questionId())) {
+                throw new BaseException(BaseErrorCode.ANSWER_003);
+            }
+
+            Question question = questionMap.get(item.questionId());
+            if (question == null) {
+                throw new BaseException(BaseErrorCode.QUESTION_005);
+            }
+
+            if (question.getQuestionType() != item.type()) {
+                throw new BaseException(BaseErrorCode.ANSWER_001);
+            }
+
+            AnswerCreateHandler handler = handlerMap.get(item.type());
+            if (handler == null) {
+                throw new BaseException(BaseErrorCode.COMMON_999);
+            }
+
+            handler.save(participation.getId(), item);
+        }
+
+        test.incrementPplCount();
+        return TestResponseCreateResponse.from(participation);
+    }
+
+    private Map<QuestionType, AnswerCreateHandler> buildHandlerMap(List<AnswerCreateHandler> handlers) {
+        Map<QuestionType, AnswerCreateHandler> map = new EnumMap<>(QuestionType.class);
+        for (AnswerCreateHandler handler : handlers) {
+            map.put(handler.supports(), handler);
+        }
+        return map;
+    }
+}

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -59,6 +59,7 @@ public enum BaseErrorCode implements ErrorCode {
     ANSWER_005(HttpStatus.BAD_REQUEST, "ANSWER_005", "응답이 입력되지 않았습니다."),
     ANSWER_006(HttpStatus.BAD_REQUEST, "ANSWER_006", "선택 개수가 허용 범위를 벗어났습니다."),
     ANSWER_007(HttpStatus.BAD_REQUEST, "ANSWER_007", "점수가 허용 범위를 벗어났습니다."),
+    ANSWER_008(HttpStatus.BAD_REQUEST, "ANSWER_008", "모든 문항에 응답해야 합니다."),
 
     // File
     FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_001", "파일 업로드에 실패했습니다."),


### PR DESCRIPTION
  ## 📍 요약      
  - 참여자가 테스트의 모든 문항에 대한 응답을 한 번에 제출하는 통합 API 구현                                            
                                                                                                                        
  ## 🔗 관련 이슈                                                                                                       
  - Closes #63                                                                                                          
                  
  ## 📌 변경 사항
  - [x] 기능
  - [x] 리팩토링                                                                                                        
  
  ## ✅ 작업 내용                                                                                                       
  - `AnswerCreateHandler` 인터페이스 및 타입별 핸들러 빈 구현 (QuestionCreateHandler 패턴 적용)
  - `AnswerService` 리팩토링: switch 패턴 매칭 → `Map<QuestionType, AnswerCreateHandler>` 위임 구조로 전환              
  - `POST /api/v1/tests/{testId}/responses` 통합 응답 등록 엔드포인트 추가                                              
  - `TestResponseService` 구현                                                                                          
    - 테스트 상태/중복/인원 검증 후 participation 자동 생성                                                             
    - 전체 질문 일괄 조회로 N+1 방지                                                                                    
    - Set 기반 중복 questionId 방어                                                                                     
    - 모든 문항 응답 여부 검증 (ANSWER_008)                                                                             
    - handler null 체크 (COMMON_999)                                                                                    
  - `ANSWER_008` 에러 코드 추가: 모든 문항에 응답해야 합니다                                                            
                                                                                                                        
  ## 테스트                                                                                                             
  - [x] 로컬 테스트 완료                                                                                                
  - 테스트 방법:                                                                                                        
    - DBeaver로 다중 질문 유형 삽입 후 Swagger에서 통합 응답 제출 검증                                                  
    - 중복 questionId / 미제출 문항 / 이미 참여한 테스트 에러 케이스 확인