### PR TITLE
feat: 질문 목록 조회 API 구현

### DIFF
--- a/src/main/java/server/MATE/domain/question/controller/QuestionController.java
+++ b/src/main/java/server/MATE/domain/question/controller/QuestionController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import server.MATE.domain.question.dto.request.QuestionCreateRequest;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
 import server.MATE.domain.question.dto.response.QuestionDetailResponse;
+import server.MATE.domain.question.dto.response.QuestionSummaryResponse;
 import server.MATE.domain.question.service.QuestionService;
 import server.MATE.global.common.response.ApiResponse;
 import server.MATE.global.security.principal.AuthenticatedUser;
@@ -303,6 +304,21 @@ public class QuestionController {
     ) {
         QuestionDetailResponse response = questionService.getQuestions(testId, authenticatedUser.getId());
         return ResponseEntity.ok(ApiResponse.ok("문항을 조회했습니다.", response));
+    }
+
+    @Operation(summary = "질문 목록 조회", description = """
+            testId에 해당하는 테스트의 질문 목록 정보를 조회합니다. 통계의 질문 탭 MKST_01 화면에 해당하는 api입니다.
+            - 테스트 메이커만 조회할 수 있습니다.
+            - 테스트가 종료된 경우에만 조회할 수 있습니다.
+            - 질문 개수, 테스트 참여자 수, 질문 목록을 반환합니다.
+            """)
+    @GetMapping("/summary")
+    public ResponseEntity<ApiResponse<QuestionSummaryResponse>> getQuestionSummary(
+            @PathVariable Long testId,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        QuestionSummaryResponse response = questionService.getQuestionSummary(testId, authenticatedUser.getId());
+        return ResponseEntity.ok(ApiResponse.ok("질문 목록을 조회했습니다.", response));
     }
 
     @Operation(summary = "질문 전체 등록", description = """

--- a/src/main/java/server/MATE/domain/question/dto/response/QuestionSummaryItem.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/QuestionSummaryItem.java
@@ -1,0 +1,20 @@
+package server.MATE.domain.question.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import server.MATE.domain.question.entity.QuestionType;
+
+@Schema(description = "질문 목록 항목")
+public record QuestionSummaryItem(
+        @Schema(description = "질문 고유번호", example = "101")
+        Long questionId,
+
+        @Schema(description = "질문 순서", example = "1")
+        Long sequence,
+
+        @Schema(description = "질문 제목", example = "가장 자주 사용하는 기능은 무엇인가요?")
+        String title,
+
+        @Schema(description = "질문 유형", example = "OBJECTIVE")
+        QuestionType type
+) {
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/QuestionSummaryResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/QuestionSummaryResponse.java
@@ -1,0 +1,18 @@
+package server.MATE.domain.question.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "질문 목록 조회 응답")
+public record QuestionSummaryResponse(
+        @Schema(description = "질문 개수", example = "7")
+        int questionCount,
+
+        @Schema(description = "테스트 참여자 수", example = "53")
+        Long participantCount,
+
+        @Schema(description = "질문 목록")
+        List<QuestionSummaryItem> questions
+) {
+}

--- a/src/main/java/server/MATE/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/QuestionRepository.java
@@ -1,6 +1,8 @@
 package server.MATE.domain.question.repository;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import server.MATE.domain.question.dto.response.QuestionSummaryItem;
 import server.MATE.domain.question.entity.Question;
 
 import java.util.List;
@@ -13,5 +15,17 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     List<Question> findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(Long testId);
 
-    Optional<Question> findByIdAndDeletedAtIsNull(Long id);
+    @Query("""
+            select new server.MATE.domain.question.dto.response.QuestionSummaryItem(
+                q.id,
+                q.sequence,
+                q.title,
+                q.questionType
+            )
+            from Question q
+            where q.testId = :testId
+              and q.deletedAt is null
+            order by q.sequence asc
+            """)
+    List<QuestionSummaryItem> findQuestionSummariesByTestId(Long testId);
 }

--- a/src/main/java/server/MATE/domain/question/service/QuestionService.java
+++ b/src/main/java/server/MATE/domain/question/service/QuestionService.java
@@ -9,12 +9,15 @@ import server.MATE.domain.question.dto.response.QuestionCreateResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResult;
 import server.MATE.domain.question.dto.response.QuestionDetailItem;
 import server.MATE.domain.question.dto.response.QuestionDetailResponse;
+import server.MATE.domain.question.dto.response.QuestionSummaryItem;
+import server.MATE.domain.question.dto.response.QuestionSummaryResponse;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.repository.QuestionRepository;
 import server.MATE.domain.question.service.handler.QuestionCreateHandler;
 import server.MATE.domain.question.service.fetcher.QuestionDetailFetcher;
 import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
@@ -122,6 +125,22 @@ public class QuestionService {
                 .toList();
 
         return new QuestionDetailResponse(testId, results);
+    }
+
+    @Transactional(readOnly = true)
+    public QuestionSummaryResponse getQuestionSummary(Long testId, Long makerId) {
+        Test test = testRepository.findByIdAndDeletedAtIsNull(testId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        if (!test.getMakerId().equals(makerId)) throw new BaseException(BaseErrorCode.TEST_005);
+        if (test.getTestStatus() != TestStatus.COMPLETED) throw new BaseException(BaseErrorCode.TEST_006);
+
+        List<QuestionSummaryItem> questions = questionRepository.findQuestionSummariesByTestId(testId);
+        return new QuestionSummaryResponse(
+                questions.size(),
+                test.getPplCount(),
+                questions
+        );
     }
 
     private Map<QuestionType, QuestionCreateHandler> buildHandlerMap(List<QuestionCreateHandler> handlers) {

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -41,6 +41,7 @@ public enum BaseErrorCode implements ErrorCode {
     TEST_003(HttpStatus.BAD_REQUEST, "TEST_003", "지원하지 않는 이미지 형식입니다. JPG, PNG만 허용됩니다."),
     TEST_004(HttpStatus.NOT_FOUND, "TEST_004", "테스트를 찾을 수 없습니다."),
     TEST_005(HttpStatus.FORBIDDEN, "TEST_005", "테스트 제작자만 접근할 수 있습니다."),
+    TEST_006(HttpStatus.BAD_REQUEST, "TEST_006", "테스트가 종료된 후에 조회할 수 있습니다."),
 
     // Question
     QUESTION_001(HttpStatus.BAD_REQUEST, "QUESTION_001", "최소 선택 개수는 1 이상이어야 합니다."),

--- a/src/test/java/server/MATE/domain/question/controller/QuestionControllerTest.java
+++ b/src/test/java/server/MATE/domain/question/controller/QuestionControllerTest.java
@@ -27,6 +27,8 @@ import server.MATE.domain.question.dto.response.ObjectiveDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResult;
 import server.MATE.domain.question.dto.response.QuestionDetailResponse;
+import server.MATE.domain.question.dto.response.QuestionSummaryItem;
+import server.MATE.domain.question.dto.response.QuestionSummaryResponse;
 import server.MATE.domain.question.dto.response.ScaleDetailResponse;
 import server.MATE.domain.question.dto.response.SubjectiveDetailResponse;
 import server.MATE.domain.question.dto.response.TreeTestDetailResponse;
@@ -124,6 +126,36 @@ class QuestionControllerTest {
                 .andExpect(jsonPath("$.data.questions[0].options[0].objectiveOptionId").value(1001))
                 .andExpect(jsonPath("$.data.questions[0].options[1].sequence").value(2))
                 .andExpect(jsonPath("$.data.questions[0].options[2].isOtherOption").value(true));
+    }
+
+    @Test
+    @DisplayName("질문 목록 조회 요청을 정상 처리한다")
+    void handlesQuestionSummaryRequestSuccessfully() throws Exception {
+        QuestionSummaryResponse response = new QuestionSummaryResponse(
+                2,
+                17L,
+                List.of(
+                        new QuestionSummaryItem(101L, 1L, "첫 번째 질문", QuestionType.OBJECTIVE),
+                        new QuestionSummaryItem(102L, 2L, "두 번째 질문", QuestionType.SCALE)
+                )
+        );
+        given(questionService.getQuestionSummary(10L, 1L)).willReturn(response);
+
+        mockMvc.perform(get("/api/v1/tests/10/questions/summary")
+                        .with(authenticationPrincipal()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("질문 요약을 조회했습니다."))
+                .andExpect(jsonPath("$.data.questionCount").value(2))
+                .andExpect(jsonPath("$.data.participantCount").value(17))
+                .andExpect(jsonPath("$.data.questions.length()").value(2))
+                .andExpect(jsonPath("$.data.questions[0].questionId").value(101))
+                .andExpect(jsonPath("$.data.questions[0].sequence").value(1))
+                .andExpect(jsonPath("$.data.questions[0].title").value("첫 번째 질문"))
+                .andExpect(jsonPath("$.data.questions[0].type").value("OBJECTIVE"))
+                .andExpect(jsonPath("$.data.questions[1].questionId").value(102))
+                .andExpect(jsonPath("$.data.questions[1].type").value("SCALE"));
     }
 
     @Test

--- a/src/test/java/server/MATE/domain/question/controller/QuestionControllerTest.java
+++ b/src/test/java/server/MATE/domain/question/controller/QuestionControllerTest.java
@@ -146,7 +146,7 @@ class QuestionControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.message").value("질문 요약을 조회했습니다."))
+                .andExpect(jsonPath("$.message").value("질문 목록을 조회했습니다."))
                 .andExpect(jsonPath("$.data.questionCount").value(2))
                 .andExpect(jsonPath("$.data.participantCount").value(17))
                 .andExpect(jsonPath("$.data.questions.length()").value(2))

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
@@ -18,12 +18,15 @@ import server.MATE.domain.question.dto.response.ObjectiveDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
 import server.MATE.domain.question.dto.response.QuestionDetailItem;
 import server.MATE.domain.question.dto.response.QuestionDetailResponse;
+import server.MATE.domain.question.dto.response.QuestionSummaryResponse;
 import server.MATE.domain.question.dto.response.ScaleDetailResponse;
+import server.MATE.domain.question.dto.response.QuestionSummaryItem;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.repository.QuestionRepository;
 import server.MATE.domain.question.service.fetcher.QuestionDetailFetcher;
 import server.MATE.domain.question.service.handler.QuestionCreateHandler;
+import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
@@ -182,6 +185,55 @@ class QuestionServiceTest {
         assertThat(response.questions()).isEmpty();
         verify(objectiveFetcher, never()).fetch(anyList());
         verify(scaleFetcher, never()).fetch(anyList());
+    }
+
+    @Test
+    @DisplayName("질문 목록 조회는 질문 개수와 참여자 수를 함께 반환한다")
+    void getQuestionSummaryReturnsCountsAndQuestionSummaries() {
+        setTestStatus(test, TestStatus.COMPLETED);
+        setTestPplCount(test, 12L);
+
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(questionRepository.findQuestionSummariesByTestId(TEST_ID)).willReturn(List.of(
+                new QuestionSummaryItem(202L, 1L, "척도 질문", QuestionType.SCALE),
+                new QuestionSummaryItem(201L, 2L, "객관식 질문", QuestionType.OBJECTIVE)
+        ));
+
+        QuestionSummaryResponse response = questionService.getQuestionSummary(TEST_ID, MAKER_ID);
+
+        assertThat(response.questionCount()).isEqualTo(2);
+        assertThat(response.participantCount()).isEqualTo(12L);
+        assertThat(response.questions()).extracting(QuestionSummaryItem::questionId)
+                .containsExactly(202L, 201L);
+        assertThat(response.questions()).extracting(QuestionSummaryItem::type)
+                .containsExactly(QuestionType.SCALE, QuestionType.OBJECTIVE);
+    }
+
+    @Test
+    @DisplayName("테스트가 진행 중이면 질문 요약 조회 시 TEST_006 예외가 발생한다")
+    void getQuestionSummaryThrowsTest006WhenTestIsInProgress() {
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+
+        assertThatThrownBy(() -> questionService.getQuestionSummary(TEST_ID, MAKER_ID))
+                .isInstanceOf(BaseException.class)
+                .extracting(ex -> ((BaseException) ex).getErrorCode())
+                .isEqualTo(BaseErrorCode.TEST_006);
+
+        verify(questionRepository, never()).findQuestionSummariesByTestId(TEST_ID);
+    }
+
+    @Test
+    @DisplayName("질문 요약 조회 요청자가 제작자가 아니면 TEST_005 예외가 발생한다")
+    void getQuestionSummaryThrowsTest005WhenMakerDoesNotMatch() {
+        setTestStatus(test, TestStatus.COMPLETED);
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+
+        assertThatThrownBy(() -> questionService.getQuestionSummary(TEST_ID, MAKER_ID + 1))
+                .isInstanceOf(BaseException.class)
+                .extracting(ex -> ((BaseException) ex).getErrorCode())
+                .isEqualTo(BaseErrorCode.TEST_005);
+
+        verify(questionRepository, never()).findQuestionSummariesByTestId(TEST_ID);
     }
 
     @Test
@@ -572,6 +624,26 @@ class QuestionServiceTest {
             java.lang.reflect.Field field = Question.class.getDeclaredField("id");
             field.setAccessible(true);
             field.set(question, id);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void setTestStatus(server.MATE.domain.test.entity.Test test, TestStatus status) {
+        try {
+            java.lang.reflect.Field field = server.MATE.domain.test.entity.Test.class.getDeclaredField("testStatus");
+            field.setAccessible(true);
+            field.set(test, status);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void setTestPplCount(server.MATE.domain.test.entity.Test test, Long pplCount) {
+        try {
+            java.lang.reflect.Field field = server.MATE.domain.test.entity.Test.class.getDeclaredField("pplCount");
+            field.setAccessible(true);
+            field.set(test, pplCount);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## 📍 요약
- 테스트 메이커가 종료된 테스트의 질문 목록을 조회하는 api를 구현함

## 🔗 관련 이슈
- Closes #112  

## 📌 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
#### 1. 조회 권한 및 정책 반영
- 질문 목록 조회는 테스트 메이커만 가능하도록 검증
   -  maker가 아니면 TEST_005
- 테스트가 종료된 경우에만 조회 가능하도록 검증
   - TestStatus.COMPLETED가 아니면 TEST_006

#### 2. 조회 성능 및 N+1 방지
- Summary api는 질문 유형별 상세 테이블을 조회하지 않음
- Question 기본 칼럼만 JPQL projection으로 직접 조회
- 총 쿼리는 다음의 2건으로 고정
   - 테스트 1건
   - 질문 summary 목록 1건

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew test --tests "server.MATE.domain.question.service.QuestionServiceTest" --tests "server.MATE.domain.question.controller.QuestionControllerTest"