### PR TITLE
feat: 메이커 테스트 리포트 전체 조회 API 구현

### DIFF
--- a/src/main/java/server/MATE/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/server/MATE/domain/answer/repository/AnswerRepository.java
@@ -3,6 +3,9 @@ package server.MATE.domain.answer.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import server.MATE.domain.answer.entity.Answer;
 
+import java.util.List;
+
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
+    List<Answer> findAllByQuestionIdInAndDeletedAtIsNull(List<Long> questionIds);
 }

--- a/src/main/java/server/MATE/domain/report/controller/ReportController.java
+++ b/src/main/java/server/MATE/domain/report/controller/ReportController.java
@@ -1,0 +1,45 @@
+package server.MATE.domain.report.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import server.MATE.domain.report.dto.response.TestReportResponse;
+import server.MATE.domain.report.service.ReportService;
+import server.MATE.global.common.response.ApiResponse;
+import server.MATE.global.security.principal.AuthenticatedUser;
+
+@Tag(name = "[REPORT] 리포트 API", description = "테스트 결과 리포트 관련 API")
+@RestController
+@RequestMapping("/api/v1/tests/{testId}/report")
+@SecurityRequirement(name = "JWT")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @Operation(
+            summary = "테스트 리포트 전체 조회",
+            description = """
+                    메이커가 자신의 테스트에 대한 질문 목록 및 질문 유형별 응답 리포트를 조회합니다. MKST_01/MKST_02 화면에 해당합니다.
+                    - 테스트 소유자(메이커)만 조회할 수 있습니다.
+                    - `testStatus`가 `IN_PROGRESS`이면 `results`는 빈 리스트를 반환합니다.
+                    - `testStatus`가 `COMPLETED`이면 질문 유형별 리포트가 포함됩니다.
+                    - `questions`는 질문 탭(MKST_01), `results`는 결과 탭(MKST_02)에 사용됩니다.
+                    """
+    )
+    @GetMapping
+    public ResponseEntity<ApiResponse<TestReportResponse>> getReport(
+            @PathVariable Long testId,
+            @AuthenticationPrincipal AuthenticatedUser user
+    ) {
+        TestReportResponse response = reportService.getReport(testId, user.getId());
+        return ResponseEntity.ok(ApiResponse.ok("리포트를 조회했습니다.", response));
+    }
+}

--- a/src/main/java/server/MATE/domain/report/dto/response/AbTestReportResult.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/AbTestReportResult.java
@@ -1,0 +1,19 @@
+package server.MATE.domain.report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "A/B 테스트 리포트 결과")
+public record AbTestReportResult(
+        @Schema(description = "A안 응답 수", example = "7")
+        int aCount,
+
+        @Schema(description = "A안 응답 비율 (%)", example = "58.3")
+        double aPercentage,
+
+        @Schema(description = "B안 응답 수", example = "5")
+        int bCount,
+
+        @Schema(description = "B안 응답 비율 (%)", example = "41.7")
+        double bPercentage
+) {
+}

--- a/src/main/java/server/MATE/domain/report/dto/response/CardSortingCardResult.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/CardSortingCardResult.java
@@ -1,0 +1,19 @@
+package server.MATE.domain.report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "카드소팅 카드별 리포트")
+public record CardSortingCardResult(
+        @Schema(description = "순위", example = "1")
+        int rank,
+
+        @Schema(description = "카드명", example = "홈 화면")
+        String cardName,
+
+        @Schema(description = "해당 그룹에 배정한 응답 수", example = "9")
+        int count,
+
+        @Schema(description = "비율 (%)", example = "75.0")
+        double percentage
+) {
+}

--- a/src/main/java/server/MATE/domain/report/dto/response/CardSortingGroupResult.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/CardSortingGroupResult.java
@@ -1,0 +1,15 @@
+package server.MATE.domain.report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "카드소팅 그룹별 리포트")
+public record CardSortingGroupResult(
+        @Schema(description = "그룹명", example = "설정")
+        String groupName,
+
+        @Schema(description = "카드별 배정 결과 (응답 수 내림차순)")
+        List<CardSortingCardResult> cards
+) {
+}

--- a/src/main/java/server/MATE/domain/report/dto/response/CardSortingReportResult.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/CardSortingReportResult.java
@@ -1,0 +1,12 @@
+package server.MATE.domain.report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "카드소팅 리포트 결과")
+public record CardSortingReportResult(
+        @Schema(description = "그룹별 카드 배정 결과")
+        List<CardSortingGroupResult> groups
+) {
+}

--- a/src/main/java/server/MATE/domain/report/dto/response/ObjectiveReportResult.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/ObjectiveReportResult.java
@@ -1,0 +1,12 @@
+package server.MATE.domain.report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "객관식 리포트 결과")
+public record ObjectiveReportResult(
+        @Schema(description = "선택지별 결과 (응답 수 내림차순)")
+        List<OptionResult> options
+) {
+}

--- a/src/main/java/server/MATE/domain/report/dto/response/OptionResult.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/OptionResult.java
@@ -1,0 +1,19 @@
+package server.MATE.domain.report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "객관식/5초테스트(객관식) 선택지별 리포트")
+public record OptionResult(
+        @Schema(description = "선택지 ID", example = "101")
+        Long optionId,
+
+        @Schema(description = "선택지 텍스트", example = "검색")
+        String content,
+
+        @Schema(description = "선택 횟수", example = "8")
+        int count,
+
+        @Schema(description = "선택 비율 (%)", example = "53.3")
+        double percentage
+) {
+}

--- a/src/main/java/server/MATE/domain/report/dto/response/QuestionReportItem.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/QuestionReportItem.java
@@ -1,0 +1,23 @@
+package server.MATE.domain.report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import server.MATE.domain.question.entity.QuestionType;
+
+@Schema(description = "질문별 리포트 항목")
+public record QuestionReportItem(
+        @Schema(description = "질문 ID", example = "101")
+        Long questionId,
+
+        @Schema(description = "질문 순서", example = "1")
+        Long sequence,
+
+        @Schema(description = "질문 제목", example = "가장 자주 사용하는 기능은?")
+        String title,
+
+        @Schema(description = "질문 유형", example = "OBJECTIVE")
+        QuestionType type,
+
+        @Schema(description = "유형별 리포트 결과 (ObjectiveReportResult / SubjectiveReportResult / ScaleReportResult / AbTestReportResult / CardSortingReportResult / TreeTestReportResult)")
+        Object report
+) {
+}

--- a/src/main/java/server/MATE/domain/report/dto/response/ScaleDistributionItem.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/ScaleDistributionItem.java
@@ -1,0 +1,13 @@
+package server.MATE.domain.report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "척도 점수별 응답 분포")
+public record ScaleDistributionItem(
+        @Schema(description = "점수", example = "3")
+        int score,
+
+        @Schema(description = "해당 점수 응답 수", example = "5")
+        int count
+) {
+}

--- a/src/main/java/server/MATE/domain/report/dto/response/ScaleReportResult.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/ScaleReportResult.java
@@ -1,0 +1,15 @@
+package server.MATE.domain.report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "척도 리포트 결과")
+public record ScaleReportResult(
+        @Schema(description = "평균 점수", example = "3.8")
+        double average,
+
+        @Schema(description = "점수별 응답 분포 (1점 ~ 최대 범위)")
+        List<ScaleDistributionItem> distribution
+) {
+}

--- a/src/main/java/server/MATE/domain/report/dto/response/SubjectiveReportResult.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/SubjectiveReportResult.java
@@ -1,0 +1,12 @@
+package server.MATE.domain.report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "주관식 리포트 결과")
+public record SubjectiveReportResult(
+        @Schema(description = "응답 텍스트 목록 (응답 시각 오름차순, 최대 15개)")
+        List<String> responses
+) {
+}

--- a/src/main/java/server/MATE/domain/report/dto/response/TestReportResponse.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/TestReportResponse.java
@@ -1,0 +1,26 @@
+package server.MATE.domain.report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import server.MATE.domain.question.dto.response.QuestionSummaryItem;
+import server.MATE.domain.test.entity.TestStatus;
+
+import java.util.List;
+
+@Schema(description = "테스트 리포트 전체 조회 응답")
+public record TestReportResponse(
+        @Schema(description = "테스트 상태 (IN_PROGRESS / COMPLETED)", example = "COMPLETED")
+        TestStatus testStatus,
+
+        @Schema(description = "총 질문 수", example = "5")
+        int questionCount,
+
+        @Schema(description = "총 참여자 수", example = "12")
+        Long participantCount,
+
+        @Schema(description = "질문 목록 (순서 오름차순)")
+        List<QuestionSummaryItem> questions,
+
+        @Schema(description = "질문별 리포트 결과 (IN_PROGRESS 이면 빈 리스트)")
+        List<QuestionReportItem> results
+) {
+}

--- a/src/main/java/server/MATE/domain/report/dto/response/TreeTestNodeResult.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/TreeTestNodeResult.java
@@ -1,0 +1,19 @@
+package server.MATE.domain.report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "트리테스트 노드별 리포트")
+public record TreeTestNodeResult(
+        @Schema(description = "노드 ID", example = "42")
+        Long nodeId,
+
+        @Schema(description = "노드 레이블", example = "설정 > 알림")
+        String label,
+
+        @Schema(description = "해당 노드를 선택한 응답 수", example = "6")
+        int count,
+
+        @Schema(description = "비율 (%)", example = "50.0")
+        double percentage
+) {
+}

--- a/src/main/java/server/MATE/domain/report/dto/response/TreeTestReportResult.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/TreeTestReportResult.java
@@ -1,0 +1,12 @@
+package server.MATE.domain.report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "트리테스트 리포트 결과")
+public record TreeTestReportResult(
+        @Schema(description = "최종 선택 노드별 응답 분포 (응답 수 내림차순)")
+        List<TreeTestNodeResult> nodes
+) {
+}

--- a/src/main/java/server/MATE/domain/report/service/ReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/ReportHandler.java
@@ -1,0 +1,15 @@
+package server.MATE.domain.report.service;
+
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ReportHandler {
+
+    QuestionType supports();
+
+    Map<Long, Object> compute(List<Question> questions, Map<Long, List<Answer>> answersByQuestionId);
+}

--- a/src/main/java/server/MATE/domain/report/service/ReportService.java
+++ b/src/main/java/server/MATE/domain/report/service/ReportService.java
@@ -1,0 +1,112 @@
+package server.MATE.domain.report.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.answer.repository.AnswerRepository;
+import server.MATE.domain.question.dto.response.QuestionSummaryItem;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.QuestionRepository;
+import server.MATE.domain.report.dto.response.QuestionReportItem;
+import server.MATE.domain.report.dto.response.TestReportResponse;
+import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.entity.TestStatus;
+import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+public class ReportService {
+
+    private final TestRepository testRepository;
+    private final QuestionRepository questionRepository;
+    private final AnswerRepository answerRepository;
+    private final Map<QuestionType, ReportHandler> handlerMap;
+
+    public ReportService(TestRepository testRepository,
+                         QuestionRepository questionRepository,
+                         AnswerRepository answerRepository,
+                         List<ReportHandler> handlers) {
+        this.testRepository = testRepository;
+        this.questionRepository = questionRepository;
+        this.answerRepository = answerRepository;
+        this.handlerMap = buildHandlerMap(handlers);
+    }
+
+    public TestReportResponse getReport(Long testId, Long makerId) {
+        Test test = testRepository.findByIdAndDeletedAtIsNull(testId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        if (!test.getMakerId().equals(makerId)) throw new BaseException(BaseErrorCode.TEST_005);
+
+        List<Question> questions = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId);
+
+        List<QuestionSummaryItem> questionSummaries = questions.stream()
+                .map(q -> new QuestionSummaryItem(q.getId(), q.getSequence(), q.getTitle(), q.getQuestionType()))
+                .toList();
+
+        if (test.getTestStatus() == TestStatus.IN_PROGRESS) {
+            return new TestReportResponse(
+                    TestStatus.IN_PROGRESS,
+                    questions.size(),
+                    test.getPplCount(),
+                    questionSummaries,
+                    List.of()
+            );
+        }
+
+        List<Long> questionIds = questions.stream().map(Question::getId).toList();
+        List<Answer> allAnswers = answerRepository.findAllByQuestionIdInAndDeletedAtIsNull(questionIds);
+
+        Map<Long, List<Answer>> answersByQuestionId = allAnswers.stream()
+                .collect(Collectors.groupingBy(Answer::getQuestionId));
+
+        Map<QuestionType, List<Question>> questionsByType = questions.stream()
+                .collect(Collectors.groupingBy(
+                        Question::getQuestionType,
+                        () -> new EnumMap<>(QuestionType.class),
+                        Collectors.toList()
+                ));
+
+        Map<Long, Object> reportByQuestionId = new LinkedHashMap<>();
+        for (Map.Entry<QuestionType, List<Question>> entry : questionsByType.entrySet()) {
+            ReportHandler handler = handlerMap.get(entry.getKey());
+            if (handler == null) throw new BaseException(BaseErrorCode.COMMON_002);
+            reportByQuestionId.putAll(handler.compute(entry.getValue(), answersByQuestionId));
+        }
+
+        List<QuestionReportItem> results = questions.stream()
+                .map(q -> new QuestionReportItem(
+                        q.getId(),
+                        q.getSequence(),
+                        q.getTitle(),
+                        q.getQuestionType(),
+                        reportByQuestionId.get(q.getId())
+                ))
+                .toList();
+
+        return new TestReportResponse(
+                TestStatus.COMPLETED,
+                questions.size(),
+                test.getPplCount(),
+                questionSummaries,
+                results
+        );
+    }
+
+    private Map<QuestionType, ReportHandler> buildHandlerMap(List<ReportHandler> handlers) {
+        Map<QuestionType, ReportHandler> map = new EnumMap<>(QuestionType.class);
+        for (ReportHandler handler : handlers) {
+            map.put(handler.supports(), handler);
+        }
+        return map;
+    }
+}

--- a/src/main/java/server/MATE/domain/report/service/handler/AbTestReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/AbTestReportHandler.java
@@ -1,0 +1,48 @@
+package server.MATE.domain.report.service.handler;
+
+import org.springframework.stereotype.Component;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.report.dto.response.AbTestReportResult;
+import server.MATE.domain.report.service.ReportHandler;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class AbTestReportHandler implements ReportHandler {
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.AB_TEST;
+    }
+
+    @Override
+    public Map<Long, Object> compute(List<Question> questions, Map<Long, List<Answer>> answersByQuestionId) {
+        Map<Long, Object> result = new LinkedHashMap<>();
+        for (Question question : questions) {
+            List<Answer> answers = answersByQuestionId.getOrDefault(question.getId(), List.of());
+            result.put(question.getId(), computeForAbTest(answers));
+        }
+        return result;
+    }
+
+    private AbTestReportResult computeForAbTest(List<Answer> answers) {
+        int aCount = 0;
+        int bCount = 0;
+        for (Answer answer : answers) {
+            Object selectedObj = answer.getAnswer().get("selected");
+            if (selectedObj == null) continue;
+            String selected = String.valueOf(selectedObj);
+            if ("A".equals(selected)) aCount++;
+            else if ("B".equals(selected)) bCount++;
+        }
+        int total = aCount + bCount;
+        return new AbTestReportResult(
+                aCount, ReportHandlerUtils.toPercentage(aCount, total),
+                bCount, ReportHandlerUtils.toPercentage(bCount, total)
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/report/service/handler/CardSortingReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/CardSortingReportHandler.java
@@ -39,7 +39,6 @@ public class CardSortingReportHandler implements ReportHandler {
         Map<Long, Object> result = new LinkedHashMap<>();
         for (Question question : questions) {
             CardSorting cardSorting = cardSortingMap.get(question.getId());
-            if (cardSorting == null) continue;
             List<Answer> answers = answersByQuestionId.getOrDefault(question.getId(), List.of());
             result.put(question.getId(), computeForCardSorting(cardSorting, answers));
         }

--- a/src/main/java/server/MATE/domain/report/service/handler/CardSortingReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/CardSortingReportHandler.java
@@ -1,0 +1,100 @@
+package server.MATE.domain.report.service.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.question.entity.CardSorting;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.CardSortingRepository;
+import server.MATE.domain.report.dto.response.CardSortingCardResult;
+import server.MATE.domain.report.dto.response.CardSortingGroupResult;
+import server.MATE.domain.report.dto.response.CardSortingReportResult;
+import server.MATE.domain.report.service.ReportHandler;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class CardSortingReportHandler implements ReportHandler {
+
+    private final CardSortingRepository cardSortingRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.CARD_SORTING;
+    }
+
+    @Override
+    public Map<Long, Object> compute(List<Question> questions, Map<Long, List<Answer>> answersByQuestionId) {
+        List<Long> questionIds = questions.stream().map(Question::getId).toList();
+        Map<Long, CardSorting> cardSortingMap = cardSortingRepository.findAllById(questionIds).stream()
+                .collect(Collectors.toMap(CardSorting::getId, cs -> cs));
+
+        Map<Long, Object> result = new LinkedHashMap<>();
+        for (Question question : questions) {
+            CardSorting cardSorting = cardSortingMap.get(question.getId());
+            List<Answer> answers = answersByQuestionId.getOrDefault(question.getId(), List.of());
+            result.put(question.getId(), computeForCardSorting(cardSorting, answers));
+        }
+        return result;
+    }
+
+    private CardSortingReportResult computeForCardSorting(CardSorting cardSorting, List<Answer> answers) {
+        // category → card → count
+        Map<String, Map<String, Integer>> categoryCardCounts = new LinkedHashMap<>();
+        for (String category : cardSorting.getCategories()) {
+            Map<String, Integer> cardCounts = new LinkedHashMap<>();
+            for (String card : cardSorting.getCards()) {
+                cardCounts.put(card, 0);
+            }
+            categoryCardCounts.put(category, cardCounts);
+        }
+
+        int total = answers.size();
+        for (Answer answer : answers) {
+            for (Map<String, Object> group : extractGroups(answer.getAnswer())) {
+                String category = (String) group.get("category");
+                @SuppressWarnings("unchecked")
+                List<String> cardNames = (List<String>) group.get("cardNames");
+                Map<String, Integer> cardCounts = categoryCardCounts.get(category);
+                if (cardCounts != null && cardNames != null) {
+                    for (String cardName : cardNames) {
+                        cardCounts.merge(cardName, 1, Integer::sum);
+                    }
+                }
+            }
+        }
+
+        List<CardSortingGroupResult> groups = new ArrayList<>();
+        for (Map.Entry<String, Map<String, Integer>> entry : categoryCardCounts.entrySet()) {
+            List<Map.Entry<String, Integer>> sorted = entry.getValue().entrySet().stream()
+                    .sorted(Comparator.comparingInt(Map.Entry<String, Integer>::getValue).reversed())
+                    .toList();
+
+            List<CardSortingCardResult> cards = new ArrayList<>();
+            int rank = 1;
+            for (int i = 0; i < sorted.size(); i++) {
+                if (i > 0 && !sorted.get(i).getValue().equals(sorted.get(i - 1).getValue())) {
+                    rank = i + 1;
+                }
+                Map.Entry<String, Integer> e = sorted.get(i);
+                cards.add(new CardSortingCardResult(rank, e.getKey(), e.getValue(), ReportHandlerUtils.toPercentage(e.getValue(), total)));
+            }
+            groups.add(new CardSortingGroupResult(entry.getKey(), cards));
+        }
+
+        return new CardSortingReportResult(groups);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> extractGroups(Map<String, Object> answerMap) {
+        List<Map<String, Object>> groups = (List<Map<String, Object>>) answerMap.get("groups");
+        return groups != null ? groups : List.of();
+    }
+}

--- a/src/main/java/server/MATE/domain/report/service/handler/CardSortingReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/CardSortingReportHandler.java
@@ -39,6 +39,7 @@ public class CardSortingReportHandler implements ReportHandler {
         Map<Long, Object> result = new LinkedHashMap<>();
         for (Question question : questions) {
             CardSorting cardSorting = cardSortingMap.get(question.getId());
+            if (cardSorting == null) continue;
             List<Answer> answers = answersByQuestionId.getOrDefault(question.getId(), List.of());
             result.put(question.getId(), computeForCardSorting(cardSorting, answers));
         }
@@ -60,11 +61,10 @@ public class CardSortingReportHandler implements ReportHandler {
         for (Answer answer : answers) {
             for (Map<String, Object> group : extractGroups(answer.getAnswer())) {
                 String category = (String) group.get("category");
-                @SuppressWarnings("unchecked")
-                List<String> cardNames = (List<String>) group.get("cardNames");
                 Map<String, Integer> cardCounts = categoryCardCounts.get(category);
-                if (cardCounts != null && cardNames != null) {
-                    for (String cardName : cardNames) {
+                if (cardCounts == null || !(group.get("cardNames") instanceof List<?> rawList)) continue;
+                for (Object item : rawList) {
+                    if (item instanceof String cardName) {
                         cardCounts.merge(cardName, 1, Integer::sum);
                     }
                 }

--- a/src/main/java/server/MATE/domain/report/service/handler/FiveSecondReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/FiveSecondReportHandler.java
@@ -1,0 +1,84 @@
+package server.MATE.domain.report.service.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.question.entity.FiveSecond;
+import server.MATE.domain.question.entity.FiveSecondOption;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.FiveSecondRepository;
+import server.MATE.domain.report.dto.response.ObjectiveReportResult;
+import server.MATE.domain.report.dto.response.OptionResult;
+import server.MATE.domain.report.dto.response.SubjectiveReportResult;
+import server.MATE.domain.report.service.ReportHandler;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class FiveSecondReportHandler implements ReportHandler {
+
+    private static final int MAX_RESPONSES = 15;
+
+    private final FiveSecondRepository fiveSecondRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.FIVE_SECOND;
+    }
+
+    @Override
+    public Map<Long, Object> compute(List<Question> questions, Map<Long, List<Answer>> answersByQuestionId) {
+        List<Long> questionIds = questions.stream().map(Question::getId).toList();
+        Map<Long, FiveSecond> fiveSecondMap = fiveSecondRepository.findAllByIdIn(questionIds).stream()
+                .collect(Collectors.toMap(FiveSecond::getId, f -> f));
+
+        Map<Long, Object> result = new LinkedHashMap<>();
+        for (Question question : questions) {
+            FiveSecond fiveSecond = fiveSecondMap.get(question.getId());
+            List<Answer> answers = answersByQuestionId.getOrDefault(question.getId(), List.of());
+            result.put(question.getId(), fiveSecond.isObjective()
+                    ? computeObjective(fiveSecond, answers)
+                    : computeSubjective(answers));
+        }
+        return result;
+    }
+
+    private ObjectiveReportResult computeObjective(FiveSecond fiveSecond, List<Answer> answers) {
+        Map<Long, Integer> countByOptionId = new LinkedHashMap<>();
+        for (FiveSecondOption option : fiveSecond.getOptions()) {
+            countByOptionId.put(option.getId(), 0);
+        }
+
+        for (Answer answer : answers) {
+            for (Long optionId : ReportHandlerUtils.extractOptionIds(answer.getAnswer())) {
+                countByOptionId.merge(optionId, 1, Integer::sum);
+            }
+        }
+
+        int total = answers.size();
+        List<OptionResult> options = fiveSecond.getOptions().stream()
+                .sorted(Comparator.comparingInt((FiveSecondOption o) -> countByOptionId.getOrDefault(o.getId(), 0)).reversed())
+                .map(option -> {
+                    int count = countByOptionId.getOrDefault(option.getId(), 0);
+                    return new OptionResult(option.getId(), option.getContent(), count, ReportHandlerUtils.toPercentage(count, total));
+                })
+                .toList();
+
+        return new ObjectiveReportResult(options);
+    }
+
+    private SubjectiveReportResult computeSubjective(List<Answer> answers) {
+        List<String> responses = answers.stream()
+                .sorted(Comparator.comparing(Answer::getCreatedAt))
+                .limit(MAX_RESPONSES)
+                .map(a -> (String) a.getAnswer().get("text"))
+                .toList();
+        return new SubjectiveReportResult(responses);
+    }
+}

--- a/src/main/java/server/MATE/domain/report/service/handler/ObjectiveReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/ObjectiveReportHandler.java
@@ -1,0 +1,70 @@
+package server.MATE.domain.report.service.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.question.entity.Objective;
+import server.MATE.domain.question.entity.ObjectiveOption;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.ObjectiveRepository;
+import server.MATE.domain.report.dto.response.ObjectiveReportResult;
+import server.MATE.domain.report.dto.response.OptionResult;
+import server.MATE.domain.report.service.ReportHandler;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ObjectiveReportHandler implements ReportHandler {
+
+    private final ObjectiveRepository objectiveRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.OBJECTIVE;
+    }
+
+    @Override
+    public Map<Long, Object> compute(List<Question> questions, Map<Long, List<Answer>> answersByQuestionId) {
+        List<Long> questionIds = questions.stream().map(Question::getId).toList();
+        Map<Long, Objective> objectiveMap = objectiveRepository.findAllByIdIn(questionIds).stream()
+                .collect(Collectors.toMap(Objective::getId, o -> o));
+
+        Map<Long, Object> result = new LinkedHashMap<>();
+        for (Question question : questions) {
+            Objective objective = objectiveMap.get(question.getId());
+            List<Answer> answers = answersByQuestionId.getOrDefault(question.getId(), List.of());
+            result.put(question.getId(), computeForObjective(objective, answers));
+        }
+        return result;
+    }
+
+    ObjectiveReportResult computeForObjective(Objective objective, List<Answer> answers) {
+        Map<Long, Integer> countByOptionId = new LinkedHashMap<>();
+        for (ObjectiveOption option : objective.getOptions()) {
+            countByOptionId.put(option.getId(), 0);
+        }
+
+        for (Answer answer : answers) {
+            for (Long optionId : ReportHandlerUtils.extractOptionIds(answer.getAnswer())) {
+                countByOptionId.merge(optionId, 1, Integer::sum);
+            }
+        }
+
+        int total = answers.size();
+        List<OptionResult> options = objective.getOptions().stream()
+                .sorted(Comparator.comparingInt((ObjectiveOption o) -> countByOptionId.getOrDefault(o.getId(), 0)).reversed())
+                .map(option -> {
+                    int count = countByOptionId.getOrDefault(option.getId(), 0);
+                    return new OptionResult(option.getId(), option.getContent(), count, ReportHandlerUtils.toPercentage(count, total));
+                })
+                .toList();
+
+        return new ObjectiveReportResult(options);
+    }
+}

--- a/src/main/java/server/MATE/domain/report/service/handler/ObjectiveReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/ObjectiveReportHandler.java
@@ -44,7 +44,7 @@ public class ObjectiveReportHandler implements ReportHandler {
         return result;
     }
 
-    ObjectiveReportResult computeForObjective(Objective objective, List<Answer> answers) {
+    private ObjectiveReportResult computeForObjective(Objective objective, List<Answer> answers) {
         Map<Long, Integer> countByOptionId = new LinkedHashMap<>();
         for (ObjectiveOption option : objective.getOptions()) {
             countByOptionId.put(option.getId(), 0);

--- a/src/main/java/server/MATE/domain/report/service/handler/ReportHandlerUtils.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/ReportHandlerUtils.java
@@ -20,7 +20,7 @@ final class ReportHandlerUtils {
         if (raw == null) return List.of();
         List<Long> ids = new ArrayList<>();
         for (Object o : raw) {
-            ids.add(((Number) o).longValue());
+            if (o instanceof Number n) ids.add(n.longValue());
         }
         return ids;
     }

--- a/src/main/java/server/MATE/domain/report/service/handler/ReportHandlerUtils.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/ReportHandlerUtils.java
@@ -1,0 +1,27 @@
+package server.MATE.domain.report.service.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+final class ReportHandlerUtils {
+
+    private ReportHandlerUtils() {
+    }
+
+    static double toPercentage(int count, int total) {
+        if (total == 0) return 0.0;
+        return Math.round(count * 1000.0 / total) / 10.0;
+    }
+
+    @SuppressWarnings("unchecked")
+    static List<Long> extractOptionIds(Map<String, Object> answerMap) {
+        List<Object> raw = (List<Object>) answerMap.get("optionIds");
+        if (raw == null) return List.of();
+        List<Long> ids = new ArrayList<>();
+        for (Object o : raw) {
+            ids.add(((Number) o).longValue());
+        }
+        return ids;
+    }
+}

--- a/src/main/java/server/MATE/domain/report/service/handler/ScaleReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/ScaleReportHandler.java
@@ -1,0 +1,72 @@
+package server.MATE.domain.report.service.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.entity.Scale;
+import server.MATE.domain.question.repository.ScaleRepository;
+import server.MATE.domain.report.dto.response.ScaleDistributionItem;
+import server.MATE.domain.report.dto.response.ScaleReportResult;
+import server.MATE.domain.report.service.ReportHandler;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ScaleReportHandler implements ReportHandler {
+
+    private final ScaleRepository scaleRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.SCALE;
+    }
+
+    @Override
+    public Map<Long, Object> compute(List<Question> questions, Map<Long, List<Answer>> answersByQuestionId) {
+        List<Long> questionIds = questions.stream().map(Question::getId).toList();
+        Map<Long, Scale> scaleMap = scaleRepository.findAllById(questionIds).stream()
+                .collect(Collectors.toMap(Scale::getId, s -> s));
+
+        Map<Long, Object> result = new LinkedHashMap<>();
+        for (Question question : questions) {
+            Scale scale = scaleMap.get(question.getId());
+            List<Answer> answers = answersByQuestionId.getOrDefault(question.getId(), List.of());
+            result.put(question.getId(), computeForScale(scale, answers));
+        }
+        return result;
+    }
+
+    private ScaleReportResult computeForScale(Scale scale, List<Answer> answers) {
+        int range = scale.getRange();
+        int[] counts = new int[range + 1];
+
+        int total = 0;
+        long sum = 0;
+        for (Answer answer : answers) {
+            Object valueObj = answer.getAnswer().get("value");
+            if (valueObj == null) continue;
+            int value = ((Number) valueObj).intValue();
+            if (value >= 1 && value <= range) {
+                counts[value]++;
+                sum += value;
+                total++;
+            }
+        }
+
+        double average = total == 0 ? 0.0 : Math.round(sum * 10.0 / total) / 10.0;
+
+        List<ScaleDistributionItem> distribution = new ArrayList<>();
+        for (int i = 1; i <= range; i++) {
+            distribution.add(new ScaleDistributionItem(i, counts[i]));
+        }
+
+        return new ScaleReportResult(average, distribution);
+    }
+}

--- a/src/main/java/server/MATE/domain/report/service/handler/ScaleReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/ScaleReportHandler.java
@@ -50,9 +50,8 @@ public class ScaleReportHandler implements ReportHandler {
         int total = 0;
         long sum = 0;
         for (Answer answer : answers) {
-            Object valueObj = answer.getAnswer().get("value");
-            if (valueObj == null) continue;
-            int value = ((Number) valueObj).intValue();
+            if (!(answer.getAnswer().get("value") instanceof Number number)) continue;
+            int value = number.intValue();
             if (value >= 1 && value <= range) {
                 counts[value]++;
                 sum += value;

--- a/src/main/java/server/MATE/domain/report/service/handler/SubjectiveReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/SubjectiveReportHandler.java
@@ -32,7 +32,7 @@ public class SubjectiveReportHandler implements ReportHandler {
         return result;
     }
 
-    SubjectiveReportResult computeForSubjective(List<Answer> answers) {
+    private SubjectiveReportResult computeForSubjective(List<Answer> answers) {
         List<String> responses = answers.stream()
                 .sorted(Comparator.comparing(Answer::getCreatedAt))
                 .limit(MAX_RESPONSES)

--- a/src/main/java/server/MATE/domain/report/service/handler/SubjectiveReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/SubjectiveReportHandler.java
@@ -1,0 +1,43 @@
+package server.MATE.domain.report.service.handler;
+
+import org.springframework.stereotype.Component;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.report.dto.response.SubjectiveReportResult;
+import server.MATE.domain.report.service.ReportHandler;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class SubjectiveReportHandler implements ReportHandler {
+
+    private static final int MAX_RESPONSES = 15;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.SUBJECTIVE;
+    }
+
+    @Override
+    public Map<Long, Object> compute(List<Question> questions, Map<Long, List<Answer>> answersByQuestionId) {
+        Map<Long, Object> result = new LinkedHashMap<>();
+        for (Question question : questions) {
+            List<Answer> answers = answersByQuestionId.getOrDefault(question.getId(), List.of());
+            result.put(question.getId(), computeForSubjective(answers));
+        }
+        return result;
+    }
+
+    SubjectiveReportResult computeForSubjective(List<Answer> answers) {
+        List<String> responses = answers.stream()
+                .sorted(Comparator.comparing(Answer::getCreatedAt))
+                .limit(MAX_RESPONSES)
+                .map(a -> (String) a.getAnswer().get("text"))
+                .toList();
+        return new SubjectiveReportResult(responses);
+    }
+}

--- a/src/main/java/server/MATE/domain/report/service/handler/TreeTestReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/TreeTestReportHandler.java
@@ -1,0 +1,83 @@
+package server.MATE.domain.report.service.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.entity.TreeTest;
+import server.MATE.domain.question.repository.TreeTestRepository;
+import server.MATE.domain.report.dto.response.TreeTestNodeResult;
+import server.MATE.domain.report.dto.response.TreeTestReportResult;
+import server.MATE.domain.report.service.ReportHandler;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class TreeTestReportHandler implements ReportHandler {
+
+    private final TreeTestRepository treeTestRepository;
+
+    @Override
+    public QuestionType supports() {
+        return QuestionType.TREE_TEST;
+    }
+
+    @Override
+    public Map<Long, Object> compute(List<Question> questions, Map<Long, List<Answer>> answersByQuestionId) {
+        List<Long> questionIds = questions.stream().map(Question::getId).toList();
+        Map<Long, Map<Long, TreeTest>> nodesByQuestion = treeTestRepository
+                .findAllByQuestionIdInOrderByQuestionAndTree(questionIds).stream()
+                .collect(Collectors.groupingBy(
+                        n -> n.getQuestion().getId(),
+                        Collectors.toMap(TreeTest::getId, n -> n)
+                ));
+
+        Map<Long, Object> result = new LinkedHashMap<>();
+        for (Question question : questions) {
+            Map<Long, TreeTest> nodeMap = nodesByQuestion.getOrDefault(question.getId(), Map.of());
+            List<Answer> answers = answersByQuestionId.getOrDefault(question.getId(), List.of());
+            result.put(question.getId(), computeForTreeTest(nodeMap, answers));
+        }
+        return result;
+    }
+
+    private TreeTestReportResult computeForTreeTest(Map<Long, TreeTest> nodeMap, List<Answer> answers) {
+        // 부모로 참조되는 노드 ID 집합 → 해당 ID는 리프가 아님
+        Set<Long> parentIds = nodeMap.values().stream()
+                .filter(n -> n.getParent() != null)
+                .map(n -> n.getParent().getId())
+                .collect(Collectors.toSet());
+
+        // 리프 노드 전체를 0건으로 초기화 (선택받지 못한 노드도 결과에 포함)
+        Map<Long, Integer> countByNodeId = new LinkedHashMap<>();
+        nodeMap.values().stream()
+                .filter(n -> !parentIds.contains(n.getId()))
+                .forEach(n -> countByNodeId.put(n.getId(), 0));
+
+        for (Answer answer : answers) {
+            Object nodeIdObj = answer.getAnswer().get("nodeId");
+            if (nodeIdObj == null) continue;
+            Long nodeId = ((Number) nodeIdObj).longValue();
+            countByNodeId.merge(nodeId, 1, Integer::sum);
+        }
+
+        int total = answers.size();
+        List<TreeTestNodeResult> nodes = countByNodeId.entrySet().stream()
+                .sorted(Comparator.comparingInt((Map.Entry<Long, Integer> e) -> e.getValue()).reversed())
+                .map(e -> {
+                    TreeTest node = nodeMap.get(e.getKey());
+                    String label = node != null ? node.getLabel() : String.valueOf(e.getKey());
+                    return new TreeTestNodeResult(e.getKey(), label, e.getValue(), ReportHandlerUtils.toPercentage(e.getValue(), total));
+                })
+                .toList();
+
+        return new TreeTestReportResult(nodes);
+    }
+}

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -1,0 +1,436 @@
+package server.MATE.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import server.MATE.domain.test.entity.TestStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
+
+    @Test
+    @DisplayName("IN_PROGRESS 테스트의 리포트는 results가 빈 리스트다")
+    void getReport_whenInProgress_returnsEmptyResults() throws Exception {
+        TestActors actors = createActors();
+        createSingleSubjectiveQuestion(actors.testId(), actors.makerToken());
+
+        JsonNode data = reportData(actors.testId(), actors.makerToken());
+
+        assertThat(data.path("testStatus").asText()).isEqualTo("IN_PROGRESS");
+        assertThat(data.path("questionCount").asInt()).isEqualTo(1);
+        assertThat(data.path("results").isArray()).isTrue();
+        assertThat(data.path("results")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("메이커가 아닌 사용자가 리포트 조회 시 403을 반환한다")
+    void getReport_byNonMaker_returns403() throws Exception {
+        TestActors actors = createActors();
+        completeTest(actors.testId());
+
+        performExpectingError(
+                get("/api/v1/tests/{testId}/report", actors.testId())
+                        .header("Authorization", actors.testerToken()),
+                403, "TEST_005"
+        );
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 테스트 리포트 조회 시 404를 반환한다")
+    void getReport_withNonExistentTest_returns404() throws Exception {
+        TestActors actors = createActors();
+
+        performExpectingError(
+                get("/api/v1/tests/{testId}/report", 999999L)
+                        .header("Authorization", actors.makerToken()),
+                404, "TEST_004"
+        );
+    }
+
+    @Test
+    @DisplayName("SUBJECTIVE 응답 제출 후 리포트에 텍스트 목록이 반환된다")
+    void getReport_withSubjectiveAnswers_returnsResponses() throws Exception {
+        TestActors actors = createActors();
+        createSingleSubjectiveQuestion(actors.testId(), actors.makerToken());
+        Long questionId = getSingleQuestion(actors.testId(), actors.makerToken()).path("questionId").asLong();
+
+        submitAnswer(actors.testId(), actors.testerToken(), """
+                {
+                  "answers": [
+                    { "type": "SUBJECTIVE", "questionId": %d, "text": "주관식 응답" }
+                  ]
+                }
+                """.formatted(questionId));
+        completeTest(actors.testId());
+
+        JsonNode result = reportData(actors.testId(), actors.makerToken()).path("results").get(0);
+        assertThat(result.path("type").asText()).isEqualTo("SUBJECTIVE");
+        JsonNode responses = result.path("report").path("responses");
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).asText()).isEqualTo("주관식 응답");
+    }
+
+    @Test
+    @DisplayName("OBJECTIVE 응답 제출 후 리포트에 선택지별 카운트가 반환된다")
+    void getReport_withObjectiveAnswers_returnsOptionCounts() throws Exception {
+        TestActors actors = createActors();
+        createObjectiveQuestion(actors.testId(), actors.makerToken(), false, null, null, false);
+        JsonNode questionNode = getSingleQuestion(actors.testId(), actors.makerToken());
+        Long questionId = questionNode.path("questionId").asLong();
+        Long firstOptionId = questionNode.path("options").get(0).path("objectiveOptionId").asLong();
+
+        submitAnswer(actors.testId(), actors.testerToken(), """
+                {
+                  "answers": [
+                    { "type": "OBJECTIVE", "questionId": %d, "optionIds": [%d] }
+                  ]
+                }
+                """.formatted(questionId, firstOptionId));
+        completeTest(actors.testId());
+
+        JsonNode options = reportData(actors.testId(), actors.makerToken())
+                .path("results").get(0).path("report").path("options");
+        assertThat(options.isArray()).isTrue();
+        int totalCount = 0;
+        for (JsonNode option : options) {
+            totalCount += option.path("count").asInt();
+        }
+        assertThat(totalCount).isEqualTo(1);
+        assertThat(options.get(0).path("count").asInt()).isEqualTo(1); // 가장 많이 선택된 옵션이 첫 번째
+    }
+
+    @Test
+    @DisplayName("SCALE 응답 제출 후 리포트에 평균과 점수별 분포가 반환된다")
+    void getReport_withScaleAnswers_returnsAverageAndDistribution() throws Exception {
+        TestActors actors = createActors();
+        createScaleQuestion(actors.testId(), actors.makerToken(), 5);
+        Long questionId = getSingleQuestion(actors.testId(), actors.makerToken()).path("questionId").asLong();
+
+        submitAnswer(actors.testId(), actors.testerToken(), """
+                {
+                  "answers": [
+                    { "type": "SCALE", "questionId": %d, "value": 4 }
+                  ]
+                }
+                """.formatted(questionId));
+        completeTest(actors.testId());
+
+        JsonNode report = reportData(actors.testId(), actors.makerToken()).path("results").get(0).path("report");
+        assertThat(report.path("average").asDouble()).isEqualTo(4.0);
+        JsonNode distribution = report.path("distribution");
+        assertThat(distribution).hasSize(5);
+        assertThat(distribution.get(3).path("score").asInt()).isEqualTo(4);
+        assertThat(distribution.get(3).path("count").asInt()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("FIVE_SECOND 주관식 응답 제출 후 리포트에 텍스트 목록이 반환된다")
+    void getReport_withFiveSecondSubjectiveAnswers_returnsResponses() throws Exception {
+        TestActors actors = createActors();
+        createFiveSecondSubjectiveQuestion(actors.testId(), actors.makerToken());
+        Long questionId = getSingleQuestion(actors.testId(), actors.makerToken()).path("questionId").asLong();
+
+        submitAnswer(actors.testId(), actors.testerToken(), """
+                {
+                  "answers": [
+                    { "type": "FIVE_SECOND", "questionId": %d, "text": "5초 주관 응답" }
+                  ]
+                }
+                """.formatted(questionId));
+        completeTest(actors.testId());
+
+        JsonNode result = reportData(actors.testId(), actors.makerToken()).path("results").get(0);
+        assertThat(result.path("type").asText()).isEqualTo("FIVE_SECOND");
+        JsonNode responses = result.path("report").path("responses");
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).asText()).isEqualTo("5초 주관 응답");
+    }
+
+    @Test
+    @DisplayName("FIVE_SECOND 객관식 응답 제출 후 리포트에 선택지별 카운트가 반환된다")
+    void getReport_withFiveSecondObjectiveAnswers_returnsOptionCounts() throws Exception {
+        TestActors actors = createActors();
+        createFiveSecondObjectiveQuestion(actors.testId(), actors.makerToken(), false, null, null, false);
+        JsonNode questionNode = getSingleQuestion(actors.testId(), actors.makerToken());
+        Long questionId = questionNode.path("questionId").asLong();
+        Long firstOptionId = questionNode.path("options").get(0).path("fiveSecondOptionId").asLong();
+
+        submitAnswer(actors.testId(), actors.testerToken(), """
+                {
+                  "answers": [
+                    { "type": "FIVE_SECOND", "questionId": %d, "optionIds": [%d] }
+                  ]
+                }
+                """.formatted(questionId, firstOptionId));
+        completeTest(actors.testId());
+
+        JsonNode options = reportData(actors.testId(), actors.makerToken())
+                .path("results").get(0).path("report").path("options");
+        assertThat(options.isArray()).isTrue();
+        int totalCount = 0;
+        for (JsonNode option : options) {
+            totalCount += option.path("count").asInt();
+        }
+        assertThat(totalCount).isEqualTo(1);
+        assertThat(options.get(0).path("count").asInt()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("AB_TEST 응답 제출 후 리포트에 A/B 카운트와 비율이 반환된다")
+    void getReport_withAbTestAnswers_returnsABCountsAndPercentages() throws Exception {
+        TestActors actors = createActors();
+        createAbTestQuestion(actors.testId(), actors.makerToken());
+        Long questionId = getSingleQuestion(actors.testId(), actors.makerToken()).path("questionId").asLong();
+
+        submitAnswer(actors.testId(), actors.testerToken(), """
+                {
+                  "answers": [
+                    { "type": "AB_TEST", "questionId": %d, "selected": "A" }
+                  ]
+                }
+                """.formatted(questionId));
+        completeTest(actors.testId());
+
+        JsonNode report = reportData(actors.testId(), actors.makerToken()).path("results").get(0).path("report");
+        assertThat(report.path("aCount").asInt()).isEqualTo(1);
+        assertThat(report.path("aPercentage").asDouble()).isEqualTo(100.0);
+        assertThat(report.path("bCount").asInt()).isEqualTo(0);
+        assertThat(report.path("bPercentage").asDouble()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("CARD_SORTING 응답 제출 후 리포트에 카테고리별 카드 랭킹이 반환된다")
+    void getReport_withCardSortingAnswers_returnsGroupResults() throws Exception {
+        TestActors actors = createActors();
+        createCardSortingQuestion(actors.testId(), actors.makerToken());
+        Long questionId = getSingleQuestion(actors.testId(), actors.makerToken()).path("questionId").asLong();
+
+        submitAnswer(actors.testId(), actors.testerToken(), """
+                {
+                  "answers": [
+                    {
+                      "type": "CARD_SORTING",
+                      "questionId": %d,
+                      "groups": [
+                        { "category": "쇼핑", "cardNames": ["홈", "장바구니"] },
+                        { "category": "정보", "cardNames": ["검색", "공지사항"] }
+                      ]
+                    }
+                  ]
+                }
+                """.formatted(questionId));
+        completeTest(actors.testId());
+
+        JsonNode groups = reportData(actors.testId(), actors.makerToken())
+                .path("results").get(0).path("report").path("groups");
+        assertThat(groups).hasSize(2);
+        assertThat(groups).anySatisfy(g -> {
+            assertThat(g.path("groupName").asText()).isEqualTo("쇼핑");
+            assertThat(g.path("cards")).hasSize(4); // 전체 카드 수 포함 (선택 안 된 카드도 0건으로 포함)
+        });
+        assertThat(groups).anySatisfy(g -> assertThat(g.path("groupName").asText()).isEqualTo("정보"));
+    }
+
+    @Test
+    @DisplayName("TREE_TEST 응답 제출 후 리포트에 리프 노드별 카운트가 반환된다")
+    void getReport_withTreeTestAnswers_returnsNodeCounts() throws Exception {
+        TestActors actors = createActors();
+        // 단일 루트 노드 트리 — 루트 자체가 리프이므로 path = [nodeId] 가 유효
+        performCreateQuestion(actors.testId(), actors.makerToken(), """
+                {
+                  "questions": [
+                    {
+                      "type": "TREE_TEST",
+                      "title": "트리 질문",
+                      "description": "설명",
+                      "features": [
+                        { "label": "홈", "children": [] }
+                      ]
+                    }
+                  ]
+                }
+                """);
+        JsonNode questionNode = getSingleQuestion(actors.testId(), actors.makerToken());
+        Long questionId = questionNode.path("questionId").asLong();
+        Long rootNodeId = questionNode.path("features").get(0).path("treeTestId").asLong();
+
+        submitAnswer(actors.testId(), actors.testerToken(), """
+                {
+                  "answers": [
+                    { "type": "TREE_TEST", "questionId": %d, "nodeId": %d, "path": [%d] }
+                  ]
+                }
+                """.formatted(questionId, rootNodeId, rootNodeId));
+        completeTest(actors.testId());
+
+        JsonNode nodes = reportData(actors.testId(), actors.makerToken())
+                .path("results").get(0).path("report").path("nodes");
+        assertThat(nodes.isArray()).isTrue();
+        assertThat(nodes).anySatisfy(node -> assertThat(node.path("count").asInt()).isEqualTo(1));
+    }
+
+    @Test
+    @DisplayName("COMPLETED 테스트에 질문이 없으면 questions와 results가 모두 빈 리스트다")
+    void getReport_whenCompletedWithNoQuestions_returnsEmptyLists() throws Exception {
+        TestActors actors = createActors();
+        completeTest(actors.testId());
+
+        JsonNode data = reportData(actors.testId(), actors.makerToken());
+
+        assertThat(data.path("testStatus").asText()).isEqualTo("COMPLETED");
+        assertThat(data.path("questionCount").asInt()).isEqualTo(0);
+        assertThat(data.path("questions")).isEmpty();
+        assertThat(data.path("results")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("응답이 없는 SCALE 질문의 리포트는 average 0.0, distribution 전체 count 0이다")
+    void getReport_withNoScaleAnswers_returnsZeroAverageAndDistribution() throws Exception {
+        TestActors actors = createActors();
+        createScaleQuestion(actors.testId(), actors.makerToken(), 5);
+        completeTest(actors.testId());
+
+        JsonNode report = reportData(actors.testId(), actors.makerToken()).path("results").get(0).path("report");
+        assertThat(report.path("average").asDouble()).isEqualTo(0.0);
+        JsonNode distribution = report.path("distribution");
+        assertThat(distribution).hasSize(5);
+        for (JsonNode item : distribution) {
+            assertThat(item.path("count").asInt()).isEqualTo(0);
+        }
+    }
+
+    @Test
+    @DisplayName("응답이 없는 OBJECTIVE 질문의 리포트는 모든 선택지 count가 0이다")
+    void getReport_withNoObjectiveAnswers_returnsZeroCounts() throws Exception {
+        TestActors actors = createActors();
+        createObjectiveQuestion(actors.testId(), actors.makerToken(), false, null, null, false);
+        completeTest(actors.testId());
+
+        JsonNode options = reportData(actors.testId(), actors.makerToken())
+                .path("results").get(0).path("report").path("options");
+        assertThat(options.isArray()).isTrue();
+        for (JsonNode option : options) {
+            assertThat(option.path("count").asInt()).isEqualTo(0);
+            assertThat(option.path("percentage").asDouble()).isEqualTo(0.0);
+        }
+    }
+
+    @Test
+    @DisplayName("리포트의 questions 필드는 sequence 오름차순으로 질문 목록을 반환한다")
+    void getReport_questions_returnedInSequenceOrder() throws Exception {
+        TestActors actors = createActors();
+        createTwoSubjectiveQuestions(actors.testId(), actors.makerToken());
+        completeTest(actors.testId());
+
+        JsonNode questions = reportData(actors.testId(), actors.makerToken()).path("questions");
+        assertThat(questions).hasSize(2);
+        assertThat(questions.get(0).path("sequence").asLong()).isEqualTo(1L);
+        assertThat(questions.get(1).path("sequence").asLong()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("응답 제출 후 리포트의 participantCount가 증가한다")
+    void getReport_afterAnswerSubmission_participantCountIncremented() throws Exception {
+        TestActors actors = createActors();
+        createSingleSubjectiveQuestion(actors.testId(), actors.makerToken());
+        Long questionId = getSingleQuestion(actors.testId(), actors.makerToken()).path("questionId").asLong();
+
+        submitAnswer(actors.testId(), actors.testerToken(), """
+                {
+                  "answers": [
+                    { "type": "SUBJECTIVE", "questionId": %d, "text": "응답" }
+                  ]
+                }
+                """.formatted(questionId));
+        completeTest(actors.testId());
+
+        JsonNode data = reportData(actors.testId(), actors.makerToken());
+        assertThat(data.path("participantCount").asLong()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("여러 타입 질문이 혼재할 때 results가 sequence 순서로 조립되고 각 항목의 필드가 올바르다")
+    void getReport_withMultipleQuestionTypes_resultsAssembledInSequenceOrder() throws Exception {
+        TestActors actors = createActors();
+        performCreateQuestion(actors.testId(), actors.makerToken(), """
+                {
+                  "questions": [
+                    { "type": "SUBJECTIVE", "title": "주관식 질문", "description": "설명", "imageKey": null },
+                    { "type": "SCALE", "title": "척도 질문", "description": "설명", "imageKey": null, "minLabel": "낮음", "maxLabel": "높음", "range": 5 },
+                    { "type": "AB_TEST", "title": "AB 질문", "description": "설명", "aImageKey": "a", "bImageKey": "b", "imageRatio": "9:16" }
+                  ]
+                }
+                """);
+        JsonNode questions = getQuestionsArray(actors.testId(), actors.makerToken());
+        Long subjectiveId = questions.get(0).path("questionId").asLong();
+        Long scaleId = questions.get(1).path("questionId").asLong();
+        Long abTestId = questions.get(2).path("questionId").asLong();
+
+        submitAnswer(actors.testId(), actors.testerToken(), """
+                {
+                  "answers": [
+                    { "type": "SUBJECTIVE", "questionId": %d, "text": "응답" },
+                    { "type": "SCALE", "questionId": %d, "value": 3 },
+                    { "type": "AB_TEST", "questionId": %d, "selected": "B" }
+                  ]
+                }
+                """.formatted(subjectiveId, scaleId, abTestId));
+        completeTest(actors.testId());
+
+        JsonNode results = reportData(actors.testId(), actors.makerToken()).path("results");
+        assertThat(results).hasSize(3);
+
+        JsonNode r0 = results.get(0);
+        assertThat(r0.path("questionId").asLong()).isEqualTo(subjectiveId);
+        assertThat(r0.path("sequence").asLong()).isEqualTo(1L);
+        assertThat(r0.path("title").asText()).isEqualTo("주관식 질문");
+        assertThat(r0.path("type").asText()).isEqualTo("SUBJECTIVE");
+        assertThat(r0.path("report").path("responses").get(0).asText()).isEqualTo("응답");
+
+        JsonNode r1 = results.get(1);
+        assertThat(r1.path("questionId").asLong()).isEqualTo(scaleId);
+        assertThat(r1.path("sequence").asLong()).isEqualTo(2L);
+        assertThat(r1.path("type").asText()).isEqualTo("SCALE");
+        assertThat(r1.path("report").path("average").asDouble()).isEqualTo(3.0);
+
+        JsonNode r2 = results.get(2);
+        assertThat(r2.path("questionId").asLong()).isEqualTo(abTestId);
+        assertThat(r2.path("sequence").asLong()).isEqualTo(3L);
+        assertThat(r2.path("type").asText()).isEqualTo("AB_TEST");
+        assertThat(r2.path("report").path("bCount").asInt()).isEqualTo(1);
+        assertThat(r2.path("report").path("bPercentage").asDouble()).isEqualTo(100.0);
+    }
+
+    private JsonNode reportData(Long testId, String token) throws Exception {
+        var result = mockMvc.perform(
+                        get("/api/v1/tests/{testId}/report", testId)
+                                .header("Authorization", token))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode body = parseBody(result);
+        assertThat(body.path("success").asBoolean()).isTrue();
+        return body.path("data");
+    }
+
+    private void completeTest(Long testId) {
+        server.MATE.domain.test.entity.Test test = testRepository.findById(testId).orElseThrow();
+        try {
+            java.lang.reflect.Field field = server.MATE.domain.test.entity.Test.class.getDeclaredField("testStatus");
+            field.setAccessible(true);
+            field.set(test, TestStatus.COMPLETED);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+        testRepository.save(test);
+    }
+
+}


### PR DESCRIPTION
  ## 📍 요약
  메이커가 자신의 테스트에 대한 질문 목록 및 질문 유형별 응답 리포트를 조회하는 API를 구현합니다.             

  ## 🔗 관련 이슈
  Closes #116
  
  ## 📌 변경 사항
  기능

  ## ✅ 작업 내용
  - `GET /api/v1/tests/{testId}/report` 엔드포인트 구현                                                       
    - 테스트 소유자(메이커) 검증
    - `IN_PROGRESS` 상태일 경우 `results` 빈 리스트 반환
    - `COMPLETED` 상태일 경우 질문 유형별 리포트 반환
  - 질문 유형별 리포트 핸들러 구현 (전략 패턴)
    - 객관식: 선택지별 응답 수·비율, 응답 수 내림차순 정렬
    - 주관식: 응답 텍스트 목록, createdAt 오름차순, 최대 15개
    - 척도: 평균 점수, 점수별 분포
    - A/B 테스트: A·B 응답 수·비율
    - 카드소팅: 그룹별 카드 배정 결과, 동점 공동순위 처리
    - 트리테스트: 선택 노드별 응답 분포 (0건 노드 포함)
    - 5초 테스트: isObjective 분기 → 객관식/주관식 구조 적용
  - JSON 필드 파싱 시 null 방어 처리 (AbTest, Scale, TreeTest)
  - `AnswerRepository` 배치 조회 메서드 추가

  ## 테스트
  - [ ] 로컬 테스트