### PR TITLE
feat: 질문 상세 조회 API 구현

### DIFF
--- a/src/main/java/server/MATE/domain/question/controller/QuestionController.java
+++ b/src/main/java/server/MATE/domain/question/controller/QuestionController.java
@@ -38,7 +38,8 @@ public class QuestionController {
             testId에 해당한 테스트의 모든 질문 문항을 상세조회합니다. TT01-01 화면에 해당하는 api 입니다.
             - 응답 루트에 `testId`와 `questions`를 함께 반환합니다.
             - `questions` 배열은 `sequence` 오름차순입니다.
-            - 각 질문 유지은 공통 필드와 유형별 상세 필드를 모두 포함합니다.
+            - 모든 로그인한 사용자가 조회할 수 있습니다.
+            - 각 질문은 공통 필드와 유형별 상세 필드를 모두 포함합니다.
             """)
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공",
@@ -299,10 +300,9 @@ public class QuestionController {
     })
     @GetMapping
     public ResponseEntity<ApiResponse<QuestionDetailResponse>> getQuestions(
-            @PathVariable Long testId,
-            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+            @PathVariable Long testId
     ) {
-        QuestionDetailResponse response = questionService.getQuestions(testId, authenticatedUser.getId());
+        QuestionDetailResponse response = questionService.getQuestions(testId);
         return ResponseEntity.ok(ApiResponse.ok("문항을 조회했습니다.", response));
     }
 

--- a/src/main/java/server/MATE/domain/question/controller/QuestionController.java
+++ b/src/main/java/server/MATE/domain/question/controller/QuestionController.java
@@ -308,7 +308,7 @@ public class QuestionController {
     }
 
     @Operation(summary = "질문 상세 조회", description = """
-            testId에 해당하는 테스트의 특정 질문 문항 하나를 상세조회합니다.
+            testId에 해당하는 테스트의 특정 질문 문항 하나를 상세조회합니다. 통계의 질문 탭 MKST_01 화면에 해당하는 api입니다.
             - 응답 루트에 `testId`와 `question`을 함께 반환합니다.
             - `question`은 공통 필드와 유형별 상세 필드를 모두 포함합니다.
             - 별도로 조회 요청한 유저가 해당 테스트 메이커인지 검증하지 않습니다.

--- a/src/main/java/server/MATE/domain/question/controller/QuestionController.java
+++ b/src/main/java/server/MATE/domain/question/controller/QuestionController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import server.MATE.domain.question.dto.request.QuestionCreateRequest;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
+import server.MATE.domain.question.dto.response.QuestionDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionsDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionSummaryResponse;
 import server.MATE.domain.question.service.QuestionService;
@@ -304,6 +305,22 @@ public class QuestionController {
     ) {
         QuestionsDetailResponse questionsDetailResponse = questionService.getQuestionsDetails(testId);
         return ResponseEntity.ok(ApiResponse.ok("문항을 조회했습니다.", questionsDetailResponse));
+    }
+
+    @Operation(summary = "질문 상세 조회", description = """
+            testId에 해당하는 테스트의 특정 질문 문항 하나를 상세조회합니다.
+            - 응답 루트에 `testId`와 `question`을 함께 반환합니다.
+            - `question`은 공통 필드와 유형별 상세 필드를 모두 포함합니다.
+            - 별도로 조회 요청한 유저가 해당 테스트 메이커인지 검증하지 않습니다.
+            - 테스트 종료 여부를 검증하지 않습니다.
+            """)
+    @GetMapping("/{questionId}")
+    public ResponseEntity<ApiResponse<QuestionDetailResponse>> getQuestionDetail(
+            @PathVariable Long testId,
+            @PathVariable Long questionId
+    ) {
+        QuestionDetailResponse questionDetailResponse = questionService.getQuestionDetail(testId, questionId);
+        return ResponseEntity.ok(ApiResponse.ok("질문 상세 조회했습니다.", questionDetailResponse));
     }
 
     @Operation(summary = "질문 목록 조회", description = """

--- a/src/main/java/server/MATE/domain/question/controller/QuestionController.java
+++ b/src/main/java/server/MATE/domain/question/controller/QuestionController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import server.MATE.domain.question.dto.request.QuestionCreateRequest;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
-import server.MATE.domain.question.dto.response.QuestionDetailResponse;
+import server.MATE.domain.question.dto.response.QuestionsDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionSummaryResponse;
 import server.MATE.domain.question.service.QuestionService;
 import server.MATE.global.common.response.ApiResponse;
@@ -299,11 +299,11 @@ public class QuestionController {
                     ))
     })
     @GetMapping
-    public ResponseEntity<ApiResponse<QuestionDetailResponse>> getQuestions(
+    public ResponseEntity<ApiResponse<QuestionsDetailResponse>> getQuestionsDetails(
             @PathVariable Long testId
     ) {
-        QuestionDetailResponse response = questionService.getQuestions(testId);
-        return ResponseEntity.ok(ApiResponse.ok("문항을 조회했습니다.", response));
+        QuestionsDetailResponse questionsDetailResponse = questionService.getQuestionsDetails(testId);
+        return ResponseEntity.ok(ApiResponse.ok("문항을 조회했습니다.", questionsDetailResponse));
     }
 
     @Operation(summary = "질문 목록 조회", description = """

--- a/src/main/java/server/MATE/domain/question/controller/QuestionController.java
+++ b/src/main/java/server/MATE/domain/question/controller/QuestionController.java
@@ -314,13 +314,224 @@ public class QuestionController {
             - 별도로 조회 요청한 유저가 해당 테스트 메이커인지 검증하지 않습니다.
             - 테스트 종료 여부를 검증하지 않습니다.
             """)
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "객관식 상세 조회",
+                                            summary = "OBJECTIVE 상세 조회 예시",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "code": "200",
+                                                      "message": "문항을 조회했습니다.",
+                                                      "data": {
+                                                        "testId": 10,
+                                                        "question": {
+                                                          "questionId": 101,
+                                                          "objectiveId": 101,
+                                                          "type": "OBJECTIVE",
+                                                          "sequence": 1,
+                                                          "title": "가장 자주 사용하는 기능은 무엇인가요?",
+                                                          "description": "해당 서비스를 사용할 때 가장 자주 쓰는 기능을 골라주세요.",
+                                                          "isDuplicate": false,
+                                                          "minSelect": null,
+                                                          "maxSelect": null,
+                                                          "isOther": true,
+                                                          "options": [
+                                                            { "objectiveOptionId": 1001, "content": "검색", "imageKey": null, "sequence": 1, "isOtherOption": false },
+                                                            { "objectiveOptionId": 1002, "content": "결제", "imageKey": "objective-option-image-key", "sequence": 2, "isOtherOption": false },
+                                                            { "objectiveOptionId": 1099, "content": "기타 (직접 입력)", "imageKey": null, "sequence": 3, "isOtherOption": true }
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "주관식 상세 조회",
+                                            summary = "SUBJECTIVE 상세 조회 예시",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "code": "200",
+                                                      "message": "문항을 조회했습니다.",
+                                                      "data": {
+                                                        "testId": 10,
+                                                        "question": {
+                                                          "questionId": 102,
+                                                          "subjectiveId": 102,
+                                                          "type": "SUBJECTIVE",
+                                                          "sequence": 2,
+                                                          "title": "개선이 필요한 점은 무엇인가요?",
+                                                          "description": "자유롭게 작성해주세요.",
+                                                          "imageKey": "subjective-image-key"
+                                                        }
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "5초 테스트 상세 조회",
+                                            summary = "FIVE_SECOND 상세 조회 예시",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "code": "200",
+                                                      "message": "문항을 조회했습니다.",
+                                                      "data": {
+                                                        "testId": 10,
+                                                        "question": {
+                                                          "questionId": 103,
+                                                          "fiveSecondId": 103,
+                                                          "type": "FIVE_SECOND",
+                                                          "sequence": 3,
+                                                          "title": "첫 화면에서 눈에 띄는 요소는 무엇인가요?",
+                                                          "description": "이미지를 5초간 본 뒤 답변해주세요.",
+                                                          "imageKey": "five-second-image-key",
+                                                          "imageRatio": "9:16",
+                                                          "isObjective": true,
+                                                          "isDuplicate": true,
+                                                          "minSelect": 1,
+                                                          "maxSelect": 3,
+                                                          "isOther": true,
+                                                          "options": [
+                                                            { "fiveSecondOptionId": 2001, "content": "검색창", "sequence": 1, "isOtherOption": false },
+                                                            { "fiveSecondOptionId": 2002, "content": "메인 배너", "sequence": 2, "isOtherOption": false },
+                                                            { "fiveSecondOptionId": 2099, "content": "기타 (직접 입력)", "sequence": 3, "isOtherOption": true }
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "척도형 상세 조회",
+                                            summary = "SCALE 상세 조회 예시",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "code": "200",
+                                                      "message": "문항을 조회했습니다.",
+                                                      "data": {
+                                                        "testId": 10,
+                                                        "question": {
+                                                          "questionId": 104,
+                                                          "scaleId": 104,
+                                                          "type": "SCALE",
+                                                          "sequence": 4,
+                                                          "title": "전반적인 만족도를 평가해주세요.",
+                                                          "description": "5점 척도로 응답해주세요.",
+                                                          "imageKey": null,
+                                                          "minLabel": "매우 불만족",
+                                                          "maxLabel": "매우 만족",
+                                                          "range": 5
+                                                        }
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "AB 테스트 상세 조회",
+                                            summary = "AB_TEST 상세 조회 예시",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "code": "200",
+                                                      "message": "문항을 조회했습니다.",
+                                                      "data": {
+                                                        "testId": 10,
+                                                        "question": {
+                                                          "questionId": 105,
+                                                          "abTestId": 105,
+                                                          "type": "AB_TEST",
+                                                          "sequence": 5,
+                                                          "title": "어느 시안이 더 마음에 드시나요?",
+                                                          "description": "두 시안을 비교하고 더 선호하는 쪽을 선택해주세요.",
+                                                          "aImageKey": "image-a.jpg",
+                                                          "bImageKey": "image-b.jpg",
+                                                          "imageRatio": "9:16"
+                                                        }
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "카드소팅 상세 조회",
+                                            summary = "CARD_SORTING 상세 조회 예시",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "code": "200",
+                                                      "message": "문항을 조회했습니다.",
+                                                      "data": {
+                                                        "testId": 10,
+                                                        "question": {
+                                                          "questionId": 106,
+                                                          "cardSortingId": 106,
+                                                          "type": "CARD_SORTING",
+                                                          "sequence": 6,
+                                                          "title": "기능 카드를 그룹으로 묶어주세요.",
+                                                          "description": "비슷하다고 생각하는 항목끼리 분류해주세요.",
+                                                          "cards": ["티셔츠", "꽃무늬가 들어간 티셔츠", "찢어진 청바지", "닥터마틴 워커"],
+                                                          "categories": ["상의", "하의", "신발"]
+                                                        }
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "트리 테스트 상세 조회",
+                                            summary = "TREE_TEST 상세 조회 예시",
+                                            value = """
+                                                    {
+                                                      "success": true,
+                                                      "code": "200",
+                                                      "message": "문항을 조회했습니다.",
+                                                      "data": {
+                                                        "testId": 10,
+                                                        "question": {
+                                                          "questionId": 107,
+                                                          "type": "TREE_TEST",
+                                                          "sequence": 7,
+                                                          "title": "설정 메뉴에서 알림 설정을 어디서 찾으시겠어요?",
+                                                          "description": "예상되는 경로를 따라 선택해주세요.",
+                                                          "features": [
+                                                            {
+                                                              "treeTestId": 3001,
+                                                              "label": "마이페이지",
+                                                              "children": [
+                                                                {
+                                                                  "treeTestId": 3002,
+                                                                  "label": "설정",
+                                                                  "children": [
+                                                                    {
+                                                                      "treeTestId": 3003,
+                                                                      "label": "알림 설정",
+                                                                      "children": []
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            }
+                    ))
+    })
     @GetMapping("/{questionId}")
     public ResponseEntity<ApiResponse<QuestionDetailResponse>> getQuestionDetail(
             @PathVariable Long testId,
             @PathVariable Long questionId
     ) {
         QuestionDetailResponse questionDetailResponse = questionService.getQuestionDetail(testId, questionId);
-        return ResponseEntity.ok(ApiResponse.ok("질문 상세 조회했습니다.", questionDetailResponse));
+        return ResponseEntity.ok(ApiResponse.ok("문항을 조회했습니다.", questionDetailResponse));
     }
 
     @Operation(summary = "질문 목록 조회", description = """

--- a/src/main/java/server/MATE/domain/question/dto/response/QuestionDetailResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/QuestionDetailResponse.java
@@ -1,0 +1,7 @@
+package server.MATE.domain.question.dto.response;
+
+public record QuestionDetailResponse(
+        Long testId,
+        QuestionDetailItem question
+) {
+}

--- a/src/main/java/server/MATE/domain/question/dto/response/QuestionsDetailResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/QuestionsDetailResponse.java
@@ -2,7 +2,7 @@ package server.MATE.domain.question.dto.response;
 
 import java.util.List;
 
-public record QuestionDetailResponse(
+public record QuestionsDetailResponse(
         Long testId,
         List<QuestionDetailItem> questions
 ) {

--- a/src/main/java/server/MATE/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/QuestionRepository.java
@@ -13,6 +13,8 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     @Query("SELECT COALESCE(MAX(q.sequence), 0) FROM Question q WHERE q.testId = :testId")
     Long findMaxSequenceByTestId(Long testId);
 
+    Optional<Question> findByIdAndTestIdAndDeletedAtIsNull(Long id, Long testId);
+
     List<Question> findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(Long testId);
 
     @Query("""

--- a/src/main/java/server/MATE/domain/question/service/QuestionService.java
+++ b/src/main/java/server/MATE/domain/question/service/QuestionService.java
@@ -99,11 +99,9 @@ public class QuestionService {
     }
 
     @Transactional(readOnly = true)
-    public QuestionDetailResponse getQuestions(Long testId, Long makerId) {
+    public QuestionDetailResponse getQuestions(Long testId) {
         Test test = testRepository.findByIdAndDeletedAtIsNull(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
-
-        if (!test.getMakerId().equals(makerId)) throw new BaseException(BaseErrorCode.TEST_005);
 
         List<Question> questions = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId);
         Map<QuestionType, List<Question>> questionsByType = questions.stream()

--- a/src/main/java/server/MATE/domain/question/service/QuestionService.java
+++ b/src/main/java/server/MATE/domain/question/service/QuestionService.java
@@ -29,6 +29,7 @@ import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -140,7 +141,8 @@ public class QuestionService {
         }
 
         List<QuestionDetailItem> questionDetails = questions.stream()
-                .map(question -> questionDetailsById.get(question.getId()))
+                .map(question -> Optional.ofNullable(questionDetailsById.get(question.getId()))
+                        .orElseThrow(() -> new BaseException(BaseErrorCode.COMMON_002)))
                 .toList();
         return questionDetails;
     }

--- a/src/main/java/server/MATE/domain/question/service/QuestionService.java
+++ b/src/main/java/server/MATE/domain/question/service/QuestionService.java
@@ -8,14 +8,14 @@ import server.MATE.domain.question.dto.request.QuestionCreateRequest;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResult;
 import server.MATE.domain.question.dto.response.QuestionDetailItem;
-import server.MATE.domain.question.dto.response.QuestionDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionSummaryItem;
 import server.MATE.domain.question.dto.response.QuestionSummaryResponse;
+import server.MATE.domain.question.dto.response.QuestionsDetailResponse;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.repository.QuestionRepository;
-import server.MATE.domain.question.service.handler.QuestionCreateHandler;
 import server.MATE.domain.question.service.fetcher.QuestionDetailFetcher;
+import server.MATE.domain.question.service.handler.QuestionCreateHandler;
 import server.MATE.domain.test.entity.Test;
 import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.domain.test.repository.TestRepository;
@@ -25,8 +25,8 @@ import server.MATE.global.storage.event.FileCleanupEvent;
 
 import java.util.ArrayList;
 import java.util.EnumMap;
-import java.util.List;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -99,8 +99,8 @@ public class QuestionService {
     }
 
     @Transactional(readOnly = true)
-    public QuestionDetailResponse getQuestions(Long testId) {
-        Test test = testRepository.findByIdAndDeletedAtIsNull(testId)
+    public QuestionsDetailResponse getQuestionsDetails(Long testId) {
+        testRepository.findByIdAndDeletedAtIsNull(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
         List<Question> questions = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId);
@@ -111,18 +111,18 @@ public class QuestionService {
                         Collectors.toList()
                 ));
 
-        Map<Long, QuestionDetailItem> detailMap = new LinkedHashMap<>();
+        Map<Long, QuestionDetailItem> questionDetailsById = new LinkedHashMap<>();
         for (Map.Entry<QuestionType, List<Question>> entry : questionsByType.entrySet()) {
             QuestionDetailFetcher fetcher = fetcherMap.get(entry.getKey());
             if (fetcher == null) throw new BaseException(BaseErrorCode.COMMON_002);
-            detailMap.putAll(fetcher.fetch(entry.getValue()));
+            questionDetailsById.putAll(fetcher.fetch(entry.getValue()));
         }
 
-        List<QuestionDetailItem> results = questions.stream()
-                .map(question -> detailMap.get(question.getId()))
+        List<QuestionDetailItem> questionDetails = questions.stream()
+                .map(question -> questionDetailsById.get(question.getId()))
                 .toList();
 
-        return new QuestionDetailResponse(testId, results);
+        return new QuestionsDetailResponse(testId, questionDetails);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/server/MATE/domain/question/service/QuestionService.java
+++ b/src/main/java/server/MATE/domain/question/service/QuestionService.java
@@ -7,6 +7,7 @@ import server.MATE.domain.question.dto.request.QuestionCreateItem;
 import server.MATE.domain.question.dto.request.QuestionCreateRequest;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResult;
+import server.MATE.domain.question.dto.response.QuestionDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionDetailItem;
 import server.MATE.domain.question.dto.response.QuestionSummaryItem;
 import server.MATE.domain.question.dto.response.QuestionSummaryResponse;
@@ -104,6 +105,26 @@ public class QuestionService {
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
         List<Question> questions = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId);
+        List<QuestionDetailItem> questionDetails = buildQuestionDetails(questions);
+
+        return new QuestionsDetailResponse(testId, questionDetails);
+    }
+
+    @Transactional(readOnly = true)
+    public QuestionDetailResponse getQuestionDetail(Long testId, Long questionId) {
+        testRepository.findByIdAndDeletedAtIsNull(testId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        Question question = questionRepository.findByIdAndTestIdAndDeletedAtIsNull(questionId, testId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.QUESTION_005));
+
+        List<QuestionDetailItem> questionDetails = buildQuestionDetails(List.of(question));
+        return new QuestionDetailResponse(testId, questionDetails.getFirst());
+    }
+
+    private List<QuestionDetailItem> buildQuestionDetails(List<Question> questions) {
+        if (questions.isEmpty()) return List.of();
+
         Map<QuestionType, List<Question>> questionsByType = questions.stream()
                 .collect(Collectors.groupingBy(
                         Question::getQuestionType,
@@ -121,8 +142,7 @@ public class QuestionService {
         List<QuestionDetailItem> questionDetails = questions.stream()
                 .map(question -> questionDetailsById.get(question.getId()))
                 .toList();
-
-        return new QuestionsDetailResponse(testId, questionDetails);
+        return questionDetails;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -40,7 +40,7 @@ public enum BaseErrorCode implements ErrorCode {
     TEST_002(HttpStatus.BAD_REQUEST, "TEST_002", "이미지는 최대 10개까지 업로드할 수 있습니다."),
     TEST_003(HttpStatus.BAD_REQUEST, "TEST_003", "지원하지 않는 이미지 형식입니다. JPG, PNG만 허용됩니다."),
     TEST_004(HttpStatus.NOT_FOUND, "TEST_004", "테스트를 찾을 수 없습니다."),
-    TEST_005(HttpStatus.FORBIDDEN, "TEST_005", "테스트 제작자만 접근할 수 있습니다."),
+    TEST_005(HttpStatus.FORBIDDEN, "TEST_005", "테스트 메이커만 조회할 수 있습니다."),
     TEST_006(HttpStatus.BAD_REQUEST, "TEST_006", "테스트가 종료된 후에 조회할 수 있습니다."),
 
     // Question

--- a/src/test/java/server/MATE/domain/question/controller/QuestionControllerTest.java
+++ b/src/test/java/server/MATE/domain/question/controller/QuestionControllerTest.java
@@ -26,6 +26,7 @@ import server.MATE.domain.question.dto.response.ObjectiveOptionDetailResponse;
 import server.MATE.domain.question.dto.response.ObjectiveDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResult;
+import server.MATE.domain.question.dto.response.QuestionDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionsDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionSummaryItem;
 import server.MATE.domain.question.dto.response.QuestionSummaryResponse;
@@ -126,6 +127,44 @@ class QuestionControllerTest {
                 .andExpect(jsonPath("$.data.questions[0].options[0].objectiveOptionId").value(1001))
                 .andExpect(jsonPath("$.data.questions[0].options[1].sequence").value(2))
                 .andExpect(jsonPath("$.data.questions[0].options[2].isOtherOption").value(true));
+    }
+
+    @Test
+    @DisplayName("문항 상세 조회 요청을 정상 처리한다")
+    void handlesQuestionDetailRequestSuccessfully() throws Exception {
+        QuestionDetailResponse response = new QuestionDetailResponse(
+                10L,
+                new ObjectiveDetailResponse(
+                        101L,
+                        101L,
+                        QuestionType.OBJECTIVE,
+                        1L,
+                        "객관식 질문",
+                        "설명",
+                        false,
+                        null,
+                        null,
+                        true,
+                        List.of(
+                                new ObjectiveOptionDetailResponse(1001L, "A", null, 1, false),
+                                new ObjectiveOptionDetailResponse(1099L, "기타 (직접 입력)", null, 2, true)
+                        )
+                )
+        );
+        given(questionService.getQuestionDetail(10L, 101L)).willReturn(response);
+
+        mockMvc.perform(get("/api/v1/tests/10/questions/101")
+                        .with(authenticationPrincipal()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("질문 상세 조회했습니다."))
+                .andExpect(jsonPath("$.data.testId").value(10))
+                .andExpect(jsonPath("$.data.question.questionId").value(101))
+                .andExpect(jsonPath("$.data.question.objectiveId").value(101))
+                .andExpect(jsonPath("$.data.question.type").value("OBJECTIVE"))
+                .andExpect(jsonPath("$.data.question.sequence").value(1))
+                .andExpect(jsonPath("$.data.question.options[1].isOtherOption").value(true));
     }
 
     @Test

--- a/src/test/java/server/MATE/domain/question/controller/QuestionControllerTest.java
+++ b/src/test/java/server/MATE/domain/question/controller/QuestionControllerTest.java
@@ -26,7 +26,7 @@ import server.MATE.domain.question.dto.response.ObjectiveOptionDetailResponse;
 import server.MATE.domain.question.dto.response.ObjectiveDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResult;
-import server.MATE.domain.question.dto.response.QuestionDetailResponse;
+import server.MATE.domain.question.dto.response.QuestionsDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionSummaryItem;
 import server.MATE.domain.question.dto.response.QuestionSummaryResponse;
 import server.MATE.domain.question.dto.response.ScaleDetailResponse;
@@ -85,7 +85,7 @@ class QuestionControllerTest {
     @Test
     @DisplayName("문항 목록 조회 요청을 정상 처리한다")
     void handlesQuestionListRequestSuccessfully() throws Exception {
-        QuestionDetailResponse response = new QuestionDetailResponse(
+        QuestionsDetailResponse response = new QuestionsDetailResponse(
                 10L,
                 List.of(
                         new ObjectiveDetailResponse(
@@ -107,7 +107,7 @@ class QuestionControllerTest {
                         )
                 )
         );
-        given(questionService.getQuestions(10L)).willReturn(response);
+        given(questionService.getQuestionsDetails(10L)).willReturn(response);
 
         mockMvc.perform(get("/api/v1/tests/10/questions")
                         .with(authenticationPrincipal()))
@@ -161,7 +161,7 @@ class QuestionControllerTest {
     @Test
     @DisplayName("문항 목록 조회 응답은 타입별 상세 id 필드와 트리 노드 계약을 포함한다")
     void returnsDetailIdsAndTreeContractInQuestionListResponse() throws Exception {
-        QuestionDetailResponse response = new QuestionDetailResponse(
+        QuestionsDetailResponse response = new QuestionsDetailResponse(
                 10L,
                 List.of(
                         new ObjectiveDetailResponse(
@@ -188,7 +188,7 @@ class QuestionControllerTest {
                         )
                 )
         );
-        given(questionService.getQuestions(10L)).willReturn(response);
+        given(questionService.getQuestionsDetails(10L)).willReturn(response);
 
         mockMvc.perform(get("/api/v1/tests/10/questions")
                         .with(authenticationPrincipal()))
@@ -213,7 +213,7 @@ class QuestionControllerTest {
     @Test
     @DisplayName("문항 목록 조회 응답은 null 필드와 빈 리스트를 계약대로 직렬화한다")
     void serializesNullAndEmptyFieldsAsExpectedForQuestionDetails() throws Exception {
-        QuestionDetailResponse response = new QuestionDetailResponse(
+        QuestionsDetailResponse response = new QuestionsDetailResponse(
                 10L,
                 List.of(
                         new SubjectiveDetailResponse(101L, 201L, QuestionType.SUBJECTIVE, 1L, "주관식", "설명", null),
@@ -228,7 +228,7 @@ class QuestionControllerTest {
                         )
                 )
         );
-        given(questionService.getQuestions(10L)).willReturn(response);
+        given(questionService.getQuestionsDetails(10L)).willReturn(response);
 
         mockMvc.perform(get("/api/v1/tests/10/questions")
                         .with(authenticationPrincipal()))
@@ -251,7 +251,7 @@ class QuestionControllerTest {
     @Test
     @DisplayName("문항 목록 조회 응답은 상세 DTO 필드명을 안정적으로 유지한다")
     void usesStableResponseFieldNamesForDetailDtos() throws Exception {
-        QuestionDetailResponse response = new QuestionDetailResponse(
+        QuestionsDetailResponse response = new QuestionsDetailResponse(
                 10L,
                 List.of(
                         new ObjectiveDetailResponse(
@@ -266,7 +266,7 @@ class QuestionControllerTest {
                         )
                 )
         );
-        given(questionService.getQuestions(10L)).willReturn(response);
+        given(questionService.getQuestionsDetails(10L)).willReturn(response);
 
         mockMvc.perform(get("/api/v1/tests/10/questions")
                         .with(authenticationPrincipal()))

--- a/src/test/java/server/MATE/domain/question/controller/QuestionControllerTest.java
+++ b/src/test/java/server/MATE/domain/question/controller/QuestionControllerTest.java
@@ -107,7 +107,7 @@ class QuestionControllerTest {
                         )
                 )
         );
-        given(questionService.getQuestions(10L, 1L)).willReturn(response);
+        given(questionService.getQuestions(10L)).willReturn(response);
 
         mockMvc.perform(get("/api/v1/tests/10/questions")
                         .with(authenticationPrincipal()))
@@ -188,7 +188,7 @@ class QuestionControllerTest {
                         )
                 )
         );
-        given(questionService.getQuestions(10L, 1L)).willReturn(response);
+        given(questionService.getQuestions(10L)).willReturn(response);
 
         mockMvc.perform(get("/api/v1/tests/10/questions")
                         .with(authenticationPrincipal()))
@@ -228,7 +228,7 @@ class QuestionControllerTest {
                         )
                 )
         );
-        given(questionService.getQuestions(10L, 1L)).willReturn(response);
+        given(questionService.getQuestions(10L)).willReturn(response);
 
         mockMvc.perform(get("/api/v1/tests/10/questions")
                         .with(authenticationPrincipal()))
@@ -266,7 +266,7 @@ class QuestionControllerTest {
                         )
                 )
         );
-        given(questionService.getQuestions(10L, 1L)).willReturn(response);
+        given(questionService.getQuestions(10L)).willReturn(response);
 
         mockMvc.perform(get("/api/v1/tests/10/questions")
                         .with(authenticationPrincipal()))

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceIntegrationTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceIntegrationTest.java
@@ -123,7 +123,7 @@ class QuestionServiceIntegrationTest {
         savedTest.delete(LocalDateTime.now());
         testRepository.saveAndFlush(savedTest);
 
-        assertThatThrownBy(() -> questionService.getQuestions(savedTest.getId(), 1L))
+        assertThatThrownBy(() -> questionService.getQuestions(savedTest.getId()))
                 .isInstanceOf(BaseException.class)
                 .extracting(ex -> ((BaseException) ex).getErrorCode())
                 .isEqualTo(BaseErrorCode.TEST_004);
@@ -150,7 +150,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
 
         ObjectiveDetailResponse objectiveResponse = (ObjectiveDetailResponse) response.questions().getFirst();
         assertThat(objectiveResponse.options()).extracting(option -> option.content(), option -> option.sequence())
@@ -186,7 +186,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
 
         FiveSecondDetailResponse fiveSecondResponse = (FiveSecondDetailResponse) response.questions().getFirst();
         assertThat(fiveSecondResponse.options()).extracting(option -> option.content(), option -> option.sequence())
@@ -220,7 +220,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
 
         TreeTestDetailResponse treeResponse = (TreeTestDetailResponse) response.questions().getFirst();
         assertThat(treeResponse.features()).singleElement();
@@ -249,7 +249,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
 
         FiveSecondDetailResponse fiveSecondResponse = (FiveSecondDetailResponse) response.questions().getFirst();
         assertThat(fiveSecondResponse.fiveSecondId()).isNotNull();
@@ -286,7 +286,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
 
         FiveSecondDetailResponse fiveSecondResponse = (FiveSecondDetailResponse) response.questions().getFirst();
         assertThat(fiveSecondResponse.fiveSecondId()).isNotNull();
@@ -331,7 +331,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
 
         TreeTestDetailResponse treeResponse = (TreeTestDetailResponse) response.questions().getFirst();
         assertThat(treeResponse.features()).hasSize(2);
@@ -374,7 +374,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
 
         TreeTestDetailResponse treeResponse = (TreeTestDetailResponse) response.questions().getFirst();
         TreeTestNodeDetailResponse root = treeResponse.features().getFirst();
@@ -444,7 +444,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
 
         assertThat(response.questions()).hasSize(7);
 
@@ -528,7 +528,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId(), 1L);
+        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
 
         assertThat(response.testId()).isEqualTo(savedTest.getId());
         assertThat(response.questions()).extracting(QuestionDetailItem::type)

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceIntegrationTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceIntegrationTest.java
@@ -25,6 +25,7 @@ import server.MATE.domain.question.dto.response.CardSortingDetailResponse;
 import server.MATE.domain.question.dto.response.FiveSecondDetailResponse;
 import server.MATE.domain.question.dto.response.ObjectiveDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
+import server.MATE.domain.question.dto.response.QuestionDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionDetailItem;
 import server.MATE.domain.question.dto.response.QuestionsDetailResponse;
 import server.MATE.domain.question.dto.response.ScaleDetailResponse;
@@ -160,6 +161,67 @@ class QuestionServiceIntegrationTest {
                         org.assertj.core.groups.Tuple.tuple("세 번째", 3),
                         org.assertj.core.groups.Tuple.tuple("기타 (직접 입력)", 4)
                 );
+    }
+
+    @Test
+    @DisplayName("문항 상세 조회는 특정 문항 하나만 반환한다")
+    void getsSingleQuestionDetail() {
+        server.MATE.domain.test.entity.Test savedTest = createTest();
+
+        QuestionCreateResponse createResponse = questionService.createQuestions(savedTest.getId(), 1L, new QuestionCreateRequest(List.of(
+                new ObjectiveCreateRequest(
+                        "객관식 질문",
+                        "설명",
+                        false,
+                        null,
+                        null,
+                        true,
+                        List.of(
+                                new ObjectiveOptionRequest("첫 번째", null),
+                                new ObjectiveOptionRequest("두 번째", null)
+                        )
+                ),
+                new SubjectiveCreateRequest(
+                        "주관식 질문",
+                        "설명",
+                        null
+                )
+        )));
+
+        long questionId = createResponse.questions().getFirst().questionId();
+        QuestionDetailResponse response = questionService.getQuestionDetail(savedTest.getId(), questionId);
+
+        assertThat(response.testId()).isEqualTo(savedTest.getId());
+        assertThat(response.question()).isInstanceOf(ObjectiveDetailResponse.class);
+
+        ObjectiveDetailResponse objectiveResponse = (ObjectiveDetailResponse) response.question();
+        assertThat(objectiveResponse.questionId()).isEqualTo(questionId);
+        assertThat(objectiveResponse.options()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("문항 상세 조회에서 다른 테스트 문항이면 QUESTION_005 예외가 발생한다")
+    void throwsQuestion005WhenGettingQuestionDetailFromAnotherTest() {
+        server.MATE.domain.test.entity.Test firstTest = createTest();
+        server.MATE.domain.test.entity.Test secondTest = testRepository.save(server.MATE.domain.test.entity.Test.builder()
+                .makerId(2L)
+                .title("다른 테스트")
+                .description("설명")
+                .serviceName("서비스")
+                .serviceDescription("서비스 설명")
+                .imageKeys(List.of())
+                .build());
+
+        QuestionCreateResponse createResponse = questionService.createQuestions(secondTest.getId(), 2L, new QuestionCreateRequest(List.of(
+                new SubjectiveCreateRequest("주관식 질문", "설명", null)
+        )));
+
+        long foreignQuestionId = createResponse.questions().getFirst().questionId();
+
+        assertThatThrownBy(() -> questionService.getQuestionDetail(firstTest.getId(), foreignQuestionId))
+                .isInstanceOf(BaseException.class)
+                .extracting(ex -> ((BaseException) ex).getErrorCode())
+                .isEqualTo(BaseErrorCode.QUESTION_005);
     }
 
     @Test

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceIntegrationTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceIntegrationTest.java
@@ -26,7 +26,7 @@ import server.MATE.domain.question.dto.response.FiveSecondDetailResponse;
 import server.MATE.domain.question.dto.response.ObjectiveDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
 import server.MATE.domain.question.dto.response.QuestionDetailItem;
-import server.MATE.domain.question.dto.response.QuestionDetailResponse;
+import server.MATE.domain.question.dto.response.QuestionsDetailResponse;
 import server.MATE.domain.question.dto.response.ScaleDetailResponse;
 import server.MATE.domain.question.dto.response.SubjectiveDetailResponse;
 import server.MATE.domain.question.dto.response.TreeTestDetailResponse;
@@ -123,7 +123,7 @@ class QuestionServiceIntegrationTest {
         savedTest.delete(LocalDateTime.now());
         testRepository.saveAndFlush(savedTest);
 
-        assertThatThrownBy(() -> questionService.getQuestions(savedTest.getId()))
+        assertThatThrownBy(() -> questionService.getQuestionsDetails(savedTest.getId()))
                 .isInstanceOf(BaseException.class)
                 .extracting(ex -> ((BaseException) ex).getErrorCode())
                 .isEqualTo(BaseErrorCode.TEST_004);
@@ -150,7 +150,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
+        QuestionsDetailResponse response = questionService.getQuestionsDetails(savedTest.getId());
 
         ObjectiveDetailResponse objectiveResponse = (ObjectiveDetailResponse) response.questions().getFirst();
         assertThat(objectiveResponse.options()).extracting(option -> option.content(), option -> option.sequence())
@@ -186,7 +186,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
+        QuestionsDetailResponse response = questionService.getQuestionsDetails(savedTest.getId());
 
         FiveSecondDetailResponse fiveSecondResponse = (FiveSecondDetailResponse) response.questions().getFirst();
         assertThat(fiveSecondResponse.options()).extracting(option -> option.content(), option -> option.sequence())
@@ -220,7 +220,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
+        QuestionsDetailResponse response = questionService.getQuestionsDetails(savedTest.getId());
 
         TreeTestDetailResponse treeResponse = (TreeTestDetailResponse) response.questions().getFirst();
         assertThat(treeResponse.features()).singleElement();
@@ -249,7 +249,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
+        QuestionsDetailResponse response = questionService.getQuestionsDetails(savedTest.getId());
 
         FiveSecondDetailResponse fiveSecondResponse = (FiveSecondDetailResponse) response.questions().getFirst();
         assertThat(fiveSecondResponse.fiveSecondId()).isNotNull();
@@ -286,7 +286,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
+        QuestionsDetailResponse response = questionService.getQuestionsDetails(savedTest.getId());
 
         FiveSecondDetailResponse fiveSecondResponse = (FiveSecondDetailResponse) response.questions().getFirst();
         assertThat(fiveSecondResponse.fiveSecondId()).isNotNull();
@@ -331,7 +331,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
+        QuestionsDetailResponse response = questionService.getQuestionsDetails(savedTest.getId());
 
         TreeTestDetailResponse treeResponse = (TreeTestDetailResponse) response.questions().getFirst();
         assertThat(treeResponse.features()).hasSize(2);
@@ -374,7 +374,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
+        QuestionsDetailResponse response = questionService.getQuestionsDetails(savedTest.getId());
 
         TreeTestDetailResponse treeResponse = (TreeTestDetailResponse) response.questions().getFirst();
         TreeTestNodeDetailResponse root = treeResponse.features().getFirst();
@@ -444,7 +444,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
+        QuestionsDetailResponse response = questionService.getQuestionsDetails(savedTest.getId());
 
         assertThat(response.questions()).hasSize(7);
 
@@ -528,7 +528,7 @@ class QuestionServiceIntegrationTest {
                 )
         )));
 
-        QuestionDetailResponse response = questionService.getQuestions(savedTest.getId());
+        QuestionsDetailResponse response = questionService.getQuestionsDetails(savedTest.getId());
 
         assertThat(response.testId()).isEqualTo(savedTest.getId());
         assertThat(response.questions()).extracting(QuestionDetailItem::type)

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
@@ -17,7 +17,7 @@ import server.MATE.domain.question.dto.response.ObjectiveOptionDetailResponse;
 import server.MATE.domain.question.dto.response.ObjectiveDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
 import server.MATE.domain.question.dto.response.QuestionDetailItem;
-import server.MATE.domain.question.dto.response.QuestionDetailResponse;
+import server.MATE.domain.question.dto.response.QuestionsDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionSummaryResponse;
 import server.MATE.domain.question.dto.response.ScaleDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionSummaryItem;
@@ -163,7 +163,7 @@ class QuestionServiceTest {
                 )
         ));
 
-        QuestionDetailResponse response = questionService.getQuestions(TEST_ID);
+        QuestionsDetailResponse response = questionService.getQuestionsDetails(TEST_ID);
 
         assertThat(response.testId()).isEqualTo(TEST_ID);
         assertThat(response.questions()).extracting(QuestionDetailItem::questionId)
@@ -179,7 +179,7 @@ class QuestionServiceTest {
         given(questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID))
                 .willReturn(List.of());
 
-        QuestionDetailResponse response = questionService.getQuestions(TEST_ID);
+        QuestionsDetailResponse response = questionService.getQuestionsDetails(TEST_ID);
 
         assertThat(response.testId()).isEqualTo(TEST_ID);
         assertThat(response.questions()).isEmpty();
@@ -241,7 +241,7 @@ class QuestionServiceTest {
     void getQuestionsThrowsTest004WhenTestDoesNotExist() {
         given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> questionService.getQuestions(TEST_ID))
+        assertThatThrownBy(() -> questionService.getQuestionsDetails(TEST_ID))
                 .isInstanceOf(BaseException.class)
                 .extracting(ex -> ((BaseException) ex).getErrorCode())
                 .isEqualTo(BaseErrorCode.TEST_004);
@@ -256,7 +256,7 @@ class QuestionServiceTest {
     void getQuestionsThrowsTest004WhenTestIsDeleted() {
         given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> questionService.getQuestions(TEST_ID))
+        assertThatThrownBy(() -> questionService.getQuestionsDetails(TEST_ID))
                 .isInstanceOf(BaseException.class)
                 .extracting(ex -> ((BaseException) ex).getErrorCode())
                 .isEqualTo(BaseErrorCode.TEST_004);
@@ -297,7 +297,7 @@ class QuestionServiceTest {
                 )
         ));
 
-        QuestionDetailResponse response = questionService.getQuestions(TEST_ID);
+        QuestionsDetailResponse response = questionService.getQuestionsDetails(TEST_ID);
 
         assertThat(response.questions()).hasSize(1);
         verify(questionRepository).findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID);

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
@@ -16,6 +16,7 @@ import server.MATE.domain.question.dto.request.TreeTestCreateRequest;
 import server.MATE.domain.question.dto.response.ObjectiveOptionDetailResponse;
 import server.MATE.domain.question.dto.response.ObjectiveDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
+import server.MATE.domain.question.dto.response.QuestionDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionDetailItem;
 import server.MATE.domain.question.dto.response.QuestionsDetailResponse;
 import server.MATE.domain.question.dto.response.QuestionSummaryResponse;
@@ -188,6 +189,45 @@ class QuestionServiceTest {
     }
 
     @Test
+    @DisplayName("문항 상세 조회는 타입별 fetcher 결과를 조립한다")
+    void getQuestionDetailAssemblesFetcherResult() {
+        Question objectiveQuestion = Question.builder()
+                .testId(TEST_ID)
+                .questionType(QuestionType.OBJECTIVE)
+                .title("객관식 질문")
+                .description("설명")
+                .sequence(2L)
+                .build();
+        setQuestionId(objectiveQuestion, 201L);
+
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(questionRepository.findByIdAndTestIdAndDeletedAtIsNull(201L, TEST_ID))
+                .willReturn(Optional.of(objectiveQuestion));
+        given(objectiveFetcher.fetch(List.of(objectiveQuestion))).willReturn(Map.of(
+                201L,
+                new ObjectiveDetailResponse(
+                        201L,
+                        201L,
+                        QuestionType.OBJECTIVE,
+                        2L,
+                        "객관식 질문",
+                        "설명",
+                        false,
+                        null,
+                        null,
+                        true,
+                        List.of(new ObjectiveOptionDetailResponse(1001L, "A", null, 1, false))
+                )
+        ));
+
+        QuestionDetailResponse response = questionService.getQuestionDetail(TEST_ID, 201L);
+
+        assertThat(response.testId()).isEqualTo(TEST_ID);
+        assertThat(response.question().questionId()).isEqualTo(201L);
+        assertThat(response.question().type()).isEqualTo(QuestionType.OBJECTIVE);
+    }
+
+    @Test
     @DisplayName("질문 목록 조회는 질문 개수와 참여자 수를 함께 반환한다")
     void getQuestionSummaryReturnsCountsAndQuestionSummaries() {
         setTestStatus(test, TestStatus.COMPLETED);
@@ -264,6 +304,32 @@ class QuestionServiceTest {
         verify(questionRepository, never()).findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID);
         verify(objectiveFetcher, never()).fetch(anyList());
         verify(scaleFetcher, never()).fetch(anyList());
+    }
+
+    @Test
+    @DisplayName("문항 상세 조회 대상 테스트가 없으면 TEST_004 예외가 발생한다")
+    void getQuestionDetailThrowsTest004WhenTestDoesNotExist() {
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> questionService.getQuestionDetail(TEST_ID, 201L))
+                .isInstanceOf(BaseException.class)
+                .extracting(ex -> ((BaseException) ex).getErrorCode())
+                .isEqualTo(BaseErrorCode.TEST_004);
+
+        verify(questionRepository, never()).findByIdAndTestIdAndDeletedAtIsNull(any(), any());
+    }
+
+    @Test
+    @DisplayName("문항 상세 조회 대상 문항이 없으면 QUESTION_005 예외가 발생한다")
+    void getQuestionDetailThrowsQuestion005WhenQuestionDoesNotExist() {
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(questionRepository.findByIdAndTestIdAndDeletedAtIsNull(201L, TEST_ID))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> questionService.getQuestionDetail(TEST_ID, 201L))
+                .isInstanceOf(BaseException.class)
+                .extracting(ex -> ((BaseException) ex).getErrorCode())
+                .isEqualTo(BaseErrorCode.QUESTION_005);
     }
 
     @Test

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
@@ -163,7 +163,7 @@ class QuestionServiceTest {
                 )
         ));
 
-        QuestionDetailResponse response = questionService.getQuestions(TEST_ID, MAKER_ID);
+        QuestionDetailResponse response = questionService.getQuestions(TEST_ID);
 
         assertThat(response.testId()).isEqualTo(TEST_ID);
         assertThat(response.questions()).extracting(QuestionDetailItem::questionId)
@@ -179,7 +179,7 @@ class QuestionServiceTest {
         given(questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID))
                 .willReturn(List.of());
 
-        QuestionDetailResponse response = questionService.getQuestions(TEST_ID, MAKER_ID);
+        QuestionDetailResponse response = questionService.getQuestions(TEST_ID);
 
         assertThat(response.testId()).isEqualTo(TEST_ID);
         assertThat(response.questions()).isEmpty();
@@ -241,7 +241,7 @@ class QuestionServiceTest {
     void getQuestionsThrowsTest004WhenTestDoesNotExist() {
         given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> questionService.getQuestions(TEST_ID, MAKER_ID))
+        assertThatThrownBy(() -> questionService.getQuestions(TEST_ID))
                 .isInstanceOf(BaseException.class)
                 .extracting(ex -> ((BaseException) ex).getErrorCode())
                 .isEqualTo(BaseErrorCode.TEST_004);
@@ -256,7 +256,7 @@ class QuestionServiceTest {
     void getQuestionsThrowsTest004WhenTestIsDeleted() {
         given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> questionService.getQuestions(TEST_ID, MAKER_ID))
+        assertThatThrownBy(() -> questionService.getQuestions(TEST_ID))
                 .isInstanceOf(BaseException.class)
                 .extracting(ex -> ((BaseException) ex).getErrorCode())
                 .isEqualTo(BaseErrorCode.TEST_004);
@@ -267,18 +267,41 @@ class QuestionServiceTest {
     }
 
     @Test
-    @DisplayName("조회 요청자가 제작자가 아니면 TEST_005 예외가 발생한다")
-    void getQuestionsThrowsTest005WhenMakerDoesNotMatch() {
+    @DisplayName("문항 목록 조회는 제작자가 아니어도 조회할 수 있다")
+    void getQuestionsDoesNotRequireMaker() {
+        Question scaleQuestion = Question.builder()
+                .testId(TEST_ID)
+                .questionType(QuestionType.SCALE)
+                .title("척도 질문")
+                .description("설명")
+                .sequence(1L)
+                .build();
+        setQuestionId(scaleQuestion, 202L);
+
         given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID))
+                .willReturn(List.of(scaleQuestion));
+        given(scaleFetcher.fetch(List.of(scaleQuestion))).willReturn(Map.of(
+                202L,
+                new ScaleDetailResponse(
+                        202L,
+                        202L,
+                        QuestionType.SCALE,
+                        1L,
+                        "척도 질문",
+                        "설명",
+                        null,
+                        "낮음",
+                        "높음",
+                        5
+                )
+        ));
 
-        assertThatThrownBy(() -> questionService.getQuestions(TEST_ID, MAKER_ID + 1))
-                .isInstanceOf(BaseException.class)
-                .extracting(ex -> ((BaseException) ex).getErrorCode())
-                .isEqualTo(BaseErrorCode.TEST_005);
+        QuestionDetailResponse response = questionService.getQuestions(TEST_ID);
 
-        verify(questionRepository, never()).findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID);
-        verify(objectiveFetcher, never()).fetch(anyList());
-        verify(scaleFetcher, never()).fetch(anyList());
+        assertThat(response.questions()).hasSize(1);
+        verify(questionRepository).findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID);
+        verify(scaleFetcher).fetch(List.of(scaleQuestion));
     }
 
     @Test

--- a/src/test/java/server/MATE/integration/QuestionAnswerEndToEndFailureIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/QuestionAnswerEndToEndFailureIntegrationTest.java
@@ -681,14 +681,15 @@ class QuestionAnswerEndToEndFailureIntegrationTest extends BaseQuestionAnswerEnd
     }
 
     @Test
-    @DisplayName("maker가 아닌 사용자가 질문 조회하면 TEST_005를 반환한다")
-    void returnsTest005WhenNonMakerGetsQuestions() throws Exception {
+    @DisplayName("maker가 아닌 사용자도 질문 조회에 성공한다")
+    void nonMakerCanGetQuestions() throws Exception {
         TestActors actors = createActors();
         createSingleSubjectiveQuestion(actors.testId(), actors.makerToken());
 
-        performExpectingError(get("/api/v1/tests/{testId}/questions", actors.testId())
-                        .header("Authorization", actors.testerToken()),
-                403, "TEST_005");
+        JsonNode response = getQuestionsArray(actors.testId(), actors.testerToken());
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).path("type").asText()).isEqualTo("SUBJECTIVE");
     }
 
     @Test


### PR DESCRIPTION
## 📍 요약
- 테스트의 질문 1건을 상세 조회하는 api를 구현함. 기존 질문 전체 조회 응답 구조를 단건/복수 의미에 맞게 정리함

## 🔗 관련 이슈
- Closes #114 

## 📌 변경 사항
- [x] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [x] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
#### 1. 조회 권한 및 정책
- 테스트 메이커 여부, 테스트 종료 여부를 검증하지 않음

#### 2. 기존 질문 상세 조회 구조 재사용
- 기존 QuestionDetailFetcher 기반 상세 조립 로직을 공통 메소드로 분리하여 재사용함
- 질문 목록 조회와 질문 상세 조회가 동일한 상세 조립 로직을 사용하도록 구현
   - 타입별 fetcher를 그대로 활용
   - 단건 조회는 List.of(question) 을 사용

#### 3. 단일/복수 응답 DTO 정리
- 기존 질문 전체 조회 응답 DTO인 QuestionDetailResponse를 QuestionsDetailResponse로 변경
- 질문 상세 조회 응답 DTO를 QuestionDetailResponse로 사용

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew test --tests "server.MATE.domain.question.controller.QuestionControllerTest" --tests "server.MATE.domain.question.service.QuestionServiceTest" --tests "server.MATE.domain.question.service.QuestionServiceIntegrationTest"
