### PR TITLE
feat: 테스트 조회 응답 및 승인 필터 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ replay_pid*
 .env
 .env.*
 application-local.yml
+src/main/java/server/MATE/domain/auth/controller/LocalTestTokenController.java
 
 # External Secrets — Entra SP (Key Vault 읽기 전용)
 deploy/apps/mate/eso-azure-credentials.yaml

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -225,13 +225,15 @@ variable "kubernetes_api_allow_source_address_prefixes" {
 variable "kubernetes_nodeport_allow_source_address_prefixes" {
   description = "K8s 노드 NSG: NodePort(30000-32767) 허용 출발지. Ingress NodePort 외부 노출용."
   type        = list(string)
-  default     = ["VirtualNetwork"]
+  # 개발 중 임시 점검이 필요하더라도 "*" override는 커밋하지 않는다.
+  # 운영 반영 전에는 LB/내부망 경유만 허용하도록 제한한다.
+  default = ["VirtualNetwork"]
 }
 
 variable "kubernetes_ingress_lb_allow_source_address_prefixes" {
-  description = "K8s 노드 NSG: LB가 전달하는 ingress-nginx HTTP/HTTPS NodePort 허용 출발지. Cloudflare 프록시만 허용하려면 Cloudflare IP 대역으로 제한."
+  description = "K8s 노드 NSG: LB가 전달하는 ingress-nginx HTTP/HTTPS NodePort 허용 출발지. 기본값은 Azure Load Balancer만 허용해 직접 NodePort 접근을 차단."
   type        = list(string)
-  default     = ["Internet"]
+  default     = ["AzureLoadBalancer"]
 }
 
 variable "cloudflare_zone_id" {

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -225,9 +225,8 @@ variable "kubernetes_api_allow_source_address_prefixes" {
 variable "kubernetes_nodeport_allow_source_address_prefixes" {
   description = "K8s 노드 NSG: NodePort(30000-32767) 허용 출발지. Ingress NodePort 외부 노출용."
   type        = list(string)
-  # 개발 중 임시 점검이 필요하더라도 "*" override는 커밋하지 않는다.
-  # 운영 반영 전에는 LB/내부망 경유만 허용하도록 제한한다.
-  default = ["VirtualNetwork"]
+  # 운영 반영 전에는 LB/내부망 경유만 허용하도록 제한 예정
+  default     = ["VirtualNetwork"]
 }
 
 variable "kubernetes_ingress_lb_allow_source_address_prefixes" {

--- a/infra/terraform/modules/kubernetes_vms/variables.tf
+++ b/infra/terraform/modules/kubernetes_vms/variables.tf
@@ -77,15 +77,17 @@ variable "cluster_internal_allow_source_address_prefixes" {
 }
 
 variable "nodeport_allow_source_address_prefixes" {
-  description = "NodePort(30000-32767) 허용 출발지. 필요 시 * 로 인터넷 노출 가능."
+  description = "NodePort(30000-32767) 허용 출발지."
   type        = list(string)
-  default     = ["VirtualNetwork"]
+  # 개발 중 임시 점검이 필요하더라도 "*" override는 커밋하지 않는다.
+  # 운영 반영 전에는 LB/내부망 경유만 허용하도록 제한한다.
+  default = ["VirtualNetwork"]
 }
 
 variable "ingress_lb_allow_source_address_prefixes" {
-  description = "Ingress LB가 전달하는 HTTP/HTTPS NodePort 허용 출발지"
+  description = "Ingress LB가 전달하는 HTTP/HTTPS NodePort 허용 출발지. 기본값은 Azure Load Balancer 전달 트래픽만 허용."
   type        = list(string)
-  default     = ["Internet"]
+  default     = ["AzureLoadBalancer"]
 }
 
 variable "ingress_http_nodeport" {

--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -13,6 +13,7 @@ import server.MATE.domain.test.dto.request.TestCreateRequest;
 import server.MATE.domain.test.dto.request.TestUpdateRequest;
 import server.MATE.domain.test.dto.response.TestCreateResponse;
 import server.MATE.domain.test.dto.response.TestDetailResponse;
+import server.MATE.domain.test.dto.response.TestLikeResponse;
 import server.MATE.domain.test.dto.response.TestSummaryResponse;
 import server.MATE.domain.test.dto.response.TestUpdateResponse;
 import server.MATE.domain.test.service.TestService;
@@ -63,6 +64,26 @@ public class TestController {
     ) {
         TestDetailResponse data = testService.getTest(testId);
         return ResponseEntity.ok(ApiResponse.ok("테스트를 조회했습니다.", data));
+    }
+
+    @Operation(summary = "테스트 찜하기", description = "테스트를 찜하고 해당 테스트의 찜 개수를 1 증가시킵니다. 이미 찜한 테스트면 현재 상태를 반환합니다.")
+    @PostMapping("/{testId}/likes")
+    public ResponseEntity<ApiResponse<TestLikeResponse>> likeTest(
+            @PathVariable Long testId,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        TestLikeResponse response = testService.likeTest(testId, authenticatedUser.getId());
+        return ResponseEntity.ok(ApiResponse.ok("테스트를 찜했습니다.", response));
+    }
+
+    @Operation(summary = "테스트 찜 취소", description = "테스트 찜을 취소하고 해당 테스트의 찜 개수를 1 감소시킵니다. 찜하지 않은 테스트면 현재 상태를 반환합니다.")
+    @DeleteMapping("/{testId}/likes")
+    public ResponseEntity<ApiResponse<TestLikeResponse>> unlikeTest(
+            @PathVariable Long testId,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        TestLikeResponse response = testService.unlikeTest(testId, authenticatedUser.getId());
+        return ResponseEntity.ok(ApiResponse.ok("테스트 찜을 취소했습니다.", response));
     }
 
     @Operation(summary = "테스트 등록", description = """

--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -46,7 +46,7 @@ public class TestController {
     public ResponseEntity<ApiResponse<List<TestSummaryResponse>>> listTests(
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser
     ) {
-        List<TestSummaryResponse> data = testService.listTests();
+        List<TestSummaryResponse> data = testService.listTests(authenticatedUser.getId());
         return ResponseEntity.ok(ApiResponse.ok("테스트 목록을 조회했습니다.", data));
     }
 

--- a/src/main/java/server/MATE/domain/test/dto/response/TestDetailResponse.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/TestDetailResponse.java
@@ -13,7 +13,9 @@ public record TestDetailResponse(
         List<String> categories,
         List<String> imageKeys,
         Integer reward,
-        String description
+        String description,
+        String serviceName,
+        String serviceDescription
 ) {
     public static TestDetailResponse from(Test test) {
         List<String> categoryCodes = test.getCategories().stream()
@@ -28,7 +30,9 @@ public record TestDetailResponse(
                 categoryCodes,
                 keys,
                 test.getReward(),
-                test.getDescription()
+                test.getDescription(),
+                test.getServiceName(),
+                test.getServiceDescription()
         );
     }
 }

--- a/src/main/java/server/MATE/domain/test/dto/response/TestLikeResponse.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/TestLikeResponse.java
@@ -1,0 +1,8 @@
+package server.MATE.domain.test.dto.response;
+
+public record TestLikeResponse(
+        Long testId,
+        Boolean isLiked,
+        Long likeCount
+) {
+}

--- a/src/main/java/server/MATE/domain/test/dto/response/TestSummaryResponse.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/TestSummaryResponse.java
@@ -14,9 +14,11 @@ public record TestSummaryResponse(
         String title,
         String description,
         Integer reward,
+        Long likeCount,
+        Boolean isLiked,
         List<String> categories
 ) {
-    public static TestSummaryResponse from(Test test) {
+    public static TestSummaryResponse from(Test test, boolean isLiked) {
         List<String> keys = test.getImageKeys();
         String representative = keys.isEmpty() ? null : keys.getFirst();
         List<String> categories = test.getCategories().stream()
@@ -29,6 +31,8 @@ public record TestSummaryResponse(
                 test.getTitle(),
                 test.getDescription(),
                 test.getReward(),
+                test.getLikeCount(),
+                isLiked,
                 categories
         );
     }

--- a/src/main/java/server/MATE/domain/test/entity/Test.java
+++ b/src/main/java/server/MATE/domain/test/entity/Test.java
@@ -61,6 +61,9 @@ public class Test extends BaseEntity {
     @Column(nullable = false)
     private Long pplCount;
 
+    @Column(nullable = false, columnDefinition = "bigint default 0")
+    private Long likeCount;
+
     private LocalDateTime deletedAt;
 
     @OneToMany(mappedBy = "test", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -106,6 +109,16 @@ public class Test extends BaseEntity {
         this.pplCount++;
     }
 
+    public void incrementLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decrementLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
     public void delete(LocalDateTime deletedAt) {
         this.deletedAt = deletedAt;
     }
@@ -126,5 +139,6 @@ public class Test extends BaseEntity {
         this.goalPpl = 100;
         this.reward = 300;
         this.pplCount = 0L;
+        this.likeCount = 0L;
     }
 }

--- a/src/main/java/server/MATE/domain/test/entity/TestLike.java
+++ b/src/main/java/server/MATE/domain/test/entity/TestLike.java
@@ -1,0 +1,40 @@
+package server.MATE.domain.test.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.MATE.global.common.entity.BaseEntity;
+
+@Getter
+@Entity
+@Table(
+        name = "test_like",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "test_id"})
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TestLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private Long userId;
+
+    @Column(name = "test_id", nullable = false, updatable = false)
+    private Long testId;
+
+    @Builder
+    public TestLike(Long userId, Long testId) {
+        this.userId = userId;
+        this.testId = testId;
+    }
+}

--- a/src/main/java/server/MATE/domain/test/repository/TestLikeRepository.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestLikeRepository.java
@@ -1,0 +1,13 @@
+package server.MATE.domain.test.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.MATE.domain.test.entity.TestLike;
+
+import java.util.Optional;
+
+public interface TestLikeRepository extends JpaRepository<TestLike, Long> {
+
+    boolean existsByUserIdAndTestId(Long userId, Long testId);
+
+    Optional<TestLike> findByUserIdAndTestId(Long userId, Long testId);
+}

--- a/src/main/java/server/MATE/domain/test/repository/TestLikeRepository.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestLikeRepository.java
@@ -1,8 +1,12 @@
 package server.MATE.domain.test.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import server.MATE.domain.test.entity.TestLike;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface TestLikeRepository extends JpaRepository<TestLike, Long> {
@@ -10,4 +14,12 @@ public interface TestLikeRepository extends JpaRepository<TestLike, Long> {
     boolean existsByUserIdAndTestId(Long userId, Long testId);
 
     Optional<TestLike> findByUserIdAndTestId(Long userId, Long testId);
+
+    @Query("""
+            select tl.testId
+            from TestLike tl
+            where tl.userId = :userId
+              and tl.testId in :testIds
+            """)
+    List<Long> findLikedTestIds(@Param("userId") Long userId, @Param("testIds") Collection<Long> testIds);
 }

--- a/src/main/java/server/MATE/domain/test/repository/TestRepository.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import server.MATE.domain.test.entity.ApprovalStatus;
 import server.MATE.domain.test.entity.Test;
 
 import java.util.List;
@@ -14,9 +15,11 @@ import java.util.Optional;
 public interface TestRepository extends JpaRepository<Test, Long> {
 
     @EntityGraph(attributePaths = {"categories"})
-    List<Test> findAllByDeletedAtIsNullOrderByCreatedAtDesc();
+    List<Test> findAllByApprovalStatusAndDeletedAtIsNullOrderByCreatedAtDesc(ApprovalStatus approvalStatus);
 
     Optional<Test> findByIdAndDeletedAtIsNull(Long id);
+
+    Optional<Test> findByIdAndApprovalStatusAndDeletedAtIsNull(Long id, ApprovalStatus approvalStatus);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -8,9 +8,12 @@ import server.MATE.domain.test.dto.request.TestCreateRequest;
 import server.MATE.domain.test.dto.request.TestUpdateRequest;
 import server.MATE.domain.test.dto.response.TestCreateResponse;
 import server.MATE.domain.test.dto.response.TestDetailResponse;
+import server.MATE.domain.test.dto.response.TestLikeResponse;
 import server.MATE.domain.test.dto.response.TestSummaryResponse;
 import server.MATE.domain.test.dto.response.TestUpdateResponse;
 import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.entity.TestLike;
+import server.MATE.domain.test.repository.TestLikeRepository;
 import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
@@ -28,6 +31,7 @@ import java.util.Set;
 public class TestService {
 
     private final TestRepository testRepository;
+    private final TestLikeRepository testLikeRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final Clock clock;
 
@@ -120,5 +124,33 @@ public class TestService {
         }
 
         test.delete(LocalDateTime.now(clock));
+    }
+
+    public TestLikeResponse likeTest(Long testId, Long userId) {
+        Test test = testRepository.findByIdAndDeletedAtIsNullForUpdate(testId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        if (!testLikeRepository.existsByUserIdAndTestId(userId, testId)) {
+            testLikeRepository.save(TestLike.builder()
+                    .userId(userId)
+                    .testId(testId)
+                    .build());
+            test.incrementLikeCount();
+        }
+
+        return new TestLikeResponse(test.getId(), true, test.getLikeCount());
+    }
+
+    public TestLikeResponse unlikeTest(Long testId, Long userId) {
+        Test test = testRepository.findByIdAndDeletedAtIsNullForUpdate(testId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        testLikeRepository.findByUserIdAndTestId(userId, testId)
+                .ifPresent(testLike -> {
+                    testLikeRepository.delete(testLike);
+                    test.decrementLikeCount();
+                });
+
+        return new TestLikeResponse(test.getId(), false, test.getLikeCount());
     }
 }

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -11,6 +11,7 @@ import server.MATE.domain.test.dto.response.TestDetailResponse;
 import server.MATE.domain.test.dto.response.TestLikeResponse;
 import server.MATE.domain.test.dto.response.TestSummaryResponse;
 import server.MATE.domain.test.dto.response.TestUpdateResponse;
+import server.MATE.domain.test.entity.ApprovalStatus;
 import server.MATE.domain.test.entity.Test;
 import server.MATE.domain.test.entity.TestLike;
 import server.MATE.domain.test.repository.TestLikeRepository;
@@ -22,6 +23,7 @@ import server.MATE.global.image.event.ImageDeleteEvent;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -36,16 +38,18 @@ public class TestService {
     private final Clock clock;
 
     @Transactional(readOnly = true)
-    public List<TestSummaryResponse> listTests() {
-        return testRepository.findAllByDeletedAtIsNullOrderByCreatedAtDesc().stream()
-                .map(TestSummaryResponse::from)
+    public List<TestSummaryResponse> listTests(Long userId) {
+        List<Test> tests = testRepository.findAllByApprovalStatusAndDeletedAtIsNullOrderByCreatedAtDesc(ApprovalStatus.ACCEPTED);
+        Set<Long> likedTestIds = findLikedTestIds(userId, tests);
+
+        return tests.stream()
+                .map(test -> TestSummaryResponse.from(test, likedTestIds.contains(test.getId())))
                 .toList();
     }
 
     @Transactional(readOnly = true)
     public TestDetailResponse getTest(Long testId) {
-        Test test = testRepository.findById(testId)
-                .filter(t -> t.getDeletedAt() == null)
+        Test test = testRepository.findByIdAndApprovalStatusAndDeletedAtIsNull(testId, ApprovalStatus.ACCEPTED)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
         return TestDetailResponse.from(test);
     }
@@ -152,5 +156,16 @@ public class TestService {
                 });
 
         return new TestLikeResponse(test.getId(), false, test.getLikeCount());
+    }
+
+    private Set<Long> findLikedTestIds(Long userId, List<Test> tests) {
+        if (tests.isEmpty()) {
+            return Set.of();
+        }
+
+        List<Long> testIds = tests.stream()
+                .map(Test::getId)
+                .toList();
+        return new HashSet<>(testLikeRepository.findLikedTestIds(userId, testIds));
     }
 }

--- a/src/main/java/server/MATE/global/security/config/SecurityConfig.java
+++ b/src/main/java/server/MATE/global/security/config/SecurityConfig.java
@@ -27,6 +27,7 @@ public class SecurityConfig {
     private static final String[] PUBLIC_WHITELIST = {
             "/",
             "/api/v1/auth/toss/login", "/api/v1/auth/reissue", "/api/v1/auth/toss/login/unlink/callback",
+            "/api/v1/auth/local-test-token",
             "/swagger-ui/**", "/swagger-ui.html", "/api-docs/**", "/v3/api-docs/**", "/docs/error-codes"
     };
 

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -8,10 +8,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Clock;
 import server.MATE.domain.test.dto.request.TestUpdateRequest;
+import server.MATE.domain.test.dto.response.TestLikeResponse;
 import server.MATE.domain.test.entity.Category;
+import server.MATE.domain.test.entity.TestLike;
+import server.MATE.domain.test.repository.TestLikeRepository;
 import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.global.image.event.ImageCleanupEvent;
 import server.MATE.global.image.event.ImageDeleteEvent;
@@ -30,6 +34,9 @@ class TestServiceTest {
 
     @Mock
     private TestRepository testRepository;
+
+    @Mock
+    private TestLikeRepository testLikeRepository;
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
@@ -54,6 +61,7 @@ class TestServiceTest {
                 .serviceDescription("기존 서비스 소개")
                 .imageKeys(new ArrayList<>(List.of("old-key-1", "old-key-2")))
                 .build();
+        ReflectionTestUtils.setField(test, "id", TEST_ID);
         test.addCategories(List.of(Category.FOOD));
     }
 
@@ -91,5 +99,37 @@ class TestServiceTest {
         testService.updateTest(TEST_ID, request, MAKER_ID);
 
         verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void 테스트_찜_시_찜_정보를_저장하고_카운트를_증가시킨다() {
+        given(testRepository.findByIdAndDeletedAtIsNullForUpdate(TEST_ID)).willReturn(Optional.of(test));
+        given(testLikeRepository.existsByUserIdAndTestId(MAKER_ID, TEST_ID)).willReturn(false);
+
+        TestLikeResponse response = testService.likeTest(TEST_ID, MAKER_ID);
+
+        assertThat(response.testId()).isEqualTo(TEST_ID);
+        assertThat(response.isLiked()).isTrue();
+        assertThat(response.likeCount()).isEqualTo(1L);
+        verify(testLikeRepository).save(any(TestLike.class));
+    }
+
+    @Test
+    void 테스트_찜_취소_시_찜_정보를_삭제하고_카운트를_감소시킨다() {
+        TestLike testLike = TestLike.builder()
+                .userId(MAKER_ID)
+                .testId(TEST_ID)
+                .build();
+        test.incrementLikeCount();
+
+        given(testRepository.findByIdAndDeletedAtIsNullForUpdate(TEST_ID)).willReturn(Optional.of(test));
+        given(testLikeRepository.findByUserIdAndTestId(MAKER_ID, TEST_ID)).willReturn(Optional.of(testLike));
+
+        TestLikeResponse response = testService.unlikeTest(TEST_ID, MAKER_ID);
+
+        assertThat(response.testId()).isEqualTo(TEST_ID);
+        assertThat(response.isLiked()).isFalse();
+        assertThat(response.likeCount()).isZero();
+        verify(testLikeRepository).delete(testLike);
     }
 }


### PR DESCRIPTION
## 📍 요약
- 테스트 조회 API에서 승인된 테스트만 노출하고 목록/상세 응답에 필요한 추가 정보를 반환하도록 변경했습니다.

## 🔗 관련 이슈
- Closes #98

## 📌 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- 테스트 전체 조회 시 `approvalStatus`가 `ACCEPTED`인 테스트만 조회되도록 변경함
- 테스트 전체 조회 응답에 현재 사용자의 찜 여부(`isLiked`)와 찜 개수(`likeCount`)를 추가함
- 테스트 상세 조회 시 `approvalStatus`가 `ACCEPTED`인 테스트만 조회되도록 변경함
- 테스트 상세 조회 응답에 서비스 소개 정보(`serviceName`, `serviceDescription`)를 추가함
- 찜한 테스트 ID를 한 번에 조회해 목록 응답의 `isLiked` 값을 계산하도록 처리함

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법: