### PR TITLE
feat: 로그아웃 및 토큰 재발급 API 구현

### DIFF
--- a/src/main/java/server/MATE/domain/auth/controller/AuthController.java
+++ b/src/main/java/server/MATE/domain/auth/controller/AuthController.java
@@ -11,7 +11,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import server.MATE.domain.auth.dto.request.AuthReissueRequest;
 import server.MATE.domain.auth.dto.request.TossLoginRequest;
+import server.MATE.domain.auth.dto.response.AuthReissueResponse;
 import server.MATE.domain.auth.dto.response.TossLoginResponse;
 import server.MATE.domain.auth.service.AuthService;
 import server.MATE.global.common.exception.BaseErrorCode;
@@ -45,6 +47,15 @@ public class AuthController {
     ) {
         authService.logout(authenticatedUser.getId());
         return ResponseEntity.ok(ApiResponse.ok("로그아웃이 완료되었습니다.", null));
+    }
+
+    @Operation(summary = "토큰 재발급", description = "MATE refresh token을 검증하고 access/refresh token을 재발급합니다.")
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<AuthReissueResponse>> reissue(
+            @RequestBody @Valid AuthReissueRequest request
+    ) {
+        AuthReissueResponse response = authService.reissue(request.refreshToken());
+        return ResponseEntity.ok(ApiResponse.ok("토큰이 재발급되었습니다.", response));
     }
 
     private TossLoginService getTossLoginService() {

--- a/src/main/java/server/MATE/domain/auth/controller/AuthController.java
+++ b/src/main/java/server/MATE/domain/auth/controller/AuthController.java
@@ -40,7 +40,7 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.ok("토스 로그인이 완료되었습니다.", response));
     }
 
-    @Operation(summary = "로그아웃", description = "현재 인증된 사용자의 Mate 로그아웃을 처리합니다.")
+    @Operation(summary = "로그아웃", description = "현재 인증된 사용자의 Mate 로그아웃 합니다. 별도 요청값 없이 헤더에 포함된 access 토큰으로 처리합니다.")
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser
@@ -49,7 +49,7 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.ok("로그아웃이 완료되었습니다.", null));
     }
 
-    @Operation(summary = "토큰 재발급", description = "MATE refresh token을 검증하고 access/refresh token을 재발급합니다.")
+    @Operation(summary = "토큰 재발급", description = "refresh 토큰으로 요청하면 새 access 토큰과 refresh 토큰을 발급합니다.")
     @PostMapping("/reissue")
     public ResponseEntity<ApiResponse<AuthReissueResponse>> reissue(
             @RequestBody @Valid AuthReissueRequest request

--- a/src/main/java/server/MATE/domain/auth/controller/AuthController.java
+++ b/src/main/java/server/MATE/domain/auth/controller/AuthController.java
@@ -4,32 +4,54 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import server.MATE.domain.auth.dto.request.TossLoginRequest;
 import server.MATE.domain.auth.dto.response.TossLoginResponse;
+import server.MATE.domain.auth.service.AuthService;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
 import server.MATE.global.common.response.ApiResponse;
+import server.MATE.global.security.principal.AuthenticatedUser;
 import server.MATE.toss.service.TossLoginService;
 
 @Tag(name = "[AUTH] 인증 API", description = "인증 관련 API")
 @RestController
 @RequestMapping("/api/v1/auth")
-@ConditionalOnProperty(prefix = "toss.api", name = "enabled", havingValue = "true")
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final TossLoginService tossLoginService;
+    private final AuthService authService;
+    private final ObjectProvider<TossLoginService> tossLoginServiceProvider;
 
     @Operation(summary = "토스 로그인", description = "토스 authorization code를 사용해 Mate JWT를 발급합니다.")
     @PostMapping("/toss/login")
     public ResponseEntity<ApiResponse<TossLoginResponse>> loginWithToss(
             @RequestBody @Valid TossLoginRequest request
     ) {
-        TossLoginResponse response = tossLoginService.login(request.authorizationCode(), request.referrer());
+        TossLoginResponse response = getTossLoginService().login(request.authorizationCode(), request.referrer());
         return ResponseEntity.ok(ApiResponse.ok("토스 로그인이 완료되었습니다.", response));
+    }
+
+    @Operation(summary = "로그아웃", description = "현재 인증된 사용자의 Mate 로그아웃을 처리합니다.")
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        authService.logout(authenticatedUser.getId());
+        return ResponseEntity.ok(ApiResponse.ok("로그아웃이 완료되었습니다.", null));
+    }
+
+    private TossLoginService getTossLoginService() {
+        TossLoginService tossLoginService = tossLoginServiceProvider.getIfAvailable();
+        if (tossLoginService == null) {
+            throw new BaseException(BaseErrorCode.COMMON_001);
+        }
+        return tossLoginService;
     }
 }

--- a/src/main/java/server/MATE/domain/auth/dto/request/AuthReissueRequest.java
+++ b/src/main/java/server/MATE/domain/auth/dto/request/AuthReissueRequest.java
@@ -1,0 +1,8 @@
+package server.MATE.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AuthReissueRequest(
+        @NotBlank String refreshToken
+) {
+}

--- a/src/main/java/server/MATE/domain/auth/dto/response/AuthReissueResponse.java
+++ b/src/main/java/server/MATE/domain/auth/dto/response/AuthReissueResponse.java
@@ -1,0 +1,7 @@
+package server.MATE.domain.auth.dto.response;
+
+public record AuthReissueResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/server/MATE/domain/auth/service/AuthService.java
+++ b/src/main/java/server/MATE/domain/auth/service/AuthService.java
@@ -36,7 +36,12 @@ public class AuthService {
         String savedRefreshToken = userRefreshTokenStore.find(userId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.AUTH_013));
 
-        if (!savedRefreshToken.equals(refreshToken)) throw new BaseException(BaseErrorCode.AUTH_013);
+        // refresh 토큰의 JWT 형태는 유효하지만 redis에 저장된 최신 토큰과 일치하지 않은 경우
+        // 기존 토큰의 탈취 위험으로 간주하여 세션 상태를 삭제함
+        if (!savedRefreshToken.equals(refreshToken)) {
+            revokeUserTokens(userId);
+            throw new BaseException(BaseErrorCode.AUTH_013);
+        }
 
         Users user = usersRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.AUTH_004));
@@ -47,5 +52,11 @@ public class AuthService {
         userRefreshTokenStore.save(userId, newRefreshToken, jwtProvider.getExpiration(TokenType.REFRESH));
 
         return new AuthReissueResponse(newAccessToken, newRefreshToken);
+    }
+
+    private void revokeUserTokens(Long userId) {
+        userRefreshTokenStore.delete(userId);
+        tossTokenStore.deleteAccessToken(userId);
+        tossTokenStore.deleteRefreshToken(userId);
     }
 }

--- a/src/main/java/server/MATE/domain/auth/service/AuthService.java
+++ b/src/main/java/server/MATE/domain/auth/service/AuthService.java
@@ -1,0 +1,22 @@
+package server.MATE.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.auth.store.TossTokenStore;
+import server.MATE.domain.auth.store.UserRefreshTokenStore;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRefreshTokenStore userRefreshTokenStore;
+    private final TossTokenStore tossTokenStore;
+
+    public void logout(Long userId) {
+        userRefreshTokenStore.delete(userId);
+        tossTokenStore.deleteAccessToken(userId);
+        tossTokenStore.deleteRefreshToken(userId);
+    }
+}

--- a/src/main/java/server/MATE/domain/auth/service/AuthService.java
+++ b/src/main/java/server/MATE/domain/auth/service/AuthService.java
@@ -3,20 +3,49 @@ package server.MATE.domain.auth.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.auth.dto.response.AuthReissueResponse;
+import server.MATE.domain.auth.jwt.JwtProvider;
+import server.MATE.domain.auth.jwt.TokenType;
 import server.MATE.domain.auth.store.TossTokenStore;
 import server.MATE.domain.auth.store.UserRefreshTokenStore;
+import server.MATE.domain.users.entity.Users;
+import server.MATE.domain.users.repository.UsersRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class AuthService {
 
+    private final JwtProvider jwtProvider;
     private final UserRefreshTokenStore userRefreshTokenStore;
     private final TossTokenStore tossTokenStore;
+    private final UsersRepository usersRepository;
 
     public void logout(Long userId) {
         userRefreshTokenStore.delete(userId);
         tossTokenStore.deleteAccessToken(userId);
         tossTokenStore.deleteRefreshToken(userId);
+    }
+
+    public AuthReissueResponse reissue(String refreshToken) {
+        jwtProvider.validateTokenTypeOrThrow(refreshToken, TokenType.REFRESH);
+
+        Long userId = jwtProvider.extractUserId(refreshToken);
+        String savedRefreshToken = userRefreshTokenStore.find(userId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.AUTH_013));
+
+        if (!savedRefreshToken.equals(refreshToken)) throw new BaseException(BaseErrorCode.AUTH_013);
+
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.AUTH_004));
+
+        String newAccessToken = jwtProvider.generateToken(userId, user.getRole().name(), TokenType.ACCESS);
+        String newRefreshToken = jwtProvider.generateToken(userId, user.getRole().name(), TokenType.REFRESH);
+
+        userRefreshTokenStore.save(userId, newRefreshToken, jwtProvider.getExpiration(TokenType.REFRESH));
+
+        return new AuthReissueResponse(newAccessToken, newRefreshToken);
     }
 }

--- a/src/main/java/server/MATE/domain/auth/store/RedisTossTokenStore.java
+++ b/src/main/java/server/MATE/domain/auth/store/RedisTossTokenStore.java
@@ -4,12 +4,16 @@ import java.util.Optional;
 
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
+import server.MATE.domain.auth.crypto.TokenEncryptor;
 
 @Component
 public class RedisTossTokenStore extends RedisTokenStore implements TossTokenStore {
 
-    public RedisTossTokenStore(StringRedisTemplate redisTemplate) {
+    private final TokenEncryptor tokenEncryptor;
+
+    public RedisTossTokenStore(StringRedisTemplate redisTemplate, TokenEncryptor tokenEncryptor) {
         super(redisTemplate);
+        this.tokenEncryptor = tokenEncryptor;
     }
 
     @Override
@@ -29,12 +33,13 @@ public class RedisTossTokenStore extends RedisTokenStore implements TossTokenSto
 
     @Override
     public void saveRefreshToken(Long userId, String refreshToken, long ttlMillis) {
-        saveValue(refreshKey(userId), refreshToken, ttlMillis);
+        saveValue(refreshKey(userId), tokenEncryptor.encrypt(refreshToken), ttlMillis);
     }
 
     @Override
     public Optional<String> findRefreshToken(Long userId) {
-        return findValue(refreshKey(userId));
+        return findValue(refreshKey(userId))
+                .map(tokenEncryptor::decrypt);
     }
 
     @Override

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -34,6 +34,7 @@ public enum BaseErrorCode implements ErrorCode {
     AUTH_010(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH_010", "토큰 암호화 설정 정보를 찾을 수 없습니다."),
     AUTH_011(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH_011", "토큰을 암호화할 수 없습니다."),
     AUTH_012(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH_012", "저장된 토큰을 복호화할 수 없습니다."),
+    AUTH_013(HttpStatus.UNAUTHORIZED, "AUTH_013", "유효하지 않은 리프레시 토큰입니다."),
 
     // Test
     TEST_001(HttpStatus.BAD_REQUEST, "TEST_001", "카테고리는 1개 이상 3개 이하로 선택해야 합니다."),

--- a/src/main/java/server/MATE/global/security/config/SecurityConfig.java
+++ b/src/main/java/server/MATE/global/security/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
 
     private static final String[] PUBLIC_WHITELIST = {
             "/",
-            "/api/v1/auth/toss/login",
+            "/api/v1/auth/toss/login", "/api/v1/auth/reissue",
             "/swagger-ui/**", "/swagger-ui.html", "/api-docs/**", "/v3/api-docs/**", "/docs/error-codes"
     };
 

--- a/src/main/java/server/MATE/toss/service/TossLoginService.java
+++ b/src/main/java/server/MATE/toss/service/TossLoginService.java
@@ -1,5 +1,6 @@
 package server.MATE.toss.service;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 
@@ -46,7 +47,7 @@ public class TossLoginService {
     private final UserRefreshTokenStore userRefreshTokenStore;
     private final TossTokenStore tossTokenStore;
     private final TokenEncryptor tokenEncryptor;
-    private final java.time.Clock clock;
+    private final Clock clock;
 
     @Value("${toss.token.refresh-cache-ttl}")
     private long tossRefreshCacheTtlMillis;
@@ -63,7 +64,8 @@ public class TossLoginService {
         TossDecryptedUserInfo decryptedUserInfo = tossUserInfoDecryptor.decrypt(loginUserResponse);
 
         UserLoginContext userLoginContext = upsertUser(decryptedUserInfo);
-        syncTossAccount(userLoginContext.user(), decryptedUserInfo, tossTokenResponse);
+        String encryptedRefreshToken = tokenEncryptor.encrypt(tossTokenResponse.refreshToken());
+        syncTossAccount(userLoginContext.user(), decryptedUserInfo, encryptedRefreshToken);
         cacheTossTokens(userLoginContext.user().getId(), tossTokenResponse);
 
         String accessToken = jwtProvider.generateToken(userLoginContext.user().getId(), userLoginContext.user().getRole().name(), TokenType.ACCESS);
@@ -93,9 +95,12 @@ public class TossLoginService {
                 ));
     }
 
-    private void syncTossAccount(Users user, TossDecryptedUserInfo decryptedUserInfo, TossTokenResponse tossTokenResponse) {
+    private void syncTossAccount(
+            Users user,
+            TossDecryptedUserInfo decryptedUserInfo,
+            String encryptedRefreshToken
+    ) {
         LocalDateTime now = LocalDateTime.now(clock);
-        String encryptedRefreshToken = tokenEncryptor.encrypt(tossTokenResponse.refreshToken());
 
         TossAccount tossAccount = tossAccountRepository.findByUser(user)
                 .orElseGet(() -> TossAccount.builder()

--- a/src/test/java/server/MATE/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/server/MATE/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,97 @@
+package server.MATE.domain.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import server.MATE.domain.auth.jwt.TokenType;
+import server.MATE.domain.auth.service.AuthService;
+import server.MATE.domain.users.entity.Role;
+import server.MATE.global.common.exception.GlobalExceptionHandler;
+import server.MATE.global.discord.DiscordWebhookNotifier;
+import server.MATE.global.security.principal.AuthenticatedUser;
+import server.MATE.toss.service.TossLoginService;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+    @Mock
+    private AuthService authService;
+
+    @Mock
+    private ObjectProvider<TossLoginService> tossLoginServiceProvider;
+
+    @Mock
+    private DiscordWebhookNotifier discordWebhookNotifier;
+
+    @InjectMocks
+    private AuthController authController;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(authController)
+                .setControllerAdvice(new GlobalExceptionHandler(discordWebhookNotifier))
+                .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("로그아웃 요청을 정상 처리한다")
+    void handlesLogoutRequestSuccessfully() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .with(authenticationPrincipal()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("로그아웃이 완료되었습니다."))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(authService).logout(1L);
+    }
+
+    private UsernamePasswordAuthenticationToken authentication() {
+        AuthenticatedUser user = new AuthenticatedUser(1L, Role.USER, TokenType.ACCESS);
+        return new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+    }
+
+    private RequestPostProcessor authenticationPrincipal() {
+        RequestPostProcessor delegate =
+                SecurityMockMvcRequestPostProcessors.authentication(authentication());
+        return request -> {
+            delegate.postProcessRequest(request);
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(authentication());
+            SecurityContextHolder.setContext(context);
+            request.setUserPrincipal(authentication());
+            return request;
+        };
+    }
+}

--- a/src/test/java/server/MATE/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/server/MATE/domain/auth/controller/AuthControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.security.web.method.annotation.AuthenticationPrincipa
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import server.MATE.domain.auth.dto.response.AuthReissueResponse;
 import server.MATE.domain.auth.jwt.TokenType;
 import server.MATE.domain.auth.service.AuthService;
 import server.MATE.domain.users.entity.Role;
@@ -26,6 +27,7 @@ import server.MATE.global.discord.DiscordWebhookNotifier;
 import server.MATE.global.security.principal.AuthenticatedUser;
 import server.MATE.toss.service.TossLoginService;
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -75,6 +77,43 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.data").doesNotExist());
 
         verify(authService).logout(1L);
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 요청을 정상 처리한다")
+    void handlesReissueRequestSuccessfully() throws Exception {
+        given(authService.reissue("refresh-token"))
+                .willReturn(new AuthReissueResponse("new-access-token", "new-refresh-token"));
+
+        mockMvc.perform(post("/api/v1/auth/reissue")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "refreshToken": "refresh-token"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("토큰이 재발급되었습니다."))
+                .andExpect(jsonPath("$.data.accessToken").value("new-access-token"))
+                .andExpect(jsonPath("$.data.refreshToken").value("new-refresh-token"));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 요청에서 refreshToken이 비어 있으면 400을 반환한다")
+    void returnsBadRequestWhenRefreshTokenIsBlank() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/reissue")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "refreshToken": ""
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("COMMON_002"))
+                .andExpect(jsonPath("$.field").value("refreshToken"));
     }
 
     private UsernamePasswordAuthenticationToken authentication() {

--- a/src/test/java/server/MATE/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/server/MATE/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,35 @@
+package server.MATE.domain.auth.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import server.MATE.domain.auth.store.TossTokenStore;
+import server.MATE.domain.auth.store.UserRefreshTokenStore;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRefreshTokenStore userRefreshTokenStore;
+
+    @Mock
+    private TossTokenStore tossTokenStore;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    @DisplayName("로그아웃 시 서비스 및 토스 토큰 저장소를 모두 정리한다")
+    void deletesAllTokensOnLogout() {
+        authService.logout(1L);
+
+        verify(userRefreshTokenStore).delete(1L);
+        verify(tossTokenStore).deleteAccessToken(1L);
+        verify(tossTokenStore).deleteRefreshToken(1L);
+    }
+}

--- a/src/test/java/server/MATE/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/server/MATE/domain/auth/service/AuthServiceTest.java
@@ -6,19 +6,39 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import server.MATE.domain.auth.dto.response.AuthReissueResponse;
+import server.MATE.domain.auth.jwt.JwtProvider;
+import server.MATE.domain.auth.jwt.TokenType;
 import server.MATE.domain.auth.store.TossTokenStore;
 import server.MATE.domain.auth.store.UserRefreshTokenStore;
+import server.MATE.domain.users.entity.Role;
+import server.MATE.domain.users.entity.Users;
+import server.MATE.domain.users.repository.UsersRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
 
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
+
+    @Mock
+    private JwtProvider jwtProvider;
 
     @Mock
     private UserRefreshTokenStore userRefreshTokenStore;
 
     @Mock
     private TossTokenStore tossTokenStore;
+
+    @Mock
+    private UsersRepository usersRepository;
 
     @InjectMocks
     private AuthService authService;
@@ -31,5 +51,73 @@ class AuthServiceTest {
         verify(userRefreshTokenStore).delete(1L);
         verify(tossTokenStore).deleteAccessToken(1L);
         verify(tossTokenStore).deleteRefreshToken(1L);
+    }
+
+    @Test
+    @DisplayName("유효한 refresh token이면 access token과 refresh token을 재발급하고 저장소를 갱신한다")
+    void reissuesTokensWhenRefreshTokenIsValid() {
+        Users user = Users.builder()
+                .ci("ci-1")
+                .name("tester")
+                .role(Role.USER)
+                .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        when(jwtProvider.extractUserId("refresh-token")).thenReturn(1L);
+        when(userRefreshTokenStore.find(1L)).thenReturn(Optional.of("refresh-token"));
+        when(usersRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(jwtProvider.generateToken(1L, "USER", TokenType.ACCESS)).thenReturn("new-access-token");
+        when(jwtProvider.generateToken(1L, "USER", TokenType.REFRESH)).thenReturn("new-refresh-token");
+        when(jwtProvider.getExpiration(TokenType.REFRESH)).thenReturn(1_209_600_000L);
+
+        AuthReissueResponse response = authService.reissue("refresh-token");
+
+        verify(jwtProvider).validateTokenTypeOrThrow("refresh-token", TokenType.REFRESH);
+        verify(userRefreshTokenStore).save(1L, "new-refresh-token", 1_209_600_000L);
+        assertThat(response.accessToken()).isEqualTo("new-access-token");
+        assertThat(response.refreshToken()).isEqualTo("new-refresh-token");
+    }
+
+    @Test
+    @DisplayName("저장된 refresh token이 없으면 AUTH_013 예외를 던진다")
+    void throwsWhenSavedRefreshTokenDoesNotExist() {
+        when(jwtProvider.extractUserId("refresh-token")).thenReturn(1L);
+        when(userRefreshTokenStore.find(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.reissue("refresh-token"))
+                .isInstanceOf(BaseException.class)
+                .extracting(exception -> ((BaseException) exception).getErrorCode())
+                .isEqualTo(BaseErrorCode.AUTH_013);
+
+        verify(jwtProvider).validateTokenTypeOrThrow("refresh-token", TokenType.REFRESH);
+    }
+
+    @Test
+    @DisplayName("저장된 refresh token과 요청 토큰이 다르면 AUTH_013 예외를 던진다")
+    void throwsWhenSavedRefreshTokenDoesNotMatch() {
+        when(jwtProvider.extractUserId("refresh-token")).thenReturn(1L);
+        when(userRefreshTokenStore.find(1L)).thenReturn(Optional.of("another-refresh-token"));
+
+        assertThatThrownBy(() -> authService.reissue("refresh-token"))
+                .isInstanceOf(BaseException.class)
+                .extracting(exception -> ((BaseException) exception).getErrorCode())
+                .isEqualTo(BaseErrorCode.AUTH_013);
+
+        verify(jwtProvider).validateTokenTypeOrThrow("refresh-token", TokenType.REFRESH);
+    }
+
+    @Test
+    @DisplayName("토큰의 사용자 정보가 없으면 AUTH_004 예외를 던진다")
+    void throwsWhenUserDoesNotExistDuringReissue() {
+        when(jwtProvider.extractUserId("refresh-token")).thenReturn(1L);
+        when(userRefreshTokenStore.find(1L)).thenReturn(Optional.of("refresh-token"));
+        when(usersRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.reissue("refresh-token"))
+                .isInstanceOf(BaseException.class)
+                .extracting(exception -> ((BaseException) exception).getErrorCode())
+                .isEqualTo(BaseErrorCode.AUTH_004);
+
+        verify(jwtProvider).validateTokenTypeOrThrow("refresh-token", TokenType.REFRESH);
     }
 }


### PR DESCRIPTION
## 📍 요약
- Mate 로그아웃 api 와 Mate 토큰 재발급 api를 추가하고, Redis 기반 토큰 정리 로직을 구현

## 🔗 관련 이슈
- Closes #86

## 📌 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
#### 1. 로그아웃 기능 구현
- 로그아웃 API
   - 별도 요청값 없이 헤더에 있는 access token 값으로 처리
- 로그아웃 시 Redis에 저장된 인증 관련 키 정리
   - Mate refresh token(`auth:refresh:token:{userId}`) 삭제
   - Toss access token(`auth:toss:access:{userId}`) 삭제
   - Toss refresh token(`auth:toss:refresh:{userId}`) 삭제
- **토스 연동 해제는 이번 범위에서 제외**
   - 앱인토스 unlink api 호출 없이 Mate 인증 상태만 종료

#### 2. 토큰 재발급 기능 구현
- 토큰 재발급 API
   - refresh token으로 요청하면 새 access token, refresh token을 재발급
- refresh token **rotation 방식** 적용
   - 요청 refresh token의 타입이 REFRESH인지 검증
   - 토큰 subject 기준 userId 추출
   - Redis에 저장된 refresh token과 요청값이 일치하는지 검증
   - 검증 성공 시 새 access token, 새 refresh token 발급
   - Redis 저장값을 새 refresh token으로 교체

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - 로그아웃 시 Redis 키 정리 확인
     - `auth:refresh:token:{userId}`
     - `auth:toss:access:{userId}`
     - `auth:toss:refresh:{userId}`
  -  재발급 시 refresh token rotation 확인
     - 요청 refresh token 검증 후 새 access token, 새 refresh token 발급
     - Redis의 `auth:refresh:token:{userId}` 값이 새 refresh token으로 교체되는지 확인
