### PR TITLE
feat: 트리 테스트 탐색 경로(path) 저장 기능 추가

### DIFF
--- a/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
+++ b/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
@@ -35,7 +35,13 @@ public class AnswerController {
             - 모든 문항에 빠짐없이 응답해야 합니다.
 
             **[type]**
-            - SUBJECTIVE, OBJECTIVE, FIVE_SECOND, SCALE, AB_TEST, CARD_SORTING, TREE_TEST
+            - SUBJECTIVE: text 필수
+            - OBJECTIVE: optionIds 필수, 기타 선택 시 otherText
+            - FIVE_SECOND: 주관식(text) 또는 객관식(optionIds) 모드
+            - SCALE: value 필수 (1 ~ range)
+            - AB_TEST: selected 필수 ("A" 또는 "B")
+            - CARD_SORTING: groups 필수
+            - TREE_TEST: nodeId 필수, path 필수 (루트부터 최종 노드까지 클릭 순서)
             """)
     @PostMapping
     public ResponseEntity<ApiResponse<AnswerBatchCreateResponse>> createAnswers(
@@ -166,7 +172,8 @@ public class AnswerController {
                                                         {
                                                           "type": "TREE_TEST",
                                                           "questionId": 7,
-                                                          "nodeId": 301
+                                                          "nodeId": 301,
+                                                          "path": [1, 45, 120, 301]
                                                         }
                                                       ]
                                                     }

--- a/src/main/java/server/MATE/domain/answer/dto/request/TreeTestAnswerCreateRequest.java
+++ b/src/main/java/server/MATE/domain/answer/dto/request/TreeTestAnswerCreateRequest.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.NotNull;
 import server.MATE.domain.question.entity.QuestionType;
 
+import java.util.List;
+
 @JsonTypeName("TREE_TEST")
 public record TreeTestAnswerCreateRequest(
         @NotNull Long questionId,
-        Long nodeId
+        Long nodeId,
+        List<Long> path
 ) implements AnswerCreateItem {
 
     @Override

--- a/src/main/java/server/MATE/domain/answer/service/handler/TreeTestAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/TreeTestAnswerCreateHandler.java
@@ -31,6 +31,8 @@ public class TreeTestAnswerCreateHandler implements AnswerCreateHandler {
         TreeTestAnswerCreateRequest request = (TreeTestAnswerCreateRequest) item;
 
         if (request.nodeId() == null) throw new BaseException(BaseErrorCode.ANSWER_005);
+        if (request.path() == null || request.path().isEmpty()) throw new BaseException(BaseErrorCode.ANSWER_005);
+        if (!request.nodeId().equals(request.path().getLast())) throw new BaseException(BaseErrorCode.ANSWER_004);
 
         TreeTest node = treeTestRepository.findByIdAndQuestion_Id(request.nodeId(), request.questionId())
                 .orElseThrow(() -> new BaseException(BaseErrorCode.ANSWER_004));
@@ -43,7 +45,7 @@ public class TreeTestAnswerCreateHandler implements AnswerCreateHandler {
                 .participationId(participationId)
                 .questionId(request.questionId())
                 .questionType(QuestionType.TREE_TEST)
-                .answer(Map.of("nodeId", request.nodeId()))
+                .answer(Map.of("nodeId", request.nodeId(), "path", request.path()))
                 .build();
         return answerRepository.save(answer);
     }


### PR DESCRIPTION
  ## 📍 요약
  트리 테스트 응답 저장 시 사용자의 실제 탐색 경로(path)를 추가 저장합니다.
  기존에는 최종 선택 nodeId만 저장하여 직접 성공 / 간접 성공 / 실패 통계 분석이 불가능했습니다.

  ## 🔗 관련 이슈 
  - Closes #81

  ## 📌 변경 사항 
  - [x] 기능

  ## ✅ 작업 내용
  - `TreeTestAnswerCreateRequest`에 `List<Long> path` 필드 추가
  - `TreeTestAnswerCreateHandler`에 path 유효성 검증 추가
    - path가 비어있으면 ANSWER_005
    - `path.last() != nodeId`이면 ANSWER_004
  - Answer JSONB 포맷 변경: `{ "nodeId": 15 }` → `{ "nodeId": 15, "path": [3, 7, 15] }`
  - Swagger 요청 예시 및 타입별 설명 업데이트

  ## 테스트 (로컬 테스트 완료 여부, 방법)
  - 컴파일 확인 완료