### PR TITLE
feat: Grafana/ArgoCD 서브도메인 Ingress 노출

### DIFF
--- a/deploy/argocd/applications/platform-application.yaml
+++ b/deploy/argocd/applications/platform-application.yaml
@@ -1,0 +1,23 @@
+# ArgoCD/Grafana 외부 Ingress 및 ArgoCD server.insecure 설정.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: platform
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/KUSITMS-CHECKMATE/MATE-SERVER.git
+    targetRevision: feat/ci
+    path: deploy/argocd/platform
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/deploy/argocd/kustomization.yaml
+++ b/deploy/argocd/kustomization.yaml
@@ -4,5 +4,6 @@ namespace: argocd
 resources:
   - applications/ingress-nginx-application.yaml
   - applications/external-secrets-operator-application.yaml
+  - applications/platform-application.yaml
   - applications/mate-application.yaml
   - applications/monitoring-application.yaml

--- a/deploy/argocd/platform/argocd-cmd-params-cm.yaml
+++ b/deploy/argocd/platform/argocd-cmd-params-cm.yaml
@@ -1,0 +1,10 @@
+# Ingress TLS 종료 후 argocd-server를 HTTP(80)로 노출하기 위한 설정.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+  labels:
+    app.kubernetes.io/name: argocd-cmd-params-cm
+    app.kubernetes.io/part-of: argocd
+data:
+  server.insecure: "true"

--- a/deploy/argocd/platform/ingress-argocd.yaml
+++ b/deploy/argocd/platform/ingress-argocd.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd-server
+  labels:
+    app.kubernetes.io/name: argocd-server
+    app.kubernetes.io/part-of: argocd
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: argocd.kusitms-mate.cloud
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: argocd-server
+                port:
+                  number: 80

--- a/deploy/argocd/platform/kustomization.yaml
+++ b/deploy/argocd/platform/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd
+resources:
+  - argocd-cmd-params-cm.yaml
+  - ingress-argocd.yaml

--- a/deploy/monitoring/ingress-grafana.yaml
+++ b/deploy/monitoring/ingress-grafana.yaml
@@ -1,22 +1,21 @@
-# MATE API 전용 Ingress. grafana/argocd는 각 서브도메인 Ingress로 분리한다.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: mate
+  name: grafana
   labels:
-    app: mate
+    app: grafana
   annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
   ingressClassName: nginx
   rules:
-    - host: api.kusitms-mate.cloud
+    - host: grafana.kusitms-mate.cloud
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: mate
+                name: monitoring-grafana
                 port:
                   number: 80

--- a/deploy/monitoring/kustomization.yaml
+++ b/deploy/monitoring/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 namespace: monitoring
 resources:
   - servicemonitor-mate-backend.yaml
+  - ingress-grafana.yaml

--- a/infra/terraform/environments/prod/cloudflare.tf
+++ b/infra/terraform/environments/prod/cloudflare.tf
@@ -17,3 +17,29 @@ resource "cloudflare_record" "api" {
 
   comment = "MATE API ingress LB endpoint managed by Terraform"
 }
+
+resource "cloudflare_record" "grafana" {
+  count = local.create_cloudflare_api_record ? 1 : 0
+
+  zone_id = trimspace(var.cloudflare_zone_id)
+  name    = var.cloudflare_grafana_record_name
+  type    = "A"
+  value   = module.kubernetes_vms.ingress_public_ip_address
+  ttl     = 1
+  proxied = var.cloudflare_api_record_proxied
+
+  comment = "Grafana ingress LB endpoint managed by Terraform"
+}
+
+resource "cloudflare_record" "argocd" {
+  count = local.create_cloudflare_api_record ? 1 : 0
+
+  zone_id = trimspace(var.cloudflare_zone_id)
+  name    = var.cloudflare_argocd_record_name
+  type    = "A"
+  value   = module.kubernetes_vms.ingress_public_ip_address
+  ttl     = 1
+  proxied = var.cloudflare_api_record_proxied
+
+  comment = "ArgoCD ingress LB endpoint managed by Terraform"
+}

--- a/infra/terraform/environments/prod/outputs.tf
+++ b/infra/terraform/environments/prod/outputs.tf
@@ -256,6 +256,16 @@ output "cloudflare_api_record_hostname" {
   value       = try(cloudflare_record.api[0].hostname, null)
 }
 
+output "cloudflare_grafana_record_hostname" {
+  description = "Cloudflare Grafana DNS 레코드 이름. cloudflare_zone_id 미설정 시 null."
+  value       = try(cloudflare_record.grafana[0].hostname, null)
+}
+
+output "cloudflare_argocd_record_hostname" {
+  description = "Cloudflare ArgoCD DNS 레코드 이름. cloudflare_zone_id 미설정 시 null."
+  value       = try(cloudflare_record.argocd[0].hostname, null)
+}
+
 output "cloudflare_api_record_proxied" {
   description = "Cloudflare API DNS 레코드 프록시 여부."
   value       = try(cloudflare_record.api[0].proxied, null)

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -289,6 +289,18 @@ variable "cloudflare_api_record_name" {
   default     = "api"
 }
 
+variable "cloudflare_grafana_record_name" {
+  description = "Cloudflare에 만들 Grafana A 레코드 이름"
+  type        = string
+  default     = "grafana"
+}
+
+variable "cloudflare_argocd_record_name" {
+  description = "Cloudflare에 만들 ArgoCD A 레코드 이름"
+  type        = string
+  default     = "argocd"
+}
+
 variable "cloudflare_api_record_proxied" {
   description = "Cloudflare 프록시(주황 구름) 사용 여부. Ingress LB가 80/443 origin을 제공하므로 true 권장."
   type        = bool


### PR DESCRIPTION
## 📍 요약
- Grafana/ArgoCD를 port-forward·SSH 없이 도메인으로 접속할 수 있도록 서브도메인 Ingress와 Cloudflare DNS를 추가했다.

## 🔗 관련 이슈
- Closes #119

## 📌 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [x] 기타

## ✅ 작업 내용
- `api.kusitms-mate.cloud` 전용 mate Ingress host 분리
- `grafana.kusitms-mate.cloud` Grafana Ingress 추가
- `argocd.kusitms-mate.cloud` ArgoCD Ingress 추가 및 `server.insecure=true` 설정
- ArgoCD `platform` Application 추가 (`deploy/argocd/platform/`)
- Terraform Cloudflare DNS: `grafana`, `argocd` A 레코드 및 output 추가

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `kubectl get ingress -A` — grafana/argocd/mate Ingress 및 host 확인
  - `curl -I https://grafana.kusitms-mate.cloud`
  - `curl -I https://argocd.kusitms-mate.cloud`
  - `curl -I https://api.kusitms-mate.cloud/actuator/health`
  - 브라우저에서 Grafana/ArgoCD 로그인 확인