### PR TITLE
feat: 토스 연결 해제 및 연결 해제 콜백 API 구현

### DIFF
--- a/src/main/java/server/MATE/domain/auth/controller/AuthController.java
+++ b/src/main/java/server/MATE/domain/auth/controller/AuthController.java
@@ -84,7 +84,7 @@ public class AuthController {
     }
 
     @Operation(
-            summary = "토스 연결 해제(userKey)",
+            summary = "🙅🏻‍♀️ 토스 연결 해제",
             description = "운영/관리/보정용 API입니다. 프론트에서 직접 호출하는 API가 아닙니다."
     )
     @PostMapping("/toss/unlink/by-user-key")
@@ -97,22 +97,29 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.ok("토스 연결이 해제되었습니다.", null));
     }
 
-    @Operation(summary = "토스 연동 상태 조회", description = "현재 사용자의 토스 로그인 연동 상태를 조회합니다.")
+    @Operation(
+            summary = "토스 연동 상태 조회",
+            description = """
+                현재 사용자의 토스 로그인 연동 상태를 서버 기준으로 조회합니다. 클라이언트 SDK 기준 연동 여부 확인용이고, 서버에 저장된 연동 상태 기준으로 응답합니다.
+                - `isLinked=true`: 현재 계정이 토스 로그인과 연동된 상태입니다.
+                - `isLinked=false`: 현재 계정이 토스 로그인과 연동되지 않았거나 연결 해제된 상태입니다.
+                
+                앱인토스 클라이언트 동작을 함께 확인하려면
+                [getIsTossLoginIntegratedService 공식 문서](https://developers-apps-in-toss.toss.im/bedrock/reference/framework/%EB%A1%9C%EA%B7%B8%EC%9D%B8/getIsTossLoginIntegratedService.html)를 참고해주세요.
+                """
+    )
     @GetMapping("/toss/integration-status")
     public ResponseEntity<ApiResponse<TossLinkStatusResponse>> getTossIntegrationStatus(
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser
     ) {
         TossLoginService tossLoginService = tossLoginServiceProvider.getIfAvailable();
         boolean isLinked = tossLoginService != null && tossLoginService.isLinked(authenticatedUser.getId());
-        return ResponseEntity.ok(ApiResponse.ok(
-                "토스 연동 상태를 조회했습니다.",
-                new TossLinkStatusResponse(isLinked)
-        ));
+        return ResponseEntity.ok(ApiResponse.ok("토스 연동 상태를 조회했습니다.", new TossLinkStatusResponse(isLinked)));
     }
 
     // @Hidden
     @Operation(
-            summary = "토스 연결 해제 콜백",
+            summary = "🙅🏻‍♀️ 토스 연결 해제 콜백",
             description = "토스 시스템이 호출하는 운영용 콜백 API입니다. 프론트에서 직접 호출하는 API가 아닙니다. Basic Auth 헤더 검증이 필요합니다."
     )
     @GetMapping("/toss/login/unlink/callback")
@@ -129,7 +136,7 @@ public class AuthController {
 
     // @Hidden
     @Operation(
-            summary = "토스 연결 해제 콜백",
+            summary = "🙅🏻‍♀️ 토스 연결 해제 콜백",
             description = "토스 시스템이 호출하는 운영용 콜백 API입니다. 프론트에서 직접 호출하는 API가 아닙니다. Basic Auth 헤더 검증이 필요합니다."
     )
     @PostMapping("/toss/login/unlink/callback")

--- a/src/main/java/server/MATE/domain/auth/controller/AuthController.java
+++ b/src/main/java/server/MATE/domain/auth/controller/AuthController.java
@@ -1,28 +1,41 @@
 package server.MATE.domain.auth.controller;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
 import server.MATE.domain.auth.dto.request.AuthReissueRequest;
 import server.MATE.domain.auth.dto.request.TossLoginRequest;
 import server.MATE.domain.auth.dto.response.AuthReissueResponse;
+import server.MATE.domain.auth.dto.response.TossLinkStatusResponse;
 import server.MATE.domain.auth.dto.response.TossLoginResponse;
 import server.MATE.domain.auth.service.AuthService;
+import server.MATE.domain.users.entity.Role;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
 import server.MATE.global.common.response.ApiResponse;
 import server.MATE.global.security.principal.AuthenticatedUser;
+import server.MATE.domain.users.entity.TossUnlinkReferrer;
+import server.MATE.toss.dto.request.TossUnlinkByUserKeyRequest;
+import server.MATE.toss.dto.request.TossUnlinkCallbackRequest;
 import server.MATE.toss.service.TossLoginService;
 
 @Tag(name = "[AUTH] 인증 API", description = "인증 관련 API")
+@Validated
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
@@ -58,11 +71,89 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.ok("토큰이 재발급되었습니다.", response));
     }
 
+    @Operation(
+            summary = "토스 연결 해제",
+            description = "현재 사용자의 토스 로그인 연결을 해제합니다. 토스 앱에서 연결이 해제되면 서비스 세션도 종료되어 재로그인이 필요합니다."
+    )
+    @PostMapping("/toss/unlink")
+    public ResponseEntity<ApiResponse<Void>> unlinkToss(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        getTossLoginService().unlinkCurrentUser(authenticatedUser.getId());
+        return ResponseEntity.ok(ApiResponse.ok("토스 연결이 해제되었습니다.", null));
+    }
+
+    @Operation(
+            summary = "토스 연결 해제(userKey)",
+            description = "운영/관리/보정용 API입니다. 프론트에서 직접 호출하는 API가 아닙니다."
+    )
+    @PostMapping("/toss/unlink/by-user-key")
+    public ResponseEntity<ApiResponse<Void>> unlinkTossByUserKey(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @RequestBody @Valid TossUnlinkByUserKeyRequest request
+    ) {
+        validateAdminRole(authenticatedUser);
+        getTossLoginService().unlinkByUserKey(request.userKey(), TossUnlinkReferrer.UNLINK);
+        return ResponseEntity.ok(ApiResponse.ok("토스 연결이 해제되었습니다.", null));
+    }
+
+    @Operation(summary = "토스 연동 상태 조회", description = "현재 사용자의 토스 로그인 연동 상태를 조회합니다.")
+    @GetMapping("/toss/integration-status")
+    public ResponseEntity<ApiResponse<TossLinkStatusResponse>> getTossIntegrationStatus(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        TossLoginService tossLoginService = tossLoginServiceProvider.getIfAvailable();
+        boolean isLinked = tossLoginService != null && tossLoginService.isLinked(authenticatedUser.getId());
+        return ResponseEntity.ok(ApiResponse.ok(
+                "토스 연동 상태를 조회했습니다.",
+                new TossLinkStatusResponse(isLinked)
+        ));
+    }
+
+    // @Hidden
+    @Operation(
+            summary = "토스 연결 해제 콜백",
+            description = "토스 시스템이 호출하는 운영용 콜백 API입니다. 프론트에서 직접 호출하는 API가 아닙니다. Basic Auth 헤더 검증이 필요합니다."
+    )
+    @GetMapping("/toss/login/unlink/callback")
+    public ResponseEntity<ApiResponse<Void>> handleTossUnlinkCallbackGet(
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            @RequestParam @NotNull Long userKey,
+            @RequestParam @NotBlank String referrer
+    ) {
+        TossLoginService tossLoginService = getTossLoginService();
+        tossLoginService.validateCallbackAuthorization(authorization);
+        tossLoginService.handleUnlinkCallback(userKey, TossUnlinkReferrer.from(referrer));
+        return ResponseEntity.ok(ApiResponse.ok("토스 연결 해제 콜백을 처리했습니다.", null));
+    }
+
+    // @Hidden
+    @Operation(
+            summary = "토스 연결 해제 콜백",
+            description = "토스 시스템이 호출하는 운영용 콜백 API입니다. 프론트에서 직접 호출하는 API가 아닙니다. Basic Auth 헤더 검증이 필요합니다."
+    )
+    @PostMapping("/toss/login/unlink/callback")
+    public ResponseEntity<ApiResponse<Void>> handleTossUnlinkCallbackPost(
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            @RequestBody @Valid TossUnlinkCallbackRequest request
+    ) {
+        TossLoginService tossLoginService = getTossLoginService();
+        tossLoginService.validateCallbackAuthorization(authorization);
+        tossLoginService.handleUnlinkCallback(request.userKey(), TossUnlinkReferrer.from(request.referrer()));
+        return ResponseEntity.ok(ApiResponse.ok("토스 연결 해제 콜백을 처리했습니다.", null));
+    }
+
     private TossLoginService getTossLoginService() {
         TossLoginService tossLoginService = tossLoginServiceProvider.getIfAvailable();
         if (tossLoginService == null) {
             throw new BaseException(BaseErrorCode.COMMON_001);
         }
         return tossLoginService;
+    }
+
+    private void validateAdminRole(AuthenticatedUser authenticatedUser) {
+        if (authenticatedUser == null || authenticatedUser.getRole() != Role.ADMIN) {
+            throw new BaseException(BaseErrorCode.COMMON_009);
+        }
     }
 }

--- a/src/main/java/server/MATE/domain/auth/dto/response/TossLinkStatusResponse.java
+++ b/src/main/java/server/MATE/domain/auth/dto/response/TossLinkStatusResponse.java
@@ -1,0 +1,6 @@
+package server.MATE.domain.auth.dto.response;
+
+public record TossLinkStatusResponse(
+        boolean isLinked
+) {
+}

--- a/src/main/java/server/MATE/domain/users/entity/TossAccount.java
+++ b/src/main/java/server/MATE/domain/users/entity/TossAccount.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -41,6 +43,16 @@ public class TossAccount extends BaseEntity {
     private String scope;
 
     @Column(nullable = false)
+    private boolean isLinked;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 50)
+    private TossUnlinkReferrer unlinkReferrer;
+
+    @Column
+    private LocalDateTime unlinkedAt;
+
+    @Column(nullable = false)
     private LocalDateTime lastLoginAt;
 
     @Column(nullable = false)
@@ -52,6 +64,9 @@ public class TossAccount extends BaseEntity {
             Long tossUserKey,
             String encryptedTossRefreshToken,
             String scope,
+            boolean isLinked,
+            TossUnlinkReferrer unlinkReferrer,
+            LocalDateTime unlinkedAt,
             LocalDateTime lastLoginAt,
             LocalDateTime lastTokenRefreshedAt
     ) {
@@ -59,6 +74,9 @@ public class TossAccount extends BaseEntity {
         this.tossUserKey = tossUserKey;
         this.encryptedTossRefreshToken = encryptedTossRefreshToken;
         this.scope = scope;
+        this.isLinked = isLinked;
+        this.unlinkReferrer = unlinkReferrer;
+        this.unlinkedAt = unlinkedAt;
         this.lastLoginAt = lastLoginAt;
         this.lastTokenRefreshedAt = lastTokenRefreshedAt;
     }
@@ -73,7 +91,30 @@ public class TossAccount extends BaseEntity {
         this.tossUserKey = tossUserKey;
         this.encryptedTossRefreshToken = encryptedTossRefreshToken;
         this.scope = scope;
+        this.isLinked = true;
+        this.unlinkReferrer = null;
+        this.unlinkedAt = null;
         this.lastLoginAt = lastLoginAt;
         this.lastTokenRefreshedAt = lastTokenRefreshedAt;
+    }
+
+    public void refreshLoginState(
+            String encryptedTossRefreshToken,
+            String scope,
+            LocalDateTime lastTokenRefreshedAt
+    ) {
+        this.encryptedTossRefreshToken = encryptedTossRefreshToken;
+        this.scope = scope;
+        this.isLinked = true;
+        this.unlinkReferrer = null;
+        this.unlinkedAt = null;
+        this.lastTokenRefreshedAt = lastTokenRefreshedAt;
+    }
+
+    public void markUnlinked(TossUnlinkReferrer unlinkReferrer, LocalDateTime unlinkedAt) {
+        this.isLinked = false;
+        this.encryptedTossRefreshToken = null;
+        this.unlinkReferrer = unlinkReferrer;
+        this.unlinkedAt = unlinkedAt;
     }
 }

--- a/src/main/java/server/MATE/domain/users/entity/TossUnlinkReferrer.java
+++ b/src/main/java/server/MATE/domain/users/entity/TossUnlinkReferrer.java
@@ -1,0 +1,24 @@
+package server.MATE.domain.users.entity;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public enum TossUnlinkReferrer {
+    UNLINK,
+    WITHDRAWAL_TERMS,
+    WITHDRAWAL_TOSS,
+    UNKNOWN;
+
+    public static TossUnlinkReferrer from(String value) {
+        if (value == null || value.isBlank()) {
+            return UNKNOWN;
+        }
+
+        try {
+            return TossUnlinkReferrer.valueOf(value.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            log.warn("Unknown Toss unlink referrer received: {}", value);
+            return UNKNOWN;
+        }
+    }
+}

--- a/src/main/java/server/MATE/domain/users/repository/TossAccountRepository.java
+++ b/src/main/java/server/MATE/domain/users/repository/TossAccountRepository.java
@@ -9,4 +9,8 @@ import server.MATE.domain.users.entity.Users;
 public interface TossAccountRepository extends JpaRepository<TossAccount, Long> {
 
     Optional<TossAccount> findByUser(Users user);
+
+    Optional<TossAccount> findByUserId(Long userId);
+
+    Optional<TossAccount> findByTossUserKey(Long tossUserKey);
 }

--- a/src/main/java/server/MATE/global/security/config/SecurityConfig.java
+++ b/src/main/java/server/MATE/global/security/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
 
     private static final String[] PUBLIC_WHITELIST = {
             "/",
-            "/api/v1/auth/toss/login", "/api/v1/auth/reissue",
+            "/api/v1/auth/toss/login", "/api/v1/auth/reissue", "/api/v1/auth/toss/login/unlink/callback",
             "/swagger-ui/**", "/swagger-ui.html", "/api-docs/**", "/v3/api-docs/**", "/docs/error-codes"
     };
 

--- a/src/main/java/server/MATE/toss/client/login/TossLoginApiClient.java
+++ b/src/main/java/server/MATE/toss/client/login/TossLoginApiClient.java
@@ -3,11 +3,14 @@ package server.MATE.toss.client.login;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+import server.MATE.toss.dto.request.TossUnlinkByUserKeyRequest;
 import server.MATE.toss.client.http.TossHttpClient;
 import server.MATE.toss.dto.response.TossLoginUserResponse;
 import server.MATE.toss.dto.request.TossRefreshTokenRequest;
 import server.MATE.toss.dto.request.TossTokenRequest;
 import server.MATE.toss.dto.response.TossTokenResponse;
+
+import java.util.Map;
 
 @Component
 @ConditionalOnProperty(prefix = "toss.api", name = "enabled", havingValue = "true")
@@ -37,6 +40,23 @@ public class TossLoginApiClient {
                 "/api-partner/v1/apps-in-toss/user/oauth2/login-me",
                 headers -> headers.setBearerAuth(accessToken),
                 TossLoginUserResponse.class
+        );
+    }
+
+    public void removeByAccessToken(String accessToken) {
+        tossHttpClient.post(
+                "/api-partner/v1/apps-in-toss/user/oauth2/access/remove-by-access-token",
+                Map.of(),
+                headers -> headers.setBearerAuth(accessToken),
+                Object.class
+        );
+    }
+
+    public void removeByUserKey(Long userKey) {
+        tossHttpClient.post(
+                "/api-partner/v1/apps-in-toss/user/oauth2/access/remove-by-user-key",
+                new TossUnlinkByUserKeyRequest(userKey),
+                Object.class
         );
     }
 }

--- a/src/main/java/server/MATE/toss/dto/request/TossUnlinkByUserKeyRequest.java
+++ b/src/main/java/server/MATE/toss/dto/request/TossUnlinkByUserKeyRequest.java
@@ -1,0 +1,8 @@
+package server.MATE.toss.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record TossUnlinkByUserKeyRequest(
+        @NotNull Long userKey
+) {
+}

--- a/src/main/java/server/MATE/toss/dto/request/TossUnlinkCallbackRequest.java
+++ b/src/main/java/server/MATE/toss/dto/request/TossUnlinkCallbackRequest.java
@@ -1,0 +1,10 @@
+package server.MATE.toss.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record TossUnlinkCallbackRequest(
+        @NotNull Long userKey,
+        @NotBlank String referrer
+) {
+}

--- a/src/main/java/server/MATE/toss/service/TossLoginService.java
+++ b/src/main/java/server/MATE/toss/service/TossLoginService.java
@@ -2,28 +2,31 @@ package server.MATE.toss.service;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
+import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.beans.factory.annotation.Value;
 import server.MATE.domain.auth.dto.response.TossLoginResponse;
-import server.MATE.domain.auth.jwt.JwtProvider;
 import server.MATE.domain.auth.jwt.TokenType;
 import server.MATE.domain.auth.crypto.TokenEncryptor;
-import server.MATE.domain.auth.store.TossTokenStore;
+import server.MATE.domain.auth.jwt.JwtProvider;
 import server.MATE.domain.auth.store.UserRefreshTokenStore;
 import server.MATE.domain.users.entity.TossAccount;
-import server.MATE.domain.users.repository.TossAccountRepository;
 import server.MATE.domain.users.dto.response.MeResponse;
 import server.MATE.domain.users.entity.Users;
+import server.MATE.domain.users.repository.TossAccountRepository;
 import server.MATE.domain.users.repository.UsersRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
 import server.MATE.toss.client.login.TossLoginApiClient;
+import server.MATE.domain.users.entity.TossUnlinkReferrer;
 import server.MATE.toss.crypto.TossUserInfoDecryptor;
 import server.MATE.toss.dto.response.TossDecryptedUserInfo;
 import server.MATE.toss.dto.response.TossLoginUserResponse;
@@ -45,12 +48,12 @@ public class TossLoginService {
     private final TossAccountRepository tossAccountRepository;
     private final JwtProvider jwtProvider;
     private final UserRefreshTokenStore userRefreshTokenStore;
-    private final TossTokenStore tossTokenStore;
     private final TokenEncryptor tokenEncryptor;
+    private final TossLoginSessionService tossLoginSessionService;
     private final Clock clock;
 
-    @Value("${toss.token.refresh-cache-ttl}")
-    private long tossRefreshCacheTtlMillis;
+    @Value("${toss.callback.basic-auth-header:}")
+    private String callbackBasicAuthHeader;
 
     public TossLoginResponse login(String authorizationCode, String referrer) {
         TossTokenResponse tossTokenResponse = tossLoginApiClient.generateToken(new TossTokenRequest(authorizationCode, referrer));
@@ -66,7 +69,7 @@ public class TossLoginService {
         UserLoginContext userLoginContext = upsertUser(decryptedUserInfo);
         String encryptedRefreshToken = tokenEncryptor.encrypt(tossTokenResponse.refreshToken());
         syncTossAccount(userLoginContext.user(), decryptedUserInfo, encryptedRefreshToken);
-        cacheTossTokens(userLoginContext.user().getId(), tossTokenResponse);
+        tossLoginSessionService.persistLoginTokens(userLoginContext.user().getId(), tossTokenResponse);
 
         String accessToken = jwtProvider.generateToken(userLoginContext.user().getId(), userLoginContext.user().getRole().name(), TokenType.ACCESS);
         String refreshToken = jwtProvider.generateToken(userLoginContext.user().getId(), userLoginContext.user().getRole().name(), TokenType.REFRESH);
@@ -78,6 +81,104 @@ public class TossLoginService {
                 MeResponse.from(userLoginContext.user()),
                 userLoginContext.isNewUser()
         );
+    }
+
+    public void unlinkCurrentUser(Long userId) {
+        Optional<TossAccount> tossAccountOptional = tossAccountRepository.findByUserId(userId);
+        if (tossAccountOptional.isEmpty()) {
+            log.warn("TOSS_UNLINK linked account not found. userId={}", userId);
+            return;
+        }
+
+        TossAccount tossAccount = tossAccountOptional.get();
+        if (!tossAccount.isLinked()) {
+            log.info("TOSS_UNLINK already unlinked. userId={}, tossUserKey={}", userId, tossAccount.getTossUserKey());
+            return;
+        }
+
+        Optional<String> accessTokenOptional = tossLoginSessionService.getValidAccessToken(userId);
+        if (accessTokenOptional.isPresent()) {
+            try {
+                removeByAccessTokenWithRetry(userId, accessTokenOptional.get());
+            } catch (BaseException e) {
+                if (!isIgnorableUnlinkException(e)) {
+                    throw e;
+                }
+                log.warn("TOSS_UNLINK idempotent success after token validation failure. userId={}, tossUserKey={}, code={}",
+                        userId, tossAccount.getTossUserKey(), e.getErrorCode().getCode());
+            }
+        } else {
+            log.warn("TOSS_UNLINK idempotent success: no toss access/refresh token. userId={}, tossUserKey={}",
+                    userId, tossAccount.getTossUserKey());
+        }
+
+        revokeLinkedState(tossAccount.getUser(), tossAccount, TossUnlinkReferrer.UNLINK);
+    }
+
+    public void unlinkByUserKey(Long userKey, TossUnlinkReferrer referrer) {
+        TossAccount tossAccount = tossAccountRepository.findByTossUserKey(userKey)
+                .orElse(null);
+        if (tossAccount == null) {
+            log.warn("TOSS_UNLINK_BY_USER_KEY linked account not found. userKey={}", userKey);
+            return;
+        }
+
+        if (!tossAccount.isLinked()) {
+            log.info("TOSS_UNLINK_BY_USER_KEY already unlinked. userId={}, tossUserKey={}",
+                    tossAccount.getUser().getId(), userKey);
+            return;
+        }
+
+        try {
+            tossLoginApiClient.removeByUserKey(userKey);
+        } catch (TossApiException e) {
+            if (!isIgnorableUnlinkException(e)) {
+                throw e;
+            }
+            log.warn("TOSS_UNLINK_BY_USER_KEY idempotent success after remote not found. userId={}, tossUserKey={}, code={}",
+                    tossAccount.getUser().getId(), userKey, e.getErrorCode().getCode());
+        }
+        revokeLinkedState(tossAccount.getUser(), tossAccount, referrer);
+    }
+
+    public void handleUnlinkCallback(Long userKey, TossUnlinkReferrer referrer) {
+        TossAccount tossAccount = tossAccountRepository.findByTossUserKey(userKey)
+                .orElse(null);
+        if (tossAccount == null) {
+            log.warn("TOSS_CALLBACK linked account not found. userKey={}, referrer={}", userKey, referrer);
+            return;
+        }
+
+        if (!tossAccount.isLinked()) {
+            log.info("TOSS_CALLBACK already unlinked. userId={}, tossUserKey={}, referrer={}",
+                    tossAccount.getUser().getId(), userKey, referrer);
+            return;
+        }
+
+        revokeLinkedState(tossAccount.getUser(), tossAccount, referrer);
+    }
+
+    public boolean isLinked(Long userId) {
+        return tossAccountRepository.findByUserId(userId)
+                .map(TossAccount::isLinked)
+                .orElse(false);
+    }
+
+    public void validateCallbackAuthorization(String authorization) {
+        String expectedHeader = callbackBasicAuthHeader == null ? "" : callbackBasicAuthHeader.trim();
+        if (expectedHeader.isBlank() || authorization == null || !authorization.startsWith("Basic ")) {
+            throw new BaseException(BaseErrorCode.COMMON_008, "유효하지 않은 토스 연결 해제 콜백 인증입니다.");
+        }
+
+        try {
+            String encodedCredentials = authorization.substring("Basic ".length()).trim();
+            String decodedCredentials = new String(Base64.getDecoder().decode(encodedCredentials), StandardCharsets.UTF_8);
+            if (!expectedHeader.equals(decodedCredentials)) {
+                throw new BaseException(BaseErrorCode.COMMON_008, "유효하지 않은 토스 연결 해제 콜백 인증입니다.");
+            }
+        } catch (IllegalArgumentException e) {
+            throw new BaseException(BaseErrorCode.COMMON_008, "유효하지 않은 토스 연결 해제 콜백 인증입니다.");
+        }
     }
 
     private UserLoginContext upsertUser(TossDecryptedUserInfo decryptedUserInfo) {
@@ -119,17 +220,6 @@ public class TossLoginService {
         );
 
         tossAccountRepository.save(tossAccount);
-    }
-
-    private void cacheTossTokens(Long userId, TossTokenResponse tossTokenResponse) {
-        try {
-            long expiresIn = tossTokenResponse.expiresIn() == null ? 0L : tossTokenResponse.expiresIn();
-            if (expiresIn > 0) tossTokenStore.saveAccessToken(userId, tossTokenResponse.accessToken(), expiresIn * 1000L);
-
-            tossTokenStore.saveRefreshToken(userId, tossTokenResponse.refreshToken(), tossRefreshCacheTtlMillis);
-        } catch (Exception e) {
-            throw new BaseException(BaseErrorCode.AUTH_009, BaseErrorCode.AUTH_009.getMessage(), e);
-        }
     }
 
     private void persistUserRefreshToken(Long userId, String refreshToken) {
@@ -190,6 +280,37 @@ public class TossLoginService {
 
     private Integer safeLength(String value) {
         return value == null ? null : value.length();
+    }
+
+    private void removeByAccessTokenWithRetry(Long userId, String accessToken) {
+        try {
+            tossLoginApiClient.removeByAccessToken(accessToken);
+        } catch (TossApiException e) {
+            if (!isInvalidAccessToken(e)) {
+                throw e;
+            }
+
+            TossTokenResponse refreshed = tossLoginSessionService.refreshLoginTokens(userId);
+            tossLoginApiClient.removeByAccessToken(refreshed.accessToken());
+        }
+    }
+
+    private void revokeLinkedState(Users user, TossAccount tossAccount, TossUnlinkReferrer referrer) {
+        tossLoginSessionService.clearLoginTokens(user.getId());
+        userRefreshTokenStore.delete(user.getId());
+        tossAccount.markUnlinked(referrer, LocalDateTime.now(clock));
+    }
+
+    private boolean isInvalidAccessToken(TossApiException e) {
+        return e.getErrorCode() == TossErrorCode.TOSS_005;
+    }
+
+    private boolean isIgnorableUnlinkException(BaseException e) {
+        return e.getErrorCode() == BaseErrorCode.AUTH_013
+                || e.getErrorCode() == TossErrorCode.TOSS_004
+                || e.getErrorCode() == TossErrorCode.TOSS_005
+                || e.getErrorCode() == TossErrorCode.TOSS_007
+                || e.getErrorCode() == TossErrorCode.TOSS_008;
     }
 
     private record UserLoginContext(Users user, boolean isNewUser) {

--- a/src/main/java/server/MATE/toss/service/TossLoginService.java
+++ b/src/main/java/server/MATE/toss/service/TossLoginService.java
@@ -3,6 +3,7 @@ package server.MATE.toss.service;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Optional;
@@ -173,7 +174,10 @@ public class TossLoginService {
         try {
             String encodedCredentials = authorization.substring("Basic ".length()).trim();
             String decodedCredentials = new String(Base64.getDecoder().decode(encodedCredentials), StandardCharsets.UTF_8);
-            if (!expectedHeader.equals(decodedCredentials)) {
+            if (!MessageDigest.isEqual(
+                    expectedHeader.getBytes(StandardCharsets.UTF_8),
+                    decodedCredentials.getBytes(StandardCharsets.UTF_8)
+            )) {
                 throw new BaseException(BaseErrorCode.COMMON_008, "유효하지 않은 토스 연결 해제 콜백 인증입니다.");
             }
         } catch (IllegalArgumentException e) {

--- a/src/main/java/server/MATE/toss/service/TossLoginService.java
+++ b/src/main/java/server/MATE/toss/service/TossLoginService.java
@@ -173,11 +173,9 @@ public class TossLoginService {
 
         try {
             String encodedCredentials = authorization.substring("Basic ".length()).trim();
-            String decodedCredentials = new String(Base64.getDecoder().decode(encodedCredentials), StandardCharsets.UTF_8);
-            if (!MessageDigest.isEqual(
-                    expectedHeader.getBytes(StandardCharsets.UTF_8),
-                    decodedCredentials.getBytes(StandardCharsets.UTF_8)
-            )) {
+            byte[] decodedBytes = Base64.getDecoder().decode(encodedCredentials);
+            byte[] expectedBytes = expectedHeader.getBytes(StandardCharsets.UTF_8);
+            if (!MessageDigest.isEqual(expectedBytes, decodedBytes)) {
                 throw new BaseException(BaseErrorCode.COMMON_008, "유효하지 않은 토스 연결 해제 콜백 인증입니다.");
             }
         } catch (IllegalArgumentException e) {

--- a/src/main/java/server/MATE/toss/service/TossLoginSessionService.java
+++ b/src/main/java/server/MATE/toss/service/TossLoginSessionService.java
@@ -1,0 +1,100 @@
+package server.MATE.toss.service;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.auth.crypto.TokenEncryptor;
+import server.MATE.domain.auth.store.TossTokenStore;
+import server.MATE.domain.users.entity.TossAccount;
+import server.MATE.domain.users.repository.TossAccountRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+import server.MATE.toss.client.login.TossLoginApiClient;
+import server.MATE.toss.dto.request.TossRefreshTokenRequest;
+import server.MATE.toss.dto.response.TossTokenResponse;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "toss.api", name = "enabled", havingValue = "true")
+public class TossLoginSessionService {
+
+    private final TossLoginApiClient tossLoginApiClient;
+    private final TossAccountRepository tossAccountRepository;
+    private final TossTokenStore tossTokenStore;
+    private final TokenEncryptor tokenEncryptor;
+    private final Clock clock;
+
+    @Value("${toss.token.refresh-cache-ttl}")
+    private long tossRefreshCacheTtlMillis;
+
+    public Optional<String> getValidAccessToken(Long userId) {
+        Optional<String> cachedAccessToken = tossTokenStore.findAccessToken(userId);
+        if (cachedAccessToken.isPresent()) return cachedAccessToken;
+
+        return findRefreshToken(userId)
+                .map(refreshToken -> refreshLoginTokens(userId, refreshToken).accessToken());
+    }
+
+    public TossTokenResponse refreshLoginTokens(Long userId) {
+        String refreshToken = findRefreshToken(userId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.AUTH_013, "토스 refresh token을 찾을 수 없습니다."));
+        return refreshLoginTokens(userId, refreshToken);
+    }
+
+    public void clearLoginTokens(Long userId) {
+        tossTokenStore.deleteAccessToken(userId);
+        tossTokenStore.deleteRefreshToken(userId);
+    }
+
+    private TossTokenResponse refreshLoginTokens(Long userId, String refreshToken) {
+        TossTokenResponse response = tossLoginApiClient.refreshToken(new TossRefreshTokenRequest(refreshToken));
+        persistLoginTokens(userId, response);
+        return response;
+    }
+
+    public void persistLoginTokens(Long userId, TossTokenResponse response) {
+        validateTokenResponse(response);
+
+        try {
+            long expiresInMillis = response.expiresIn() == null ? 0L : response.expiresIn() * 1000L;
+            if (expiresInMillis > 0) tossTokenStore.saveAccessToken(userId, response.accessToken(), expiresInMillis);
+
+            tossTokenStore.saveRefreshToken(userId, response.refreshToken(), tossRefreshCacheTtlMillis);
+
+            TossAccount tossAccount = tossAccountRepository.findByUserId(userId)
+                    .orElseThrow(() -> new BaseException(BaseErrorCode.AUTH_004, "토스 연동 계정을 찾을 수 없습니다."));
+            tossAccount.refreshLoginState(
+                    tokenEncryptor.encrypt(response.refreshToken()),
+                    response.scope(),
+                    LocalDateTime.now(clock)
+            );
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BaseException(BaseErrorCode.AUTH_009, BaseErrorCode.AUTH_009.getMessage(), e);
+        }
+    }
+
+    private Optional<String> findRefreshToken(Long userId) {
+        Optional<String> cachedRefreshToken = tossTokenStore.findRefreshToken(userId);
+        if (cachedRefreshToken.isPresent()) return cachedRefreshToken;
+
+        return tossAccountRepository.findByUserId(userId)
+                .map(TossAccount::getEncryptedTossRefreshToken)
+                .filter(value -> value != null && !value.isBlank())
+                .map(tokenEncryptor::decrypt);
+    }
+
+    private void validateTokenResponse(TossTokenResponse response) {
+        if (response == null || response.accessToken() == null || response.refreshToken() == null) {
+            throw new BaseException(BaseErrorCode.AUTH_008, "토스 토큰 재발급 응답에 필수 값이 누락되었습니다.");
+        }
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,6 +28,8 @@ toss:
     ssl:
       enabled: ${TOSS_API_SSL_ENABLED:true}
       bundle: toss
+  callback:
+    basic-auth-header: ${TOSS_CALLBACK_BASIC_AUTH_HEADER:}
   crypto:
     decryption-key: ${TOSS_CRYPTO_DECRYPTION_KEY:}
     aad: ${TOSS_CRYPTO_AAD:}

--- a/src/test/java/server/MATE/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/server/MATE/domain/auth/controller/AuthControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
@@ -22,6 +23,7 @@ import server.MATE.domain.auth.dto.response.AuthReissueResponse;
 import server.MATE.domain.auth.jwt.TokenType;
 import server.MATE.domain.auth.service.AuthService;
 import server.MATE.domain.users.entity.Role;
+import server.MATE.domain.users.entity.TossUnlinkReferrer;
 import server.MATE.global.common.exception.GlobalExceptionHandler;
 import server.MATE.global.discord.DiscordWebhookNotifier;
 import server.MATE.global.security.principal.AuthenticatedUser;
@@ -29,9 +31,13 @@ import server.MATE.toss.service.TossLoginService;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 @ExtendWith(MockitoExtension.class)
 class AuthControllerTest {
@@ -41,6 +47,9 @@ class AuthControllerTest {
 
     @Mock
     private ObjectProvider<TossLoginService> tossLoginServiceProvider;
+
+    @Mock
+    private TossLoginService tossLoginService;
 
     @Mock
     private DiscordWebhookNotifier discordWebhookNotifier;
@@ -53,6 +62,7 @@ class AuthControllerTest {
 
     @BeforeEach
     void setUp() {
+        ReflectionTestUtils.setField(authController, "tossLoginServiceProvider", tossLoginServiceProvider);
         mockMvc = MockMvcBuilders.standaloneSetup(authController)
                 .setControllerAdvice(new GlobalExceptionHandler(discordWebhookNotifier))
                 .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
@@ -116,8 +126,129 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.field").value("refreshToken"));
     }
 
+    @Test
+    @DisplayName("토스 연결 해제 요청을 정상 처리한다")
+    void handlesTossUnlinkRequestSuccessfully() throws Exception {
+        given(tossLoginServiceProvider.getIfAvailable()).willReturn(tossLoginService);
+
+        mockMvc.perform(post("/api/v1/auth/toss/unlink")
+                        .with(authenticationPrincipal()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("토스 연결이 해제되었습니다."));
+
+        verify(tossLoginService).unlinkCurrentUser(1L);
+    }
+
+    @Test
+    @DisplayName("userKey 기준 토스 연결 해제 요청을 정상 처리한다")
+    void handlesTossUnlinkByUserKeySuccessfully() throws Exception {
+        given(tossLoginServiceProvider.getIfAvailable()).willReturn(tossLoginService);
+
+        mockMvc.perform(post("/api/v1/auth/toss/unlink/by-user-key")
+                        .with(adminAuthenticationPrincipal())
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "userKey": 443731103
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("토스 연결이 해제되었습니다."));
+
+        verify(tossLoginService).unlinkByUserKey(443731103L, TossUnlinkReferrer.UNLINK);
+    }
+
+    @Test
+    @DisplayName("일반 사용자가 userKey 기준 토스 연결 해제 요청을 하면 403을 반환한다")
+    void returnsForbiddenWhenNonAdminRequestsUnlinkByUserKey() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/toss/unlink/by-user-key")
+                        .with(authenticationPrincipal())
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "userKey": 443731103
+                                }
+                                """))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("COMMON_009"));
+    }
+
+    @Test
+    @DisplayName("토스 연동 상태 조회 요청을 정상 처리한다")
+    void handlesTossIntegrationStatusRequestSuccessfully() throws Exception {
+        given(tossLoginServiceProvider.getIfAvailable()).willReturn(tossLoginService);
+        given(tossLoginService.isLinked(1L)).willReturn(true);
+
+        mockMvc.perform(get("/api/v1/auth/toss/integration-status")
+                .with(authenticationPrincipal()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("토스 연동 상태를 조회했습니다."))
+                .andExpect(jsonPath("$.data.isLinked").value(true));
+    }
+
+    @Test
+    @DisplayName("GET 연결 해제 콜백을 정상 처리한다")
+    void handlesGetCallbackSuccessfully() throws Exception {
+        given(tossLoginServiceProvider.getIfAvailable()).willReturn(tossLoginService);
+
+        mockMvc.perform(get("/api/v1/auth/toss/login/unlink/callback")
+                        .header("Authorization", basicAuthHeader())
+                        .param("userKey", "443731103")
+                        .param("referrer", "UNLINK"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(tossLoginService).validateCallbackAuthorization(basicAuthHeader());
+        verify(tossLoginService).handleUnlinkCallback(443731103L, server.MATE.domain.users.entity.TossUnlinkReferrer.UNLINK);
+    }
+
+    @Test
+    @DisplayName("POST 연결 해제 콜백을 정상 처리한다")
+    void handlesPostCallbackSuccessfully() throws Exception {
+        given(tossLoginServiceProvider.getIfAvailable()).willReturn(tossLoginService);
+
+        mockMvc.perform(post("/api/v1/auth/toss/login/unlink/callback")
+                        .header("Authorization", basicAuthHeader())
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "userKey": 443731103,
+                                  "referrer": "WITHDRAWAL_TOSS"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(tossLoginService).validateCallbackAuthorization(basicAuthHeader());
+        verify(tossLoginService).handleUnlinkCallback(443731103L, server.MATE.domain.users.entity.TossUnlinkReferrer.WITHDRAWAL_TOSS);
+    }
+
+    @Test
+    @DisplayName("콜백 인증이 올바르지 않으면 401을 반환한다")
+    void returnsUnauthorizedWhenCallbackAuthorizationIsInvalid() throws Exception {
+        given(tossLoginServiceProvider.getIfAvailable()).willReturn(tossLoginService);
+        org.mockito.Mockito.doThrow(new server.MATE.global.common.exception.BaseException(server.MATE.global.common.exception.BaseErrorCode.COMMON_008))
+                .when(tossLoginService)
+                .validateCallbackAuthorization("Basic invalid");
+
+        mockMvc.perform(get("/api/v1/auth/toss/login/unlink/callback")
+                        .header("Authorization", "Basic invalid")
+                        .param("userKey", "443731103")
+                        .param("referrer", "UNLINK"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("COMMON_008"));
+    }
+
     private UsernamePasswordAuthenticationToken authentication() {
         AuthenticatedUser user = new AuthenticatedUser(1L, Role.USER, TokenType.ACCESS);
+        return new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+    }
+
+    private UsernamePasswordAuthenticationToken adminAuthentication() {
+        AuthenticatedUser user = new AuthenticatedUser(99L, Role.ADMIN, TokenType.ACCESS);
         return new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
     }
 
@@ -132,5 +263,23 @@ class AuthControllerTest {
             request.setUserPrincipal(authentication());
             return request;
         };
+    }
+
+    private RequestPostProcessor adminAuthenticationPrincipal() {
+        RequestPostProcessor delegate =
+                SecurityMockMvcRequestPostProcessors.authentication(adminAuthentication());
+        return request -> {
+            delegate.postProcessRequest(request);
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(adminAuthentication());
+            SecurityContextHolder.setContext(context);
+            request.setUserPrincipal(adminAuthentication());
+            return request;
+        };
+    }
+
+    private String basicAuthHeader() {
+        String value = "callback-user:callback-pass";
+        return "Basic " + Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -24,3 +24,10 @@ jwt:
 toss:
   api:
     enabled: false
+  crypto:
+    decryption-key: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
+    aad: test-aad
+
+security:
+  token-encryption:
+    key: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=


### PR DESCRIPTION
## 📍 요약
- 토스 로그인 연결 해제 API와 연결 해제 콜백을 구현하고, 토스 로그인 세션 재발급 흐름까지 포함한 연동 상태 관리 구조를 확장 설계함

## 🔗 관련 이슈
- Closes #83 

## 📌 변경 사항
- [x] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
#### 1. 로그인 연결 해제 및 콜백 API 구현
- 토스 앱에서 연결 해제되면 서비스 세션도 종료되어 재로그인이 필요하다는 동작 기준 반영
- 토스 시스템용 연결 해제 콜백 API 추가 (프론트 요청용이 아닌 운영용 콜백용)
- userKey 기준 연결 해제 API 추가
   - 운영/관리/보정용으로 분리
   - 관리자 권한만 호출 가능하도록 제한

#### 2. 토스 로그인 세션 재발급 구조
- TossLoginSessionService 추가
   - Redis access 토큰 조회
   - access 토큰이 없을 때 refresh 토큰 으로 재발급
   - 재발급 성공 시 Redis/DB 토큰 상태 갱신
- 로그인 연결 해제 시 토스 access 토큰이 없더라도 refresh 토큰이 남아 있으면 복구 후 해제할 수 있도록 처리
- 토스 access/refresh token이 모두 없는 경우에는 멱등 성공으로 처리하되 경고 로그를 남기도록 정리

#### 3. 토스 연동 상태 검증
- TossAccount에 토스 연동 상태 필드 추가: `isLinked`, `unlinkedAt`, `unlinkReferrer`
- 연결 상태 전이 메서드 구현
   - 로그인 성공 시 linked 상태 복구
   - unlink/callback api 요청 시 unlinked 상태 기록
- unlinkReferrer는 토스 기준 enum으로 정리: `UNLINK`, `WITHDRAWAL_TERMS`, `WITHDRAWAL_TOSS`, `UNKNOWN`

#### 4. 토큰/세션 정리 정책 반영
- 토스 unlink 및 callback 처리 시 **공통 revoke 후처리** 추가
   - Redis의 toss access 토큰 삭제
   - Redis의 toss refresh 토큰 삭제
   - DB의 encryptedTossRefreshToken 제거
   - TossAccount unlink 상태 반영
   - Mate refresh 토큰 삭제
- access token blacklist는 도입하지 않고, **refresh 토큰 revoke 기준으로 세션 종료 정책 유지**

#### 5. 프론트 보조 API 및 내부 구조 정리
- 토스 연동 상태 조회 API 추가
   - 응답은 isLinked 기준으로 반환
- 토스 unlink, callback, userKey unlink 흐름을 TossLoginService로 통합

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - 로컬에서 토스 로그인 후 실제 API 호출 확인
  - Redis/DB 상태 확인
     - 로그인 직후 `auth:toss:access:{userId}`, `auth:toss:refresh:{userId}` 적재 확인
     - unlink/callback 후 Redis 토큰 키 삭제 확인
     - toss_accounts.is_linked, unlink_referrer, unlinked_at, encrypted_toss_refresh_token 변경 확인
  - refresh 경로 수동 검증
     - redis에서 `auth:toss:access:{userId}`만 삭제
     - 토스 연결 해제 api 호출
     - refresh 토큰 기반 복구 후 unlink 성공 및 최종 cleanup 확인
