### PR TITLE
test: 토스 인증 API 관련 보안 검증 보완

### DIFF
--- a/src/main/java/server/MATE/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/server/MATE/global/common/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -64,6 +65,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of(BaseErrorCode.COMMON_002, message, field));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        log.warn("MissingServletRequestParameterException: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of(BaseErrorCode.COMMON_004));
     }
 
     @ExceptionHandler(ConstraintViolationException.class)

--- a/src/main/java/server/MATE/toss/client/http/TossHttpClient.java
+++ b/src/main/java/server/MATE/toss/client/http/TossHttpClient.java
@@ -2,6 +2,7 @@ package server.MATE.toss.client.http;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.function.Consumer;
 
 import com.fasterxml.jackson.databind.JavaType;
@@ -43,7 +44,7 @@ public class TossHttpClient {
     }
 
     public <T> T get(String path, Consumer<HttpHeaders> headersConsumer, Class<T> responseType) {
-        String responseBody = tossWebClient.get()
+        String responseBody = execute(path, () -> tossWebClient.get()
                 .uri(path)
                 .headers(headersConsumer)
                 .retrieve()
@@ -51,7 +52,7 @@ public class TossHttpClient {
                         .defaultIfEmpty("")
                         .flatMap(body -> Mono.error(toException(response.statusCode(), path, body))))
                 .bodyToMono(String.class)
-                .block();
+                .block());
 
         return unwrapSuccess(path, responseBody, responseType);
     }
@@ -75,7 +76,7 @@ public class TossHttpClient {
             Consumer<HttpHeaders> headersConsumer,
             Class<T> responseType
     ) {
-        String responseBody = tossWebClient.post()
+        String responseBody = execute(path, () -> tossWebClient.post()
                 .uri(path)
                 .contentType(MediaType.APPLICATION_JSON)
                 .headers(headersConsumer)
@@ -85,9 +86,19 @@ public class TossHttpClient {
                         .defaultIfEmpty("")
                         .flatMap(body -> Mono.error(toException(response.statusCode(), path, body))))
                 .bodyToMono(String.class)
-                .block();
+                .block());
 
         return unwrapSuccess(path, responseBody, responseType);
+    }
+
+    private String execute(String path, Supplier<String> requestSupplier) {
+        try {
+            return requestSupplier.get();
+        } catch (TossApiException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw toNetworkException(path, e);
+        }
     }
 
     private <T> T unwrapSuccess(String path, String responseBody, Class<T> responseType) {
@@ -117,5 +128,14 @@ public class TossHttpClient {
                 .findFirst()
                 .orElseThrow();
         return TossApiException.from(statusCode, parser.parse(statusCode, path, responseBody), responseBody);
+    }
+
+    private TossApiException toNetworkException(String path, RuntimeException cause) {
+        return new TossApiException(
+                TossErrorCode.TOSS_001,
+                "토스 API 호출에 실패했습니다. path=" + path,
+                null,
+                cause
+        );
     }
 }

--- a/src/main/java/server/MATE/toss/exception/TossApiException.java
+++ b/src/main/java/server/MATE/toss/exception/TossApiException.java
@@ -36,4 +36,11 @@ public class TossApiException extends BaseException {
         this.error = null;
         this.responseBody = responseBody;
     }
+
+    public TossApiException(TossErrorCode errorCode, String message, String responseBody, Throwable cause) {
+        super(errorCode, message, cause);
+        this.statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
+        this.error = null;
+        this.responseBody = responseBody;
+    }
 }

--- a/src/test/java/server/MATE/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/server/MATE/domain/auth/controller/AuthControllerTest.java
@@ -19,9 +19,11 @@ import org.springframework.security.web.method.annotation.AuthenticationPrincipa
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import server.MATE.domain.auth.dto.response.TossLoginResponse;
 import server.MATE.domain.auth.dto.response.AuthReissueResponse;
 import server.MATE.domain.auth.jwt.TokenType;
 import server.MATE.domain.auth.service.AuthService;
+import server.MATE.domain.users.dto.response.MeResponse;
 import server.MATE.domain.users.entity.Role;
 import server.MATE.domain.users.entity.TossUnlinkReferrer;
 import server.MATE.global.common.exception.GlobalExceptionHandler;
@@ -73,6 +75,69 @@ class AuthControllerTest {
     @org.junit.jupiter.api.AfterEach
     void clearSecurityContext() {
         SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("토스 로그인 요청을 정상 처리한다")
+    void handlesTossLoginRequestSuccessfully() throws Exception {
+        given(tossLoginServiceProvider.getIfAvailable()).willReturn(tossLoginService);
+        given(tossLoginService.login("authorization-code", "APP"))
+                .willReturn(new TossLoginResponse(
+                        "mate-access",
+                        "mate-refresh",
+                        MeResponse.of(1L, "tester", Role.USER),
+                        true
+                ));
+
+        mockMvc.perform(post("/api/v1/auth/toss/login")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "authorizationCode": "authorization-code",
+                                  "referrer": "APP"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("토스 로그인이 완료되었습니다."))
+                .andExpect(jsonPath("$.data.accessToken").value("mate-access"))
+                .andExpect(jsonPath("$.data.refreshToken").value("mate-refresh"))
+                .andExpect(jsonPath("$.data.meResponse.id").value(1L))
+                .andExpect(jsonPath("$.data.isNewUser").value(true));
+    }
+
+    @Test
+    @DisplayName("토스 로그인 요청에서 authorizationCode가 비어 있으면 400을 반환한다")
+    void returnsBadRequestWhenAuthorizationCodeIsBlank() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/toss/login")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "authorizationCode": "",
+                                  "referrer": "APP"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("COMMON_002"))
+                .andExpect(jsonPath("$.field").value("authorizationCode"));
+    }
+
+    @Test
+    @DisplayName("토스 로그인 요청에서 referrer가 비어 있으면 400을 반환한다")
+    void returnsBadRequestWhenReferrerIsBlank() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/toss/login")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "authorizationCode": "authorization-code",
+                                  "referrer": ""
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("COMMON_002"))
+                .andExpect(jsonPath("$.field").value("referrer"));
     }
 
     @Test
@@ -190,6 +255,19 @@ class AuthControllerTest {
     }
 
     @Test
+    @DisplayName("토스 연동 상태가 false이면 false를 반환한다")
+    void handlesTossIntegrationStatusRequestWhenUnlinked() throws Exception {
+        given(tossLoginServiceProvider.getIfAvailable()).willReturn(tossLoginService);
+        given(tossLoginService.isLinked(1L)).willReturn(false);
+
+        mockMvc.perform(get("/api/v1/auth/toss/integration-status")
+                        .with(authenticationPrincipal()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.isLinked").value(false));
+    }
+
+    @Test
     @DisplayName("GET 연결 해제 콜백을 정상 처리한다")
     void handlesGetCallbackSuccessfully() throws Exception {
         given(tossLoginServiceProvider.getIfAvailable()).willReturn(tossLoginService);
@@ -240,6 +318,33 @@ class AuthControllerTest {
                         .param("referrer", "UNLINK"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("COMMON_008"));
+    }
+
+    @Test
+    @DisplayName("GET 연결 해제 콜백에서 userKey가 누락되면 400을 반환한다")
+    void returnsBadRequestWhenCallbackUserKeyMissing() throws Exception {
+        mockMvc.perform(get("/api/v1/auth/toss/login/unlink/callback")
+                        .header("Authorization", basicAuthHeader())
+                        .param("referrer", "UNLINK"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMON_004"));
+    }
+
+    @Test
+    @DisplayName("POST 연결 해제 콜백에서 referrer가 비어 있으면 400을 반환한다")
+    void returnsBadRequestWhenCallbackReferrerBlank() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/toss/login/unlink/callback")
+                        .header("Authorization", basicAuthHeader())
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "userKey": 443731103,
+                                  "referrer": ""
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMON_002"))
+                .andExpect(jsonPath("$.field").value("referrer"));
     }
 
     private UsernamePasswordAuthenticationToken authentication() {

--- a/src/test/java/server/MATE/domain/auth/crypto/TokenEncryptorTest.java
+++ b/src/test/java/server/MATE/domain/auth/crypto/TokenEncryptorTest.java
@@ -1,0 +1,47 @@
+package server.MATE.domain.auth.crypto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+class TokenEncryptorTest {
+
+    private static final String VALID_BASE64_KEY = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
+
+    @Test
+    @DisplayName("encrypt/decrypt roundtrip이 동작한다")
+    void encryptsAndDecryptsRoundTrip() {
+        TokenEncryptor tokenEncryptor = new TokenEncryptor(new TokenEncryptionProperties(VALID_BASE64_KEY));
+
+        String encrypted = tokenEncryptor.encrypt("refresh-token-value");
+        String decrypted = tokenEncryptor.decrypt(encrypted);
+
+        assertThat(encrypted).isNotEqualTo("refresh-token-value");
+        assertThat(decrypted).isEqualTo("refresh-token-value");
+    }
+
+    @Test
+    @DisplayName("잘못된 ciphertext는 AUTH_012 예외를 던진다")
+    void throwsWhenCiphertextInvalid() {
+        TokenEncryptor tokenEncryptor = new TokenEncryptor(new TokenEncryptionProperties(VALID_BASE64_KEY));
+
+        assertThatThrownBy(() -> tokenEncryptor.decrypt("not-base64"))
+                .isInstanceOf(BaseException.class)
+                .extracting(exception -> ((BaseException) exception).getErrorCode())
+                .isEqualTo(BaseErrorCode.AUTH_012);
+    }
+
+    @Test
+    @DisplayName("key가 비어 있으면 AUTH_010 예외를 던진다")
+    void throwsWhenKeyMissing() {
+        assertThatThrownBy(() -> new TokenEncryptor(new TokenEncryptionProperties(" ")))
+                .isInstanceOf(BaseException.class)
+                .extracting(exception -> ((BaseException) exception).getErrorCode())
+                .isEqualTo(BaseErrorCode.AUTH_010);
+    }
+}

--- a/src/test/java/server/MATE/domain/auth/store/RedisTokenStoreContextTest.java
+++ b/src/test/java/server/MATE/domain/auth/store/RedisTokenStoreContextTest.java
@@ -1,0 +1,100 @@
+package server.MATE.domain.auth.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import server.MATE.domain.auth.crypto.TokenEncryptionProperties;
+import server.MATE.domain.auth.crypto.TokenEncryptor;
+
+@SpringBootTest(classes = RedisTokenStoreContextTest.TestConfig.class)
+class RedisTokenStoreContextTest {
+
+    private static final String VALID_BASE64_KEY = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
+
+    @TestConfiguration
+    @Import({
+            RedisTossTokenStore.class,
+            RedisUserRefreshTokenStore.class,
+            TokenEncryptor.class
+    })
+    static class TestConfig {
+
+        @Bean
+        TokenEncryptionProperties tokenEncryptionProperties() {
+            return new TokenEncryptionProperties(VALID_BASE64_KEY);
+        }
+    }
+
+    @MockitoBean
+    private StringRedisTemplate redisTemplate;
+
+    @MockitoBean
+    @SuppressWarnings("unchecked")
+    private ValueOperations<String, String> valueOperations;
+
+    @Autowired
+    private RedisTossTokenStore redisTossTokenStore;
+
+    @Autowired
+    private RedisUserRefreshTokenStore redisUserRefreshTokenStore;
+
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    @DisplayName("RedisTossTokenStore는 access token key와 TTL을 예상한 방식으로 사용한다")
+    void savesAccessTokenWithExpectedKeyAndTtl() {
+        redisTossTokenStore.saveAccessToken(1L, "access-token", 123_000L);
+
+        verify(valueOperations).set("auth:toss:access:1", "access-token", 123_000L, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    @DisplayName("RedisTossTokenStore는 refresh token을 암호화해서 저장하고 복호화해서 조회한다")
+    void savesEncryptedRefreshTokenAndFindsDecryptedValue() {
+        redisTossTokenStore.saveRefreshToken(1L, "refresh-token", 456_000L);
+
+        org.mockito.ArgumentCaptor<String> storedValue = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(valueOperations).set(
+                org.mockito.ArgumentMatchers.eq("auth:toss:refresh:1"),
+                storedValue.capture(),
+                org.mockito.ArgumentMatchers.eq(456_000L),
+                org.mockito.ArgumentMatchers.eq(TimeUnit.MILLISECONDS)
+        );
+
+        assertThat(storedValue.getValue()).isNotEqualTo("refresh-token");
+        when(valueOperations.get("auth:toss:refresh:1")).thenReturn(storedValue.getValue());
+
+        Optional<String> foundRefreshToken = redisTossTokenStore.findRefreshToken(1L);
+
+        assertThat(foundRefreshToken).contains("refresh-token");
+    }
+
+    @Test
+    @DisplayName("RedisUserRefreshTokenStore는 사용자 refresh token key와 TTL을 예상한 방식으로 사용한다")
+    void savesUserRefreshTokenWithExpectedKeyAndTtl() {
+        redisUserRefreshTokenStore.save(1L, "mate-refresh-token", 789_000L);
+
+        verify(valueOperations).set("auth:refresh:token:1", "mate-refresh-token", 789_000L, TimeUnit.MILLISECONDS);
+    }
+}

--- a/src/test/java/server/MATE/domain/auth/store/RedisTossTokenStoreTest.java
+++ b/src/test/java/server/MATE/domain/auth/store/RedisTossTokenStoreTest.java
@@ -1,0 +1,101 @@
+package server.MATE.domain.auth.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import server.MATE.domain.auth.crypto.TokenEncryptionProperties;
+import server.MATE.domain.auth.crypto.TokenEncryptor;
+
+@ExtendWith(MockitoExtension.class)
+class RedisTossTokenStoreTest {
+
+    private static final String VALID_BASE64_KEY = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private RedisTossTokenStore redisTossTokenStore;
+
+    @BeforeEach
+    void setUp() {
+        org.mockito.Mockito.lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        redisTossTokenStore = new RedisTossTokenStore(redisTemplate, new TokenEncryptor(new TokenEncryptionProperties(VALID_BASE64_KEY)));
+    }
+
+    @Test
+    @DisplayName("access token은 평문으로 조회된다")
+    void savesAndFindsAccessTokenAsPlainText() {
+        redisTossTokenStore.saveAccessToken(1L, "plain-access", 300_000L);
+        when(valueOperations.get("auth:toss:access:1")).thenReturn("plain-access");
+
+        Optional<String> result = redisTossTokenStore.findAccessToken(1L);
+
+        verify(valueOperations).set("auth:toss:access:1", "plain-access", 300_000L, TimeUnit.MILLISECONDS);
+        assertThat(result).contains("plain-access");
+    }
+
+    @Test
+    @DisplayName("refresh token은 Redis raw value가 평문과 다르게 저장되고 조회 시 복호화된다")
+    void storesEncryptedRefreshTokenAndDecryptsWhenFinding() {
+        redisTossTokenStore.saveRefreshToken(1L, "plain-refresh", 600_000L);
+
+        ArgumentCaptor<String> valueCaptor = ArgumentCaptor.forClass(String.class);
+        verify(valueOperations).set(
+                org.mockito.ArgumentMatchers.eq("auth:toss:refresh:1"),
+                valueCaptor.capture(),
+                org.mockito.ArgumentMatchers.eq(600_000L),
+                org.mockito.ArgumentMatchers.eq(TimeUnit.MILLISECONDS)
+        );
+
+        String rawStoredValue = valueCaptor.getValue();
+        assertThat(rawStoredValue).isNotEqualTo("plain-refresh");
+
+        when(valueOperations.get("auth:toss:refresh:1")).thenReturn(rawStoredValue);
+
+        Optional<String> result = redisTossTokenStore.findRefreshToken(1L);
+
+        assertThat(result).contains("plain-refresh");
+    }
+
+    @Test
+    @DisplayName("access/refresh token 삭제가 정상 동작한다")
+    void deletesAccessAndRefreshTokens() {
+        redisTossTokenStore.deleteAccessToken(1L);
+        redisTossTokenStore.deleteRefreshToken(1L);
+
+        verify(redisTemplate).delete("auth:toss:access:1");
+        verify(redisTemplate).delete("auth:toss:refresh:1");
+    }
+
+    @Test
+    @DisplayName("TTL이 저장 시 반영된다")
+    void appliesTtlWhenSavingTokens() {
+        redisTossTokenStore.saveAccessToken(1L, "plain-access", 123_000L);
+        redisTossTokenStore.saveRefreshToken(1L, "plain-refresh", 456_000L);
+
+        verify(valueOperations).set("auth:toss:access:1", "plain-access", 123_000L, TimeUnit.MILLISECONDS);
+        verify(valueOperations).set(
+                org.mockito.ArgumentMatchers.eq("auth:toss:refresh:1"),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.eq(456_000L),
+                org.mockito.ArgumentMatchers.eq(TimeUnit.MILLISECONDS)
+        );
+    }
+}

--- a/src/test/java/server/MATE/toss/client/http/TossHttpClientTest.java
+++ b/src/test/java/server/MATE/toss/client/http/TossHttpClientTest.java
@@ -125,13 +125,18 @@ class TossHttpClientTest {
     }
 
     @Test
-    @DisplayName("네트워크 예외는 현재 구현 기준으로 그대로 전파된다")
-    void propagatesNetworkExceptionAsIs() {
+    @DisplayName("네트워크 예외는 TOSS_001 TossApiException으로 변환한다")
+    void convertsNetworkExceptionToToss001() {
         TossHttpClient tossHttpClient = createClient(request -> Mono.error(new IllegalStateException("network failure")));
 
         assertThatThrownBy(() -> tossHttpClient.get("/api-partner/v1/apps-in-toss/user/oauth2/login-me", TossTokenResponse.class))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("network failure");
+                .isInstanceOf(TossApiException.class)
+                .satisfies(exception -> {
+                    TossApiException tossApiException = (TossApiException) exception;
+                    assertThat(tossApiException.getErrorCode()).isEqualTo(TossErrorCode.TOSS_001);
+                    assertThat(tossApiException.getCause()).isInstanceOf(IllegalStateException.class);
+                    assertThat(tossApiException.getCause()).hasMessage("network failure");
+                });
     }
 
     private TossHttpClient createClient(ExchangeFunction exchangeFunction) {

--- a/src/test/java/server/MATE/toss/client/http/TossHttpClientTest.java
+++ b/src/test/java/server/MATE/toss/client/http/TossHttpClientTest.java
@@ -1,0 +1,154 @@
+package server.MATE.toss.client.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import reactor.core.publisher.Mono;
+import server.MATE.toss.dto.response.TossTokenResponse;
+import server.MATE.toss.exception.TossApiException;
+import server.MATE.toss.exception.TossErrorCode;
+import server.MATE.toss.exception.parser.TossLoginErrorResponseParser;
+
+class TossHttpClientTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("success wrapper를 정상 unwrap 한다")
+    void unwrapsSuccessResponse() {
+        TossHttpClient tossHttpClient = createClient(request -> Mono.just(jsonResponse(
+                HttpStatus.OK,
+                """
+                {
+                  "resultType": "SUCCESS",
+                  "success": {
+                    "tokenType": "Bearer",
+                    "accessToken": "access-token",
+                    "refreshToken": "refresh-token",
+                    "expiresIn": 3600,
+                    "scope": "user_ci"
+                  }
+                }
+                """
+        )));
+
+        TossTokenResponse response = tossHttpClient.post("/api-partner/v1/apps-in-toss/user/oauth2/generate-token", java.util.Map.of(), TossTokenResponse.class);
+
+        assertThat(response.accessToken()).isEqualTo("access-token");
+        assertThat(response.refreshToken()).isEqualTo("refresh-token");
+    }
+
+    @Test
+    @DisplayName("FAIL wrapper는 TossApiException으로 변환한다")
+    void convertsFailWrapperToTossApiException() {
+        TossHttpClient tossHttpClient = createClient(request -> Mono.just(jsonResponse(
+                HttpStatus.OK,
+                """
+                {
+                  "resultType": "FAIL",
+                  "error": {
+                    "errorCode": "INVALID_ACCESS_TOKEN",
+                    "reason": "access token이 유효하지 않습니다."
+                  }
+                }
+                """
+        )));
+
+        assertThatThrownBy(() -> tossHttpClient.get("/api-partner/v1/apps-in-toss/user/oauth2/login-me", TossTokenResponse.class))
+                .isInstanceOf(TossApiException.class)
+                .extracting(exception -> ((TossApiException) exception).getErrorCode())
+                .isEqualTo(TossErrorCode.TOSS_005);
+    }
+
+    @Test
+    @DisplayName("malformed success body는 TOSS_002로 변환한다")
+    void convertsMalformedSuccessBodyToToss002() {
+        TossHttpClient tossHttpClient = createClient(request -> Mono.just(jsonResponse(HttpStatus.OK, "not-json")));
+
+        assertThatThrownBy(() -> tossHttpClient.get("/api-partner/v1/apps-in-toss/user/oauth2/login-me", TossTokenResponse.class))
+                .isInstanceOf(TossApiException.class)
+                .extracting(exception -> ((TossApiException) exception).getErrorCode())
+                .isEqualTo(TossErrorCode.TOSS_002);
+    }
+
+    @Test
+    @DisplayName("4xx error body는 parser를 통해 TossApiException으로 변환한다")
+    void converts4xxErrorResponseToTossApiException() {
+        TossHttpClient tossHttpClient = createClient(request -> Mono.just(jsonResponse(
+                HttpStatus.BAD_REQUEST,
+                """
+                {
+                  "error": "invalid_grant"
+                }
+                """
+        )));
+
+        assertThatThrownBy(() -> tossHttpClient.post("/api-partner/v1/apps-in-toss/user/oauth2/refresh-token", java.util.Map.of(), TossTokenResponse.class))
+                .isInstanceOf(TossApiException.class)
+                .extracting(exception -> ((TossApiException) exception).getErrorCode())
+                .isEqualTo(TossErrorCode.TOSS_004);
+    }
+
+    @Test
+    @DisplayName("5xx error body는 parser를 통해 TossApiException으로 변환한다")
+    void converts5xxErrorResponseToTossApiException() {
+        TossHttpClient tossHttpClient = createClient(request -> Mono.just(jsonResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                """
+                {
+                  "error": {
+                    "errorCode": "INTERNAL_ERROR",
+                    "reason": "토스 내부 오류"
+                  }
+                }
+                """
+        )));
+
+        assertThatThrownBy(() -> tossHttpClient.get("/api-partner/v1/apps-in-toss/user/oauth2/login-me", TossTokenResponse.class))
+                .isInstanceOf(TossApiException.class)
+                .extracting(exception -> ((TossApiException) exception).getErrorCode())
+                .isEqualTo(TossErrorCode.TOSS_006);
+    }
+
+    @Test
+    @DisplayName("네트워크 예외는 현재 구현 기준으로 그대로 전파된다")
+    void propagatesNetworkExceptionAsIs() {
+        TossHttpClient tossHttpClient = createClient(request -> Mono.error(new IllegalStateException("network failure")));
+
+        assertThatThrownBy(() -> tossHttpClient.get("/api-partner/v1/apps-in-toss/user/oauth2/login-me", TossTokenResponse.class))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("network failure");
+    }
+
+    private TossHttpClient createClient(ExchangeFunction exchangeFunction) {
+        WebClient webClient = WebClient.builder()
+                .exchangeFunction(exchangeFunction)
+                .build();
+        return new TossHttpClient(
+                webClient,
+                objectMapper,
+                List.of(new TossLoginErrorResponseParser(objectMapper))
+        );
+    }
+
+    private ClientResponse jsonResponse(HttpStatus status, String body) {
+        return ClientResponse.create(status)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .body(body)
+                .build();
+    }
+}

--- a/src/test/java/server/MATE/toss/crypto/TossUserInfoDecryptorTest.java
+++ b/src/test/java/server/MATE/toss/crypto/TossUserInfoDecryptorTest.java
@@ -1,0 +1,105 @@
+package server.MATE.toss.crypto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+import server.MATE.toss.dto.response.TossDecryptedUserInfo;
+import server.MATE.toss.dto.response.TossLoginUserResponse;
+
+class TossUserInfoDecryptorTest {
+
+    private static final String VALID_BASE64_KEY = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
+    private static final String VALID_AAD = "test-aad";
+    private static final int IV_LENGTH = 12;
+    private static final int AUTH_TAG_LENGTH_BITS = 16 * Byte.SIZE;
+
+    @Test
+    @DisplayName("ci/name 복호화가 정상 동작한다")
+    void decryptsCiAndNameSuccessfully() throws Exception {
+        TossUserInfoDecryptor decryptor = new TossUserInfoDecryptor(new TossCryptoProperties(VALID_BASE64_KEY, VALID_AAD));
+        TossLoginUserResponse response = new TossLoginUserResponse(
+                777L,
+                "user_ci,name",
+                encrypt("tester"),
+                encrypt("ci-value")
+        );
+
+        TossDecryptedUserInfo decrypted = decryptor.decrypt(response);
+
+        assertThat(decrypted.userKey()).isEqualTo(777L);
+        assertThat(decrypted.scope()).isEqualTo("user_ci,name");
+        assertThat(decrypted.name()).isEqualTo("tester");
+        assertThat(decrypted.ci()).isEqualTo("ci-value");
+    }
+
+    @Test
+    @DisplayName("ci 복호화 결과가 비어 있으면 AUTH_008 예외를 던진다")
+    void throwsWhenCiMissingAfterDecrypt() {
+        TossUserInfoDecryptor decryptor = new TossUserInfoDecryptor(new TossCryptoProperties(VALID_BASE64_KEY, VALID_AAD));
+        TossLoginUserResponse response = new TossLoginUserResponse(777L, "user_ci", encryptQuietly("tester"), null);
+
+        assertThatThrownBy(() -> decryptor.decrypt(response))
+                .isInstanceOf(BaseException.class)
+                .extracting(exception -> ((BaseException) exception).getErrorCode())
+                .isEqualTo(BaseErrorCode.AUTH_008);
+    }
+
+    @Test
+    @DisplayName("잘못된 암호문은 AUTH_007 예외를 던진다")
+    void throwsWhenCipherTextInvalid() {
+        TossUserInfoDecryptor decryptor = new TossUserInfoDecryptor(new TossCryptoProperties(VALID_BASE64_KEY, VALID_AAD));
+        TossLoginUserResponse response = new TossLoginUserResponse(777L, "user_ci", "not-base64", encryptQuietly("ci-value"));
+
+        assertThatThrownBy(() -> decryptor.decrypt(response))
+                .isInstanceOf(BaseException.class)
+                .extracting(exception -> ((BaseException) exception).getErrorCode())
+                .isEqualTo(BaseErrorCode.AUTH_007);
+    }
+
+    @Test
+    @DisplayName("필수 암복호화 설정이 없으면 AUTH_006 예외를 던진다")
+    void throwsWhenCryptoPropertiesMissing() {
+        assertThatThrownBy(() -> new TossUserInfoDecryptor(new TossCryptoProperties(null, null)))
+                .isInstanceOf(BaseException.class)
+                .extracting(exception -> ((BaseException) exception).getErrorCode())
+                .isEqualTo(BaseErrorCode.AUTH_006);
+    }
+
+    private String encryptQuietly(String plainText) {
+        try {
+            return encrypt(plainText);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String encrypt(String plainText) throws Exception {
+        byte[] keyBytes = Base64.getDecoder().decode(VALID_BASE64_KEY);
+        SecretKeySpec keySpec = new SecretKeySpec(keyBytes, "AES");
+        byte[] iv = new byte[IV_LENGTH];
+        new SecureRandom().nextBytes(iv);
+
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, new GCMParameterSpec(AUTH_TAG_LENGTH_BITS, iv));
+        cipher.updateAAD(VALID_AAD.getBytes(StandardCharsets.UTF_8));
+
+        byte[] encrypted = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+        byte[] combined = new byte[iv.length + encrypted.length];
+        System.arraycopy(iv, 0, combined, 0, iv.length);
+        System.arraycopy(encrypted, 0, combined, iv.length, encrypted.length);
+        return Base64.getEncoder().encodeToString(combined);
+    }
+}

--- a/src/test/java/server/MATE/toss/exception/parser/TossLoginErrorResponseParserTest.java
+++ b/src/test/java/server/MATE/toss/exception/parser/TossLoginErrorResponseParserTest.java
@@ -48,6 +48,55 @@ class TossLoginErrorResponseParserTest {
     }
 
     @Test
+    void parseLoginMeInvalidGrantAsInvalidAccessToken() {
+        TossErrorContext context = parser.parse(
+                HttpStatus.BAD_REQUEST,
+                LOGIN_API_PREFIX + "/login-me",
+                """
+                {
+                  "error": "invalid_grant"
+                }
+                """
+        );
+
+        assertThat(context.errorCode()).isEqualTo(TossErrorCode.TOSS_005);
+        assertThat(context.errorResponse().errorCode()).isEqualTo("INVALID_ACCESS_TOKEN");
+        assertThat(context.errorResponse().reason()).isEqualTo("access token이 만료되었거나 유효하지 않습니다.");
+    }
+
+    @Test
+    void parseObjectErrorBody() {
+        TossErrorContext context = parser.parse(
+                HttpStatus.BAD_REQUEST,
+                LOGIN_API_PREFIX + "/login-me",
+                """
+                {
+                  "error": {
+                    "errorCode": "USER_NOT_FOUND",
+                    "reason": "토스 사용자를 찾을 수 없습니다."
+                  }
+                }
+                """
+        );
+
+        assertThat(context.errorCode()).isEqualTo(TossErrorCode.TOSS_008);
+        assertThat(context.errorResponse().errorCode()).isEqualTo("USER_NOT_FOUND");
+        assertThat(context.errorResponse().reason()).isEqualTo("토스 사용자를 찾을 수 없습니다.");
+    }
+
+    @Test
+    void parseMalformedBodyAsFallbackError() {
+        TossErrorContext context = parser.parse(
+                HttpStatus.BAD_REQUEST,
+                LOGIN_API_PREFIX + "/generate-token",
+                "not-json"
+        );
+
+        assertThat(context.errorCode()).isEqualTo(TossErrorCode.TOSS_001);
+        assertThat(context.errorResponse().errorCode()).isEqualTo("TOSS_LOGIN_UNKNOWN_ERROR");
+    }
+
+    @Test
     void supportsOnlyTossLoginApiPath() {
         assertThat(parser.supports(HttpStatus.BAD_REQUEST, LOGIN_API_PREFIX + "/generate-token", "{}")).isTrue();
         assertThat(parser.supports(HttpStatus.BAD_REQUEST, "/api-partner/v1/payments/confirm", "{}")).isFalse();

--- a/src/test/java/server/MATE/toss/integration/TossLoginIntegrationTest.java
+++ b/src/test/java/server/MATE/toss/integration/TossLoginIntegrationTest.java
@@ -1,0 +1,271 @@
+package server.MATE.toss.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.test.web.servlet.MockMvc;
+
+import server.MATE.domain.auth.crypto.TokenEncryptor;
+import server.MATE.domain.auth.dto.response.TossLoginResponse;
+import server.MATE.domain.auth.store.TossTokenStore;
+import server.MATE.domain.auth.store.UserRefreshTokenStore;
+import server.MATE.domain.users.entity.TossAccount;
+import server.MATE.domain.users.entity.TossUnlinkReferrer;
+import server.MATE.domain.users.entity.Users;
+import server.MATE.domain.users.repository.TossAccountRepository;
+import server.MATE.domain.users.repository.UsersRepository;
+import server.MATE.global.image.ImageService;
+import server.MATE.toss.client.login.TossLoginApiClient;
+import server.MATE.toss.crypto.TossUserInfoDecryptor;
+import server.MATE.toss.dto.request.TossRefreshTokenRequest;
+import server.MATE.toss.dto.request.TossTokenRequest;
+import server.MATE.toss.dto.response.TossDecryptedUserInfo;
+import server.MATE.toss.dto.response.TossLoginUserResponse;
+import server.MATE.toss.dto.response.TossTokenResponse;
+import server.MATE.toss.service.TossLoginService;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {
+        "toss.api.enabled=true",
+        "toss.callback.basic-auth-header=callback-secret",
+        "toss.token.refresh-cache-ttl=600000"
+})
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class TossLoginIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TossLoginService tossLoginService;
+
+    @Autowired
+    private UsersRepository usersRepository;
+
+    @Autowired
+    private TossAccountRepository tossAccountRepository;
+
+    @Autowired
+    private TokenEncryptor tokenEncryptor;
+
+    @MockitoBean
+    private TossLoginApiClient tossLoginApiClient;
+
+    @MockitoBean
+    private TossUserInfoDecryptor tossUserInfoDecryptor;
+
+    @MockitoBean
+    private TossTokenStore tossTokenStore;
+
+    @MockitoBean
+    private UserRefreshTokenStore userRefreshTokenStore;
+
+    @MockitoBean
+    private ImageService imageService;
+
+    @AfterEach
+    void tearDown() {
+        tossAccountRepository.deleteAll();
+        usersRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("토스 연결 해제 API는 인증 없이 호출하면 401을 반환한다")
+    void returnsUnauthorizedWhenUnlinkCalledWithoutAuthentication() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/toss/unlink"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("COMMON_008"));
+    }
+
+    @Test
+    @DisplayName("로그인 성공 시 users, toss_accounts 저장과 토큰 저장이 수행된다")
+    void logsInSuccessfullyAndPersistsUserAndTossAccount() {
+        TossTokenResponse tokenResponse = new TossTokenResponse("Bearer", "toss-access", "toss-refresh", 3600L, "user_ci");
+        TossLoginUserResponse loginUserResponse = new TossLoginUserResponse(777L, "user_ci,name", "encrypted-name", "encrypted-ci");
+        TossDecryptedUserInfo decryptedUserInfo = new TossDecryptedUserInfo(777L, "user_ci,name", "ci-1", "tester");
+
+        when(tossLoginApiClient.generateToken(new TossTokenRequest("authorization-code", "APP"))).thenReturn(tokenResponse);
+        when(tossLoginApiClient.getLoginUserInfo("toss-access")).thenReturn(loginUserResponse);
+        when(tossUserInfoDecryptor.decrypt(loginUserResponse)).thenReturn(decryptedUserInfo);
+
+        TossLoginResponse response = tossLoginService.login("authorization-code", "APP");
+
+        Users savedUser = usersRepository.findByCi("ci-1").orElseThrow();
+        TossAccount savedAccount = tossAccountRepository.findByUserId(savedUser.getId()).orElseThrow();
+
+        assertThat(response.isNewUser()).isTrue();
+        assertThat(response.meResponse().id()).isEqualTo(savedUser.getId());
+        assertThat(savedAccount.getTossUserKey()).isEqualTo(777L);
+        assertThat(savedAccount.isLinked()).isTrue();
+        assertThat(savedAccount.getEncryptedTossRefreshToken()).isNotBlank();
+        assertThat(tokenEncryptor.decrypt(savedAccount.getEncryptedTossRefreshToken())).isEqualTo("toss-refresh");
+
+        verify(tossTokenStore).saveAccessToken(savedUser.getId(), "toss-access", 3_600_000L);
+        verify(tossTokenStore).saveRefreshToken(savedUser.getId(), "toss-refresh", 600_000L);
+        verify(userRefreshTokenStore).save(eq(savedUser.getId()), any(String.class), any(Long.class));
+    }
+
+    @Test
+    @DisplayName("기존 사용자 재로그인 시 이름 갱신과 linked 상태 복구가 수행된다")
+    void restoresLinkedStateOnRelogin() {
+        Users existingUser = usersRepository.save(Users.builder()
+                .ci("ci-1")
+                .name("before-name")
+                .build());
+        TossAccount existingAccount = tossAccountRepository.save(TossAccount.builder()
+                .user(existingUser)
+                .tossUserKey(123L)
+                .encryptedTossRefreshToken("old-refresh")
+                .scope("old")
+                .isLinked(false)
+                .unlinkReferrer(TossUnlinkReferrer.UNLINK)
+                .unlinkedAt(LocalDateTime.now().minusDays(1))
+                .lastLoginAt(LocalDateTime.now().minusDays(1))
+                .lastTokenRefreshedAt(LocalDateTime.now().minusDays(1))
+                .build());
+
+        TossTokenResponse tokenResponse = new TossTokenResponse("Bearer", "toss-access", "toss-refresh", 3600L, "user_ci");
+        TossLoginUserResponse loginUserResponse = new TossLoginUserResponse(777L, "user_ci,name", "encrypted-name", "encrypted-ci");
+        TossDecryptedUserInfo decryptedUserInfo = new TossDecryptedUserInfo(777L, "user_ci,name", "ci-1", "after-name");
+
+        when(tossLoginApiClient.generateToken(new TossTokenRequest("authorization-code", "APP"))).thenReturn(tokenResponse);
+        when(tossLoginApiClient.getLoginUserInfo("toss-access")).thenReturn(loginUserResponse);
+        when(tossUserInfoDecryptor.decrypt(loginUserResponse)).thenReturn(decryptedUserInfo);
+
+        TossLoginResponse response = tossLoginService.login("authorization-code", "APP");
+
+        Users updatedUser = usersRepository.findById(existingUser.getId()).orElseThrow();
+        TossAccount updatedAccount = tossAccountRepository.findById(existingAccount.getId()).orElseThrow();
+
+        assertThat(response.isNewUser()).isFalse();
+        assertThat(updatedUser.getName()).isEqualTo("after-name");
+        assertThat(updatedAccount.getTossUserKey()).isEqualTo(777L);
+        assertThat(updatedAccount.isLinked()).isTrue();
+        assertThat(updatedAccount.getUnlinkReferrer()).isNull();
+        assertThat(updatedAccount.getUnlinkedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("unlink 성공 시 토큰 저장소 정리와 unlink 상태 반영이 수행된다")
+    void unlinksCurrentUserAndClearsTokens() {
+        Users user = usersRepository.save(Users.builder()
+                .ci("ci-1")
+                .name("tester")
+                .build());
+        TossAccount tossAccount = tossAccountRepository.save(TossAccount.builder()
+                .user(user)
+                .tossUserKey(777L)
+                .encryptedTossRefreshToken(tokenEncryptor.encrypt("toss-refresh"))
+                .scope("user_ci")
+                .isLinked(true)
+                .lastLoginAt(LocalDateTime.now().minusDays(1))
+                .lastTokenRefreshedAt(LocalDateTime.now().minusDays(1))
+                .build());
+
+        when(tossTokenStore.findAccessToken(user.getId())).thenReturn(Optional.of("cached-access"));
+
+        tossLoginService.unlinkCurrentUser(user.getId());
+
+        TossAccount updatedAccount = tossAccountRepository.findById(tossAccount.getId()).orElseThrow();
+        assertThat(updatedAccount.isLinked()).isFalse();
+        assertThat(updatedAccount.getUnlinkReferrer()).isEqualTo(TossUnlinkReferrer.UNLINK);
+        assertThat(updatedAccount.getUnlinkedAt()).isNotNull();
+        assertThat(updatedAccount.getEncryptedTossRefreshToken()).isNull();
+
+        verify(tossLoginApiClient).removeByAccessToken("cached-access");
+        verify(tossTokenStore).deleteAccessToken(user.getId());
+        verify(tossTokenStore).deleteRefreshToken(user.getId());
+        verify(userRefreshTokenStore).delete(user.getId());
+    }
+
+    @Test
+    @DisplayName("callback 성공 시 unlinkReferrer/unlinkedAt 반영과 토큰 정리가 수행된다")
+    void handlesUnlinkCallbackAndClearsTokens() {
+        Users user = usersRepository.save(Users.builder()
+                .ci("ci-1")
+                .name("tester")
+                .build());
+        TossAccount tossAccount = tossAccountRepository.save(TossAccount.builder()
+                .user(user)
+                .tossUserKey(777L)
+                .encryptedTossRefreshToken(tokenEncryptor.encrypt("toss-refresh"))
+                .scope("user_ci")
+                .isLinked(true)
+                .lastLoginAt(LocalDateTime.now().minusDays(1))
+                .lastTokenRefreshedAt(LocalDateTime.now().minusDays(1))
+                .build());
+
+        tossLoginService.handleUnlinkCallback(777L, TossUnlinkReferrer.WITHDRAWAL_TOSS);
+
+        TossAccount updatedAccount = tossAccountRepository.findById(tossAccount.getId()).orElseThrow();
+        assertThat(updatedAccount.isLinked()).isFalse();
+        assertThat(updatedAccount.getUnlinkReferrer()).isEqualTo(TossUnlinkReferrer.WITHDRAWAL_TOSS);
+        assertThat(updatedAccount.getUnlinkedAt()).isNotNull();
+        assertThat(updatedAccount.getEncryptedTossRefreshToken()).isNull();
+
+        verify(tossTokenStore).deleteAccessToken(user.getId());
+        verify(tossTokenStore).deleteRefreshToken(user.getId());
+        verify(userRefreshTokenStore).delete(user.getId());
+        verify(tossLoginApiClient, never()).removeByAccessToken(any());
+    }
+
+    @Test
+    @DisplayName("Redis access token이 없으면 DB refresh token으로 재발급 후 unlink 한다")
+    void refreshesUsingEncryptedDbRefreshTokenBeforeUnlink() {
+        Users user = usersRepository.save(Users.builder()
+                .ci("ci-1")
+                .name("tester")
+                .build());
+        TossAccount tossAccount = tossAccountRepository.save(TossAccount.builder()
+                .user(user)
+                .tossUserKey(777L)
+                .encryptedTossRefreshToken(tokenEncryptor.encrypt("db-refresh"))
+                .scope("user_ci")
+                .isLinked(true)
+                .lastLoginAt(LocalDateTime.now().minusDays(1))
+                .lastTokenRefreshedAt(LocalDateTime.now().minusDays(1))
+                .build());
+
+        TossTokenResponse refreshedResponse = new TossTokenResponse("Bearer", "new-access", "new-refresh", 3600L, "user_ci,name");
+
+        when(tossTokenStore.findAccessToken(user.getId())).thenReturn(Optional.empty());
+        when(tossTokenStore.findRefreshToken(user.getId())).thenReturn(Optional.empty());
+        when(tossLoginApiClient.refreshToken(new TossRefreshTokenRequest("db-refresh"))).thenReturn(refreshedResponse);
+
+        tossLoginService.unlinkCurrentUser(user.getId());
+
+        TossAccount updatedAccount = tossAccountRepository.findById(tossAccount.getId()).orElseThrow();
+        assertThat(updatedAccount.isLinked()).isFalse();
+        assertThat(updatedAccount.getEncryptedTossRefreshToken()).isNull();
+        assertThat(updatedAccount.getUnlinkReferrer()).isEqualTo(TossUnlinkReferrer.UNLINK);
+
+        verify(tossLoginApiClient).refreshToken(new TossRefreshTokenRequest("db-refresh"));
+        verify(tossTokenStore).saveAccessToken(user.getId(), "new-access", 3_600_000L);
+        verify(tossTokenStore).saveRefreshToken(user.getId(), "new-refresh", 600_000L);
+        verify(tossLoginApiClient).removeByAccessToken("new-access");
+        verify(tossTokenStore).deleteAccessToken(user.getId());
+        verify(tossTokenStore).deleteRefreshToken(user.getId());
+        verify(userRefreshTokenStore).delete(user.getId());
+    }
+}

--- a/src/test/java/server/MATE/toss/integration/TossLoginIntegrationTest.java
+++ b/src/test/java/server/MATE/toss/integration/TossLoginIntegrationTest.java
@@ -99,7 +99,7 @@ class TossLoginIntegrationTest {
     }
 
     @Test
-    @DisplayName("로그인 성공 시 users, toss_accounts 저장과 토큰 저장이 수행된다")
+    @DisplayName("로그인 성공 시 users, toss_accounts 저장과 토큰 저장소 호출이 수행된다")
     void logsInSuccessfullyAndPersistsUserAndTossAccount() {
         TossTokenResponse tokenResponse = new TossTokenResponse("Bearer", "toss-access", "toss-refresh", 3600L, "user_ci");
         TossLoginUserResponse loginUserResponse = new TossLoginUserResponse(777L, "user_ci,name", "encrypted-name", "encrypted-ci");

--- a/src/test/java/server/MATE/toss/service/TossLoginServiceTest.java
+++ b/src/test/java/server/MATE/toss/service/TossLoginServiceTest.java
@@ -215,6 +215,18 @@ class TossLoginServiceTest {
                     .extracting(exception -> ((BaseException) exception).getErrorCode())
                     .isEqualTo(BaseErrorCode.AUTH_008);
         }
+
+        @Test
+        @DisplayName("토스 로그인 중 네트워크 실패가 발생하면 TOSS_001 예외를 그대로 전파한다")
+        void propagatesToss001WhenGenerateTokenFailsByNetwork() {
+            when(tossLoginApiClient.generateToken(new TossTokenRequest("authorization-code", "APP")))
+                    .thenThrow(new TossApiException(TossErrorCode.TOSS_001, "토스 API 호출에 실패했습니다.", null));
+
+            assertThatThrownBy(() -> tossLoginService.login("authorization-code", "APP"))
+                    .isInstanceOf(TossApiException.class)
+                    .extracting(exception -> ((TossApiException) exception).getErrorCode())
+                    .isEqualTo(TossErrorCode.TOSS_001);
+        }
     }
 
     @Nested
@@ -324,6 +336,25 @@ class TossLoginServiceTest {
             verify(tossLoginSessionService).clearLoginTokens(1L);
             verify(userRefreshTokenStore).delete(1L);
             assertThat(tossAccount.isLinked()).isFalse();
+        }
+
+        @Test
+        @DisplayName("unlink 중 네트워크 실패가 발생하면 TOSS_001 예외를 전파하고 revoke 하지 않는다")
+        void throwsToss001AndDoesNotRevokeWhenNetworkFailureOccursDuringUnlink() {
+            TossAccount tossAccount = createLinkedAccount(1L);
+            when(tossAccountRepository.findByUserId(1L)).thenReturn(Optional.of(tossAccount));
+            when(tossLoginSessionService.getValidAccessToken(1L)).thenReturn(Optional.of("valid-access"));
+            doThrow(new TossApiException(TossErrorCode.TOSS_001, "토스 API 호출에 실패했습니다.", null))
+                    .when(tossLoginApiClient).removeByAccessToken("valid-access");
+
+            assertThatThrownBy(() -> tossLoginService.unlinkCurrentUser(1L))
+                    .isInstanceOf(TossApiException.class)
+                    .extracting(exception -> ((TossApiException) exception).getErrorCode())
+                    .isEqualTo(TossErrorCode.TOSS_001);
+
+            verify(tossLoginSessionService, never()).clearLoginTokens(1L);
+            verify(userRefreshTokenStore, never()).delete(1L);
+            assertThat(tossAccount.isLinked()).isTrue();
         }
 
         @Test

--- a/src/test/java/server/MATE/toss/service/TossLoginServiceTest.java
+++ b/src/test/java/server/MATE/toss/service/TossLoginServiceTest.java
@@ -1,0 +1,522 @@
+package server.MATE.toss.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Base64;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import server.MATE.domain.auth.crypto.TokenEncryptor;
+import server.MATE.domain.auth.dto.response.TossLoginResponse;
+import server.MATE.domain.auth.jwt.JwtProvider;
+import server.MATE.domain.auth.jwt.TokenType;
+import server.MATE.domain.auth.store.UserRefreshTokenStore;
+import server.MATE.domain.users.entity.Role;
+import server.MATE.domain.users.entity.TossAccount;
+import server.MATE.domain.users.entity.TossUnlinkReferrer;
+import server.MATE.domain.users.entity.Users;
+import server.MATE.domain.users.repository.TossAccountRepository;
+import server.MATE.domain.users.repository.UsersRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+import server.MATE.toss.client.login.TossLoginApiClient;
+import server.MATE.toss.crypto.TossUserInfoDecryptor;
+import server.MATE.toss.dto.request.TossTokenRequest;
+import server.MATE.toss.dto.response.TossDecryptedUserInfo;
+import server.MATE.toss.dto.response.TossLoginUserResponse;
+import server.MATE.toss.dto.response.TossTokenResponse;
+import server.MATE.toss.exception.TossApiException;
+import server.MATE.toss.exception.TossErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class TossLoginServiceTest {
+
+    @Mock
+    private TossLoginApiClient tossLoginApiClient;
+
+    @Mock
+    private TossUserInfoDecryptor tossUserInfoDecryptor;
+
+    @Mock
+    private UsersRepository usersRepository;
+
+    @Mock
+    private TossAccountRepository tossAccountRepository;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private UserRefreshTokenStore userRefreshTokenStore;
+
+    @Mock
+    private TokenEncryptor tokenEncryptor;
+
+    @Mock
+    private TossLoginSessionService tossLoginSessionService;
+
+    private TossLoginService tossLoginService;
+    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-05-15T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+
+    @BeforeEach
+    void setUp() {
+        tossLoginService = new TossLoginService(
+                tossLoginApiClient,
+                tossUserInfoDecryptor,
+                usersRepository,
+                tossAccountRepository,
+                jwtProvider,
+                userRefreshTokenStore,
+                tokenEncryptor,
+                tossLoginSessionService,
+                fixedClock
+        );
+        ReflectionTestUtils.setField(tossLoginService, "callbackBasicAuthHeader", "callback-secret");
+    }
+
+    @Nested
+    class LoginTest {
+
+        @Test
+        @DisplayName("신규 사용자 로그인 성공 시 사용자 생성, TossAccount 동기화, Mate 토큰 발급이 수행된다")
+        void logsInNewUserSuccessfully() {
+            TossTokenResponse tokenResponse = new TossTokenResponse("Bearer", "toss-access", "toss-refresh", 3600L, "user_ci");
+            TossLoginUserResponse loginUserResponse = new TossLoginUserResponse(777L, "user_ci,name", "encrypted-name", "encrypted-ci");
+            TossDecryptedUserInfo decryptedUserInfo = new TossDecryptedUserInfo(777L, "user_ci,name", "ci-1", "new-user");
+            Users savedUser = createUser(1L, "ci-1", "new-user");
+
+            when(tossLoginApiClient.generateToken(new TossTokenRequest("authorization-code", "APP"))).thenReturn(tokenResponse);
+            when(tossLoginApiClient.getLoginUserInfo("toss-access")).thenReturn(loginUserResponse);
+            when(tossUserInfoDecryptor.decrypt(loginUserResponse)).thenReturn(decryptedUserInfo);
+            when(usersRepository.findByCi("ci-1")).thenReturn(Optional.empty());
+            when(usersRepository.save(any(Users.class))).thenReturn(savedUser);
+            when(tokenEncryptor.encrypt("toss-refresh")).thenReturn("encrypted-refresh");
+            when(tossAccountRepository.findByUser(savedUser)).thenReturn(Optional.empty());
+            when(jwtProvider.generateToken(1L, "USER", TokenType.ACCESS)).thenReturn("mate-access");
+            when(jwtProvider.generateToken(1L, "USER", TokenType.REFRESH)).thenReturn("mate-refresh");
+            when(jwtProvider.getExpiration(TokenType.REFRESH)).thenReturn(1_209_600_000L);
+
+            TossLoginResponse response = tossLoginService.login("authorization-code", "APP");
+
+            assertThat(response.accessToken()).isEqualTo("mate-access");
+            assertThat(response.refreshToken()).isEqualTo("mate-refresh");
+            assertThat(response.meResponse().id()).isEqualTo(1L);
+            assertThat(response.isNewUser()).isTrue();
+            verify(tossLoginSessionService).persistLoginTokens(1L, tokenResponse);
+            verify(userRefreshTokenStore).save(1L, "mate-refresh", 1_209_600_000L);
+
+            ArgumentCaptor<TossAccount> tossAccountCaptor = ArgumentCaptor.forClass(TossAccount.class);
+            verify(tossAccountRepository).save(tossAccountCaptor.capture());
+            TossAccount savedAccount = tossAccountCaptor.getValue();
+            assertThat(savedAccount.getTossUserKey()).isEqualTo(777L);
+            assertThat(savedAccount.getEncryptedTossRefreshToken()).isEqualTo("encrypted-refresh");
+            assertThat(savedAccount.getScope()).isEqualTo("user_ci,name");
+            assertThat(savedAccount.isLinked()).isTrue();
+        }
+
+        @Test
+        @DisplayName("기존 사용자 로그인 성공 시 이름을 갱신하고 linked 상태를 복구한다")
+        void logsInExistingUserSuccessfully() {
+            TossTokenResponse tokenResponse = new TossTokenResponse("Bearer", "toss-access", "toss-refresh", 3600L, "user_ci");
+            TossLoginUserResponse loginUserResponse = new TossLoginUserResponse(777L, "user_ci,name", "encrypted-name", "encrypted-ci");
+            TossDecryptedUserInfo decryptedUserInfo = new TossDecryptedUserInfo(777L, "user_ci,name", "ci-1", "renamed-user");
+            Users existingUser = createUser(1L, "ci-1", "before-name");
+            TossAccount existingAccount = TossAccount.builder()
+                    .user(existingUser)
+                    .tossUserKey(123L)
+                    .encryptedTossRefreshToken("old-refresh")
+                    .scope("old")
+                    .isLinked(false)
+                    .unlinkReferrer(TossUnlinkReferrer.UNLINK)
+                    .unlinkedAt(LocalDateTime.of(2026, 5, 14, 10, 0))
+                    .lastLoginAt(LocalDateTime.of(2026, 5, 14, 10, 0))
+                    .lastTokenRefreshedAt(LocalDateTime.of(2026, 5, 14, 10, 0))
+                    .build();
+
+            when(tossLoginApiClient.generateToken(new TossTokenRequest("authorization-code", "APP"))).thenReturn(tokenResponse);
+            when(tossLoginApiClient.getLoginUserInfo("toss-access")).thenReturn(loginUserResponse);
+            when(tossUserInfoDecryptor.decrypt(loginUserResponse)).thenReturn(decryptedUserInfo);
+            when(usersRepository.findByCi("ci-1")).thenReturn(Optional.of(existingUser));
+            when(tokenEncryptor.encrypt("toss-refresh")).thenReturn("encrypted-refresh");
+            when(tossAccountRepository.findByUser(existingUser)).thenReturn(Optional.of(existingAccount));
+            when(jwtProvider.generateToken(1L, "USER", TokenType.ACCESS)).thenReturn("mate-access");
+            when(jwtProvider.generateToken(1L, "USER", TokenType.REFRESH)).thenReturn("mate-refresh");
+            when(jwtProvider.getExpiration(TokenType.REFRESH)).thenReturn(1_209_600_000L);
+
+            TossLoginResponse response = tossLoginService.login("authorization-code", "APP");
+
+            assertThat(response.isNewUser()).isFalse();
+            assertThat(existingUser.getName()).isEqualTo("renamed-user");
+            assertThat(existingAccount.getTossUserKey()).isEqualTo(777L);
+            assertThat(existingAccount.isLinked()).isTrue();
+            assertThat(existingAccount.getUnlinkReferrer()).isNull();
+            assertThat(existingAccount.getUnlinkedAt()).isNull();
+            verify(usersRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("토큰 응답 필수값이 누락되면 TOSS_002 예외를 던진다")
+        void throwsWhenTokenResponseMissingRequiredFields() {
+            when(tossLoginApiClient.generateToken(new TossTokenRequest("authorization-code", "APP")))
+                    .thenReturn(new TossTokenResponse("Bearer", null, "toss-refresh", 3600L, "user_ci"));
+
+            assertThatThrownBy(() -> tossLoginService.login("authorization-code", "APP"))
+                    .isInstanceOf(TossApiException.class)
+                    .extracting(exception -> ((TossApiException) exception).getErrorCode())
+                    .isEqualTo(TossErrorCode.TOSS_002);
+        }
+
+        @Test
+        @DisplayName("login-me 응답에 userKey가 없으면 TOSS_007 예외를 던진다")
+        void throwsWhenUserKeyMissingInLoginMeResponse() {
+            TossTokenResponse tokenResponse = new TossTokenResponse("Bearer", "toss-access", "toss-refresh", 3600L, "user_ci");
+            when(tossLoginApiClient.generateToken(new TossTokenRequest("authorization-code", "APP"))).thenReturn(tokenResponse);
+            when(tossLoginApiClient.getLoginUserInfo("toss-access"))
+                    .thenReturn(new TossLoginUserResponse(null, "user_ci", "encrypted-name", "encrypted-ci"));
+
+            assertThatThrownBy(() -> tossLoginService.login("authorization-code", "APP"))
+                    .isInstanceOf(TossApiException.class)
+                    .extracting(exception -> ((TossApiException) exception).getErrorCode())
+                    .isEqualTo(TossErrorCode.TOSS_007);
+        }
+
+        @Test
+        @DisplayName("user_ci scope가 없으면 AUTH_008 예외를 던진다")
+        void throwsWhenUserCiScopeMissing() {
+            TossTokenResponse tokenResponse = new TossTokenResponse("Bearer", "toss-access", "toss-refresh", 3600L, "name");
+            when(tossLoginApiClient.generateToken(new TossTokenRequest("authorization-code", "APP"))).thenReturn(tokenResponse);
+            when(tossLoginApiClient.getLoginUserInfo("toss-access"))
+                    .thenReturn(new TossLoginUserResponse(777L, "name", "encrypted-name", "encrypted-ci"));
+
+            assertThatThrownBy(() -> tossLoginService.login("authorization-code", "APP"))
+                    .isInstanceOf(BaseException.class)
+                    .extracting(exception -> ((BaseException) exception).getErrorCode())
+                    .isEqualTo(BaseErrorCode.AUTH_008);
+        }
+    }
+
+    @Nested
+    class UnlinkTest {
+
+        @Test
+        @DisplayName("linked account가 없으면 조용히 종료한다")
+        void returnsWhenLinkedAccountDoesNotExist() {
+            when(tossAccountRepository.findByUserId(1L)).thenReturn(Optional.empty());
+
+            tossLoginService.unlinkCurrentUser(1L);
+
+            verify(tossLoginSessionService, never()).getValidAccessToken(any());
+            verify(userRefreshTokenStore, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("이미 unlink 상태면 조용히 종료한다")
+        void returnsWhenAlreadyUnlinked() {
+            TossAccount tossAccount = createUnlinkedAccount(1L);
+            when(tossAccountRepository.findByUserId(1L)).thenReturn(Optional.of(tossAccount));
+
+            tossLoginService.unlinkCurrentUser(1L);
+
+            verify(tossLoginSessionService, never()).getValidAccessToken(any());
+            verify(userRefreshTokenStore, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("access token이 있으면 remove-by-access-token을 수행하고 revoke 한다")
+        void unlinksCurrentUserWithAccessToken() {
+            TossAccount tossAccount = createLinkedAccount(1L);
+            when(tossAccountRepository.findByUserId(1L)).thenReturn(Optional.of(tossAccount));
+            when(tossLoginSessionService.getValidAccessToken(1L)).thenReturn(Optional.of("valid-access"));
+
+            tossLoginService.unlinkCurrentUser(1L);
+
+            verify(tossLoginApiClient).removeByAccessToken("valid-access");
+            verify(tossLoginSessionService).clearLoginTokens(1L);
+            verify(userRefreshTokenStore).delete(1L);
+            assertThat(tossAccount.isLinked()).isFalse();
+            assertThat(tossAccount.getUnlinkReferrer()).isEqualTo(TossUnlinkReferrer.UNLINK);
+            assertThat(tossAccount.getUnlinkedAt()).isEqualTo(LocalDateTime.now(fixedClock));
+        }
+
+        @Test
+        @DisplayName("access token이 없고 refresh 가능하면 재발급된 access token으로 unlink 한다")
+        void unlinksCurrentUserWhenRefreshedAccessTokenAvailable() {
+            TossAccount tossAccount = createLinkedAccount(1L);
+            when(tossAccountRepository.findByUserId(1L)).thenReturn(Optional.of(tossAccount));
+            when(tossLoginSessionService.getValidAccessToken(1L)).thenReturn(Optional.of("refreshed-access"));
+
+            tossLoginService.unlinkCurrentUser(1L);
+
+            verify(tossLoginApiClient).removeByAccessToken("refreshed-access");
+            verify(tossLoginSessionService).clearLoginTokens(1L);
+            verify(userRefreshTokenStore).delete(1L);
+            assertThat(tossAccount.isLinked()).isFalse();
+        }
+
+        @Test
+        @DisplayName("access token과 refresh token이 모두 없으면 멱등 성공으로 처리하고 revoke 한다")
+        void treatsMissingTokensAsIdempotentSuccess() {
+            TossAccount tossAccount = createLinkedAccount(1L);
+            when(tossAccountRepository.findByUserId(1L)).thenReturn(Optional.of(tossAccount));
+            when(tossLoginSessionService.getValidAccessToken(1L)).thenReturn(Optional.empty());
+
+            tossLoginService.unlinkCurrentUser(1L);
+
+            verify(tossLoginApiClient, never()).removeByAccessToken(any());
+            verify(tossLoginSessionService).clearLoginTokens(1L);
+            verify(userRefreshTokenStore).delete(1L);
+            assertThat(tossAccount.isLinked()).isFalse();
+        }
+
+        @Test
+        @DisplayName("invalid access token이면 refresh 후 재시도한다")
+        void retriesAfterRefreshingWhenAccessTokenInvalid() {
+            TossAccount tossAccount = createLinkedAccount(1L);
+            TossTokenResponse refreshed = new TossTokenResponse("Bearer", "new-access", "new-refresh", 3600L, "user_ci");
+
+            when(tossAccountRepository.findByUserId(1L)).thenReturn(Optional.of(tossAccount));
+            when(tossLoginSessionService.getValidAccessToken(1L)).thenReturn(Optional.of("old-access"));
+            doThrow(new TossApiException(TossErrorCode.TOSS_005, "invalid access token", null))
+                    .when(tossLoginApiClient).removeByAccessToken("old-access");
+            when(tossLoginSessionService.refreshLoginTokens(1L)).thenReturn(refreshed);
+
+            tossLoginService.unlinkCurrentUser(1L);
+
+            verify(tossLoginApiClient).removeByAccessToken("old-access");
+            verify(tossLoginSessionService).refreshLoginTokens(1L);
+            verify(tossLoginApiClient).removeByAccessToken("new-access");
+            verify(userRefreshTokenStore).delete(1L);
+        }
+
+        @Test
+        @DisplayName("ignorable unlink 예외는 삼키고 revoke는 수행한다")
+        void ignoresIgnorableUnlinkExceptionAndStillRevokes() {
+            TossAccount tossAccount = createLinkedAccount(1L);
+            when(tossAccountRepository.findByUserId(1L)).thenReturn(Optional.of(tossAccount));
+            when(tossLoginSessionService.getValidAccessToken(1L)).thenReturn(Optional.of("valid-access"));
+            doThrow(new TossApiException(TossErrorCode.TOSS_007, "user key not found", null))
+                    .when(tossLoginApiClient).removeByAccessToken("valid-access");
+
+            tossLoginService.unlinkCurrentUser(1L);
+
+            verify(tossLoginSessionService).clearLoginTokens(1L);
+            verify(userRefreshTokenStore).delete(1L);
+            assertThat(tossAccount.isLinked()).isFalse();
+        }
+
+        @Test
+        @DisplayName("unlinkByUserKey 호출 시 remote not found는 멱등 성공으로 처리한다")
+        void treatsRemoteNotFoundAsIdempotentSuccessWhenUnlinkByUserKey() {
+            TossAccount tossAccount = createLinkedAccount(1L);
+            when(tossAccountRepository.findByTossUserKey(777L)).thenReturn(Optional.of(tossAccount));
+            doThrow(new TossApiException(TossErrorCode.TOSS_007, "not found", null))
+                    .when(tossLoginApiClient).removeByUserKey(777L);
+
+            tossLoginService.unlinkByUserKey(777L, TossUnlinkReferrer.UNLINK);
+
+            verify(tossLoginSessionService).clearLoginTokens(1L);
+            verify(userRefreshTokenStore).delete(1L);
+            assertThat(tossAccount.isLinked()).isFalse();
+        }
+
+        @Test
+        @DisplayName("unlinkByUserKey 호출 시 정상 unlink를 수행한다")
+        void unlinksByUserKeySuccessfully() {
+            TossAccount tossAccount = createLinkedAccount(1L);
+            when(tossAccountRepository.findByTossUserKey(777L)).thenReturn(Optional.of(tossAccount));
+
+            tossLoginService.unlinkByUserKey(777L, TossUnlinkReferrer.UNLINK);
+
+            verify(tossLoginApiClient).removeByUserKey(777L);
+            verify(tossLoginSessionService).clearLoginTokens(1L);
+            verify(userRefreshTokenStore).delete(1L);
+            assertThat(tossAccount.isLinked()).isFalse();
+            assertThat(tossAccount.getUnlinkReferrer()).isEqualTo(TossUnlinkReferrer.UNLINK);
+        }
+
+        @Test
+        @DisplayName("unlinkByUserKey 호출 시 account가 없으면 조용히 종료한다")
+        void returnsWhenUnlinkByUserKeyAccountDoesNotExist() {
+            when(tossAccountRepository.findByTossUserKey(777L)).thenReturn(Optional.empty());
+
+            tossLoginService.unlinkByUserKey(777L, TossUnlinkReferrer.UNLINK);
+
+            verify(tossLoginApiClient, never()).removeByUserKey(any());
+            verify(tossLoginSessionService, never()).clearLoginTokens(any());
+            verify(userRefreshTokenStore, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("unlinkByUserKey 호출 시 이미 unlink 상태면 조용히 종료한다")
+        void returnsWhenUnlinkByUserKeyAlreadyUnlinked() {
+            TossAccount tossAccount = createUnlinkedAccount(1L);
+            when(tossAccountRepository.findByTossUserKey(777L)).thenReturn(Optional.of(tossAccount));
+
+            tossLoginService.unlinkByUserKey(777L, TossUnlinkReferrer.UNLINK);
+
+            verify(tossLoginApiClient, never()).removeByUserKey(any());
+            verify(tossLoginSessionService, never()).clearLoginTokens(any());
+            verify(userRefreshTokenStore, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("callback 처리 시 unlink 상태와 refresh token 정리가 수행된다")
+        void handlesUnlinkCallbackSuccessfully() {
+            TossAccount tossAccount = createLinkedAccount(1L);
+            when(tossAccountRepository.findByTossUserKey(777L)).thenReturn(Optional.of(tossAccount));
+
+            tossLoginService.handleUnlinkCallback(777L, TossUnlinkReferrer.WITHDRAWAL_TOSS);
+
+            verify(tossLoginSessionService).clearLoginTokens(1L);
+            verify(userRefreshTokenStore).delete(1L);
+            assertThat(tossAccount.isLinked()).isFalse();
+            assertThat(tossAccount.getUnlinkReferrer()).isEqualTo(TossUnlinkReferrer.WITHDRAWAL_TOSS);
+            assertThat(tossAccount.getUnlinkedAt()).isEqualTo(LocalDateTime.now(fixedClock));
+        }
+
+        @Test
+        @DisplayName("callback 처리 시 account가 없으면 조용히 종료한다")
+        void returnsWhenCallbackAccountDoesNotExist() {
+            when(tossAccountRepository.findByTossUserKey(777L)).thenReturn(Optional.empty());
+
+            tossLoginService.handleUnlinkCallback(777L, TossUnlinkReferrer.WITHDRAWAL_TOSS);
+
+            verify(tossLoginSessionService, never()).clearLoginTokens(any());
+            verify(userRefreshTokenStore, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("callback 처리 시 이미 unlink 상태면 조용히 종료한다")
+        void returnsWhenCallbackAccountAlreadyUnlinked() {
+            TossAccount tossAccount = createUnlinkedAccount(1L);
+            when(tossAccountRepository.findByTossUserKey(777L)).thenReturn(Optional.of(tossAccount));
+
+            tossLoginService.handleUnlinkCallback(777L, TossUnlinkReferrer.WITHDRAWAL_TOSS);
+
+            verify(tossLoginSessionService, never()).clearLoginTokens(any());
+            verify(userRefreshTokenStore, never()).delete(any());
+        }
+    }
+
+    @Nested
+    class CallbackAuthTest {
+
+        @Test
+        @DisplayName("callback auth 검증 성공 케이스를 통과시킨다")
+        void validatesCallbackAuthorizationSuccessfully() {
+            String header = basicAuth("callback-secret");
+
+            tossLoginService.validateCallbackAuthorization(header);
+        }
+
+        @Test
+        @DisplayName("callback auth 검증 시 header가 없으면 COMMON_008 예외를 던진다")
+        void throwsWhenAuthorizationHeaderMissing() {
+            assertThatThrownBy(() -> tossLoginService.validateCallbackAuthorization(null))
+                    .isInstanceOf(BaseException.class)
+                    .extracting(exception -> ((BaseException) exception).getErrorCode())
+                    .isEqualTo(BaseErrorCode.COMMON_008);
+        }
+
+        @Test
+        @DisplayName("callback auth 검증 시 prefix가 다르면 COMMON_008 예외를 던진다")
+        void throwsWhenAuthorizationPrefixInvalid() {
+            assertThatThrownBy(() -> tossLoginService.validateCallbackAuthorization("Bearer token"))
+                    .isInstanceOf(BaseException.class)
+                    .extracting(exception -> ((BaseException) exception).getErrorCode())
+                    .isEqualTo(BaseErrorCode.COMMON_008);
+        }
+
+        @Test
+        @DisplayName("callback auth 검증 시 base64 decode가 실패하면 COMMON_008 예외를 던진다")
+        void throwsWhenAuthorizationIsNotBase64() {
+            assertThatThrownBy(() -> tossLoginService.validateCallbackAuthorization("Basic !!!"))
+                    .isInstanceOf(BaseException.class)
+                    .extracting(exception -> ((BaseException) exception).getErrorCode())
+                    .isEqualTo(BaseErrorCode.COMMON_008);
+        }
+
+        @Test
+        @DisplayName("callback auth 검증 시 값이 다르면 COMMON_008 예외를 던진다")
+        void throwsWhenAuthorizationValueDoesNotMatch() {
+            assertThatThrownBy(() -> tossLoginService.validateCallbackAuthorization(basicAuth("wrong-secret")))
+                    .isInstanceOf(BaseException.class)
+                    .extracting(exception -> ((BaseException) exception).getErrorCode())
+                    .isEqualTo(BaseErrorCode.COMMON_008);
+        }
+    }
+
+    @Test
+    @DisplayName("isLinked는 연동 상태를 올바르게 반환한다")
+    void returnsLinkedStatus() {
+        when(tossAccountRepository.findByUserId(1L)).thenReturn(Optional.of(createLinkedAccount(1L)));
+        when(tossAccountRepository.findByUserId(2L)).thenReturn(Optional.of(createUnlinkedAccount(2L)));
+        when(tossAccountRepository.findByUserId(3L)).thenReturn(Optional.empty());
+
+        assertThat(tossLoginService.isLinked(1L)).isTrue();
+        assertThat(tossLoginService.isLinked(2L)).isFalse();
+        assertThat(tossLoginService.isLinked(3L)).isFalse();
+    }
+
+    private TossAccount createLinkedAccount(Long userId) {
+        return TossAccount.builder()
+                .user(createUser(userId, "ci-" + userId, "tester"))
+                .tossUserKey(777L)
+                .encryptedTossRefreshToken("encrypted-refresh")
+                .scope("user_ci")
+                .isLinked(true)
+                .lastLoginAt(LocalDateTime.of(2026, 5, 14, 12, 0))
+                .lastTokenRefreshedAt(LocalDateTime.of(2026, 5, 14, 12, 0))
+                .build();
+    }
+
+    private TossAccount createUnlinkedAccount(Long userId) {
+        return TossAccount.builder()
+                .user(createUser(userId, "ci-" + userId, "tester"))
+                .tossUserKey(777L)
+                .encryptedTossRefreshToken(null)
+                .scope("user_ci")
+                .isLinked(false)
+                .unlinkReferrer(TossUnlinkReferrer.UNLINK)
+                .unlinkedAt(LocalDateTime.of(2026, 5, 14, 12, 30))
+                .lastLoginAt(LocalDateTime.of(2026, 5, 14, 12, 0))
+                .lastTokenRefreshedAt(LocalDateTime.of(2026, 5, 14, 12, 0))
+                .build();
+    }
+
+    private Users createUser(Long userId, String ci, String name) {
+        Users user = Users.builder()
+                .ci(ci)
+                .name(name)
+                .role(Role.USER)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        return user;
+    }
+
+    private String basicAuth(String rawCredentials) {
+        return "Basic " + Base64.getEncoder().encodeToString(rawCredentials.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/test/java/server/MATE/toss/service/TossLoginSessionServiceTest.java
+++ b/src/test/java/server/MATE/toss/service/TossLoginSessionServiceTest.java
@@ -1,0 +1,239 @@
+package server.MATE.toss.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import server.MATE.domain.auth.crypto.TokenEncryptor;
+import server.MATE.domain.auth.store.TossTokenStore;
+import server.MATE.domain.users.entity.TossAccount;
+import server.MATE.domain.users.entity.TossUnlinkReferrer;
+import server.MATE.domain.users.entity.Users;
+import server.MATE.domain.users.repository.TossAccountRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+import server.MATE.toss.client.login.TossLoginApiClient;
+import server.MATE.toss.dto.request.TossRefreshTokenRequest;
+import server.MATE.toss.dto.response.TossTokenResponse;
+
+@ExtendWith(MockitoExtension.class)
+class TossLoginSessionServiceTest {
+
+    @Mock
+    private TossLoginApiClient tossLoginApiClient;
+
+    @Mock
+    private TossAccountRepository tossAccountRepository;
+
+    @Mock
+    private TossTokenStore tossTokenStore;
+
+    @Mock
+    private TokenEncryptor tokenEncryptor;
+
+    @InjectMocks
+    private TossLoginSessionService tossLoginSessionService;
+
+    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-05-15T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(tossLoginSessionService, "clock", fixedClock);
+        ReflectionTestUtils.setField(tossLoginSessionService, "tossRefreshCacheTtlMillis", 600_000L);
+    }
+
+    @Test
+    @DisplayName("Redis에 access token이 있으면 그대로 반환한다")
+    void returnsCachedAccessTokenWhenPresent() {
+        when(tossTokenStore.findAccessToken(1L)).thenReturn(Optional.of("cached-access"));
+
+        Optional<String> result = tossLoginSessionService.getValidAccessToken(1L);
+
+        assertThat(result).contains("cached-access");
+        verify(tossTokenStore).findAccessToken(1L);
+        verify(tossTokenStore, never()).findRefreshToken(1L);
+    }
+
+    @Test
+    @DisplayName("Redis access token이 없고 Redis refresh token이 있으면 refresh 후 access token을 반환한다")
+    void refreshesWithCachedRefreshTokenWhenAccessTokenMissing() {
+        TossTokenResponse response = new TossTokenResponse("Bearer", "new-access", "new-refresh", 3600L, "user_ci");
+        TossAccount tossAccount = createLinkedTossAccount(1L, "encrypted-old-refresh");
+
+        when(tossTokenStore.findAccessToken(1L)).thenReturn(Optional.empty());
+        when(tossTokenStore.findRefreshToken(1L)).thenReturn(Optional.of("cached-refresh"));
+        when(tossLoginApiClient.refreshToken(any(TossRefreshTokenRequest.class))).thenReturn(response);
+        when(tossAccountRepository.findByUserId(1L)).thenReturn(Optional.of(tossAccount));
+        when(tokenEncryptor.encrypt("new-refresh")).thenReturn("encrypted-new-refresh");
+
+        Optional<String> result = tossLoginSessionService.getValidAccessToken(1L);
+
+        assertThat(result).contains("new-access");
+        verify(tossLoginApiClient).refreshToken(new TossRefreshTokenRequest("cached-refresh"));
+        verify(tossTokenStore).saveAccessToken(1L, "new-access", 3_600_000L);
+        verify(tossTokenStore).saveRefreshToken(1L, "new-refresh", 600_000L);
+        assertThat(tossAccount.getEncryptedTossRefreshToken()).isEqualTo("encrypted-new-refresh");
+        assertThat(tossAccount.getScope()).isEqualTo("user_ci");
+        assertThat(tossAccount.isLinked()).isTrue();
+        assertThat(tossAccount.getUnlinkReferrer()).isNull();
+        assertThat(tossAccount.getUnlinkedAt()).isNull();
+        assertThat(tossAccount.getLastTokenRefreshedAt()).isEqualTo(LocalDateTime.now(fixedClock));
+    }
+
+    @Test
+    @DisplayName("Redis refresh token이 없으면 DB encrypted refresh token을 복호화해 refresh 한다")
+    void refreshesWithEncryptedRefreshTokenFromDatabaseWhenCacheMissing() {
+        TossTokenResponse response = new TossTokenResponse("Bearer", "new-access", "new-refresh", 1800L, "user_ci,name");
+        TossAccount tossAccount = createLinkedTossAccount(1L, "encrypted-db-refresh");
+
+        when(tossTokenStore.findAccessToken(1L)).thenReturn(Optional.empty());
+        when(tossTokenStore.findRefreshToken(1L)).thenReturn(Optional.empty());
+        when(tossAccountRepository.findByUserId(1L)).thenReturn(Optional.of(tossAccount));
+        when(tokenEncryptor.decrypt("encrypted-db-refresh")).thenReturn("db-refresh");
+        when(tossLoginApiClient.refreshToken(any(TossRefreshTokenRequest.class))).thenReturn(response);
+        when(tokenEncryptor.encrypt("new-refresh")).thenReturn("encrypted-new-refresh");
+
+        Optional<String> result = tossLoginSessionService.getValidAccessToken(1L);
+
+        assertThat(result).contains("new-access");
+        verify(tokenEncryptor).decrypt("encrypted-db-refresh");
+        verify(tossLoginApiClient).refreshToken(new TossRefreshTokenRequest("db-refresh"));
+        verify(tossTokenStore).saveAccessToken(1L, "new-access", 1_800_000L);
+        verify(tossTokenStore).saveRefreshToken(1L, "new-refresh", 600_000L);
+    }
+
+    @Test
+    @DisplayName("refresh token을 찾을 수 없으면 AUTH_013 예외를 던진다")
+    void throwsWhenRefreshTokenDoesNotExist() {
+        when(tossTokenStore.findRefreshToken(1L)).thenReturn(Optional.empty());
+        when(tossAccountRepository.findByUserId(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tossLoginSessionService.refreshLoginTokens(1L))
+                .isInstanceOf(BaseException.class)
+                .extracting(exception -> ((BaseException) exception).getErrorCode())
+                .isEqualTo(BaseErrorCode.AUTH_013);
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 성공 시 Redis와 DB 상태를 갱신한다")
+    void persistsTokensWhenRefreshSucceeds() {
+        TossTokenResponse response = new TossTokenResponse("Bearer", "new-access", "new-refresh", 7200L, "user_ci");
+        TossAccount tossAccount = createUnlinkedTossAccount(1L, "encrypted-old-refresh");
+
+        when(tossAccountRepository.findByUserId(1L)).thenReturn(Optional.of(tossAccount));
+        when(tokenEncryptor.encrypt("new-refresh")).thenReturn("encrypted-new-refresh");
+
+        tossLoginSessionService.persistLoginTokens(1L, response);
+
+        verify(tossTokenStore).saveAccessToken(1L, "new-access", 7_200_000L);
+        verify(tossTokenStore).saveRefreshToken(1L, "new-refresh", 600_000L);
+        assertThat(tossAccount.getEncryptedTossRefreshToken()).isEqualTo("encrypted-new-refresh");
+        assertThat(tossAccount.getScope()).isEqualTo("user_ci");
+        assertThat(tossAccount.isLinked()).isTrue();
+        assertThat(tossAccount.getUnlinkReferrer()).isNull();
+        assertThat(tossAccount.getUnlinkedAt()).isNull();
+        assertThat(tossAccount.getLastTokenRefreshedAt()).isEqualTo(LocalDateTime.now(fixedClock));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 응답에 필수값이 누락되면 AUTH_008 예외를 던진다")
+    void throwsWhenTokenResponseMissingRequiredFields() {
+        TossTokenResponse response = new TossTokenResponse("Bearer", null, "new-refresh", 3600L, "user_ci");
+
+        assertThatThrownBy(() -> tossLoginSessionService.persistLoginTokens(1L, response))
+                .isInstanceOf(BaseException.class)
+                .extracting(exception -> ((BaseException) exception).getErrorCode())
+                .isEqualTo(BaseErrorCode.AUTH_008);
+    }
+
+    @Test
+    @DisplayName("연동 계정이 없으면 AUTH_004 예외를 던진다")
+    void throwsWhenLinkedAccountDoesNotExist() {
+        TossTokenResponse response = new TossTokenResponse("Bearer", "new-access", "new-refresh", 3600L, "user_ci");
+
+        when(tossAccountRepository.findByUserId(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tossLoginSessionService.persistLoginTokens(1L, response))
+                .isInstanceOf(BaseException.class)
+                .extracting(exception -> ((BaseException) exception).getErrorCode())
+                .isEqualTo(BaseErrorCode.AUTH_004);
+    }
+
+    @Test
+    @DisplayName("토큰 저장 중 예외가 발생하면 AUTH_009 예외로 변환한다")
+    void throwsAuth009WhenTokenPersistenceFails() {
+        TossTokenResponse response = new TossTokenResponse("Bearer", "new-access", "new-refresh", 3600L, "user_ci");
+
+        doThrow(new RuntimeException("redis down"))
+                .when(tossTokenStore).saveAccessToken(eq(1L), eq("new-access"), eq(3_600_000L));
+
+        assertThatThrownBy(() -> tossLoginSessionService.persistLoginTokens(1L, response))
+                .isInstanceOf(BaseException.class)
+                .extracting(exception -> ((BaseException) exception).getErrorCode())
+                .isEqualTo(BaseErrorCode.AUTH_009);
+    }
+
+    @Test
+    @DisplayName("clearLoginTokens 호출 시 Redis access/refresh token을 모두 삭제한다")
+    void clearsBothAccessAndRefreshTokens() {
+        tossLoginSessionService.clearLoginTokens(1L);
+
+        verify(tossTokenStore).deleteAccessToken(1L);
+        verify(tossTokenStore).deleteRefreshToken(1L);
+    }
+
+    private TossAccount createLinkedTossAccount(Long userId, String encryptedRefreshToken) {
+        return TossAccount.builder()
+                .user(createUser(userId))
+                .tossUserKey(777L)
+                .encryptedTossRefreshToken(encryptedRefreshToken)
+                .scope("user_ci")
+                .isLinked(true)
+                .lastLoginAt(LocalDateTime.of(2026, 5, 14, 12, 0))
+                .lastTokenRefreshedAt(LocalDateTime.of(2026, 5, 14, 12, 0))
+                .build();
+    }
+
+    private TossAccount createUnlinkedTossAccount(Long userId, String encryptedRefreshToken) {
+        return TossAccount.builder()
+                .user(createUser(userId))
+                .tossUserKey(777L)
+                .encryptedTossRefreshToken(encryptedRefreshToken)
+                .scope("user_ci")
+                .isLinked(false)
+                .unlinkReferrer(TossUnlinkReferrer.UNLINK)
+                .unlinkedAt(LocalDateTime.of(2026, 5, 14, 13, 0))
+                .lastLoginAt(LocalDateTime.of(2026, 5, 14, 12, 0))
+                .lastTokenRefreshedAt(LocalDateTime.of(2026, 5, 14, 12, 0))
+                .build();
+    }
+
+    private Users createUser(Long userId) {
+        Users user = Users.builder()
+                .ci("ci-" + userId)
+                .name("tester")
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        return user;
+    }
+}


### PR DESCRIPTION
## 📍 요약
- 토스 인증 관련 테스트 코드를 추가하고 테스트 과정에서 발견한 예외 처리를 해결함

## 🔗 관련 이슈
- Closes #92 

## 📌 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [x] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->

#### 1. 토스 로그인/인증 서비스 테스트 보강
- `TossLoginServiceTest` 추가
  - 로그인 성공/실패
  - unlink, current user
  - userKey unlink
  - callback 처리
  - callback Basic Auth 검증
- `TossLoginSessionServiceTest` 추가
  - access token 조회
  - refresh token 기반 재발급
  - Redis/DB 토큰 저장 및 정리

#### 2. 보안, 저장소, 에러 처리 테스트 추가
- 암복호화 및 저장소 테스트 추가
  - `TokenEncryptorTest`, `TossUserInfoDecryptorTest`, `RedisTossTokenStoreTest`, `RedisTokenStoreContextTest`
- 토스 에러 응답 및 HTTP 클라이언트 테스트 보강
  - `TossLoginErrorResponseParserTest`, `TossHttpClientTest`
- 토스 네트워크 실패가 `TOSS_001`로 표준화되는지, 서비스 레벨에서 어떻게 처리되는지 테스트로 고정

#### 3. 컨트롤러, 통합 테스트 보강
- `AuthControllerTest` 보강
  - 로그인 요청 validation
  - integration-status
  - unlink, by-user-key 권한 검증
  - callback 인증/입력값 검증
- `TossLoginIntegrationTest` 추가
  - 로그인
  - 재로그인
  - unlink
  - callback
  - refresh 후 unlink 흐름 검증

#### 4. 테스트 과정에서 발견한 예외 처리 해결
- 누락된 request param이 `COMMON_004`로 처리되도록 `GlobalExceptionHandler` 보강
- 토스 네트워크/연결 실패가 raw 예외가 아닌 `TossApiException(TOSS_001)`로 내려가도록 `TossHttpClient` 보완

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - 토스 로그인/인증 관련 단위 테스트, 컨트롤러 테스트, 통합 테스트 실행
  - Redis key/TTL/암호화 저장 방식 검증
  - 토스 네트워크 예외의 `TOSS_001` 전환 및 서비스 정책 검증
