### PR TITLE
fix: Report 집계 완료 판단 시 부분 생성을 허용하는 버그 수정

### DIFF
--- a/src/main/java/server/MATE/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/QuestionRepository.java
@@ -15,6 +15,8 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     Optional<Question> findByIdAndTestIdAndDeletedAtIsNull(Long id, Long testId);
 
+    long countByTestIdAndDeletedAtIsNull(Long testId);
+
     List<Question> findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(Long testId);
 
     @Query("""

--- a/src/main/java/server/MATE/domain/report/repository/ReportRepository.java
+++ b/src/main/java/server/MATE/domain/report/repository/ReportRepository.java
@@ -10,4 +10,6 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     List<Report> findAllByTestId(Long testId);
 
     boolean existsByTestId(Long testId);
+
+    long countByTestId(Long testId);
 }

--- a/src/main/java/server/MATE/domain/report/service/ReportAggregationEventListener.java
+++ b/src/main/java/server/MATE/domain/report/service/ReportAggregationEventListener.java
@@ -16,6 +16,8 @@ public class ReportAggregationEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onTestCompleted(TestCompletedEvent event) {
+        // answer 저장 -> testStatus, reportStatus 변경 보장
+        // event 발행하면 report 집계를 시작
         reportAggregationService.aggregate(event.testId());
     }
 }

--- a/src/main/java/server/MATE/domain/report/service/ReportAggregationService.java
+++ b/src/main/java/server/MATE/domain/report/service/ReportAggregationService.java
@@ -60,7 +60,8 @@ public class ReportAggregationService {
         long questionCount = questionRepository.countByTestIdAndDeletedAtIsNull(testId);
         long reportCount = reportRepository.countByTestId(testId);
 
-        // 질문 수와 리포트 수가 같으면 이미 전체 집계가 끝난 상태
+        // 질문 수와 리포트 수가 같으면 이미 전체 집계가 끝난 상태로 처리
+        // 질문과 리포트가 모두 0개인 경우를 포함함
         if (reportCount == questionCount) {
             test.completeReportAggregation();
             testRepository.save(test);
@@ -72,13 +73,6 @@ public class ReportAggregationService {
             log.error("테스트 {} 리포트 완전성 불일치 감지: questionCount={}, reportCount={}",
                     testId, questionCount, reportCount);
             test.failReportAggregation();
-            testRepository.save(test);
-            return List.of();
-        }
-
-        // 질문이 없으면 생성할 리포트도 없으므로 빈 리스트르 반환
-        if (questionCount == 0) {
-            test.completeReportAggregation();
             testRepository.save(test);
             return List.of();
         }
@@ -97,7 +91,7 @@ public class ReportAggregationService {
                         Collectors.toList()
                 ));
 
-        // 질문 유형별 핸들러로 부분 집계를 수행, questionId 기준으로 결과 맵 저장
+        // 질문 유형별 핸들러로 부분 집계를 수행, questionId 기준으로 결과 맵 저
         Map<Long, Map<String, Object>> resultByQuestionId = new LinkedHashMap<>();
         for (Map.Entry<QuestionType, List<Question>> entry : questionsByType.entrySet()) {
             ReportHandler handler = handlerMap.get(entry.getKey());

--- a/src/main/java/server/MATE/domain/report/service/ReportAggregationService.java
+++ b/src/main/java/server/MATE/domain/report/service/ReportAggregationService.java
@@ -57,13 +57,27 @@ public class ReportAggregationService {
         Test test = testRepository.findByIdAndDeletedAtIsNull(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
-        if (reportRepository.existsByTestId(testId)) {
+        List<Question> questions = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId);
+        int questionCount = questions.size();
+        long reportCount = reportRepository.countByTestId(testId);
+
+        // 질문 수와 리포트 수가 같으면 이미 전체 집계가 끝난 상태
+        if (reportCount == questionCount) {
             test.completeReportAggregation();
             testRepository.save(test);
             return reportRepository.findAllByTestId(testId);
         }
 
-        List<Question> questions = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId);
+        // 일부 리포트만 남아 있으면 불일치 상태이므로 실패 처리
+        if (reportCount > 0) {
+            log.error("테스트 {} 리포트 완전성 불일치 감지: questionCount={}, reportCount={}",
+                    testId, questionCount, reportCount);
+            test.failReportAggregation();
+            testRepository.save(test);
+            return List.of();
+        }
+
+        // 질문이 없으면 생성할 리포트도 없으므로 빈 리스트르 반환
         if (questions.isEmpty()) {
             test.completeReportAggregation();
             testRepository.save(test);
@@ -73,9 +87,9 @@ public class ReportAggregationService {
         List<Long> questionIds = questions.stream().map(Question::getId).toList();
         List<Answer> allAnswers = answerRepository.findAllByQuestionIdInAndDeletedAtIsNull(questionIds);
 
+        // 질문별 집계 계산에 바로 쓸 수 있도록 응답을 questionId 기준으로 묶음
         Map<Long, List<Answer>> answersByQuestionId = allAnswers.stream()
                 .collect(Collectors.groupingBy(Answer::getQuestionId));
-
         Map<QuestionType, List<Question>> questionsByType = questions.stream()
                 .collect(Collectors.groupingBy(
                         Question::getQuestionType,
@@ -83,6 +97,7 @@ public class ReportAggregationService {
                         Collectors.toList()
                 ));
 
+        // 질문 유형별 핸들러로 부분 집계를 수행, questionId 기준으로 결과 맵 저장
         Map<Long, Map<String, Object>> resultByQuestionId = new LinkedHashMap<>();
         for (Map.Entry<QuestionType, List<Question>> entry : questionsByType.entrySet()) {
             ReportHandler handler = handlerMap.get(entry.getKey());
@@ -108,11 +123,22 @@ public class ReportAggregationService {
     @Recover
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public List<Report> recover(Exception e, Long testId) {
-        if (e instanceof DataIntegrityViolationException || reportRepository.existsByTestId(testId)) {
-            log.info("테스트 {} 리포트가 이미 존재합니다. 상태를 완료로 업데이트합니다.", testId);
-            updateReportStatus(testId, Test::completeReportAggregation);
-            return reportRepository.findAllByTestId(testId);
+        int questionCount = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId).size();
+        long reportCount = reportRepository.countByTestId(testId);
+
+        if (e instanceof DataIntegrityViolationException || reportCount > 0) {
+            if (reportCount == questionCount) {
+                log.info("테스트 {} 리포트가 이미 완전하게 존재합니다. 상태를 완료로 업데이트합니다.", testId);
+                updateReportStatus(testId, Test::completeReportAggregation);
+                return reportRepository.findAllByTestId(testId);
+            }
+
+            log.error("테스트 {} recover 중 리포트 완전성 불일치 감지: questionCount={}, reportCount={}",
+                    testId, questionCount, reportCount, e);
+            updateReportStatus(testId, Test::failReportAggregation);
+            return List.of();
         }
+
         log.error("테스트 {} 집계 3회 실패", testId, e);
         updateReportStatus(testId, Test::failReportAggregation);
         return List.of();

--- a/src/main/java/server/MATE/domain/report/service/ReportAggregationService.java
+++ b/src/main/java/server/MATE/domain/report/service/ReportAggregationService.java
@@ -57,8 +57,7 @@ public class ReportAggregationService {
         Test test = testRepository.findByIdAndDeletedAtIsNull(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
-        List<Question> questions = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId);
-        int questionCount = questions.size();
+        long questionCount = questionRepository.countByTestIdAndDeletedAtIsNull(testId);
         long reportCount = reportRepository.countByTestId(testId);
 
         // 질문 수와 리포트 수가 같으면 이미 전체 집계가 끝난 상태
@@ -78,12 +77,13 @@ public class ReportAggregationService {
         }
 
         // 질문이 없으면 생성할 리포트도 없으므로 빈 리스트르 반환
-        if (questions.isEmpty()) {
+        if (questionCount == 0) {
             test.completeReportAggregation();
             testRepository.save(test);
             return List.of();
         }
 
+        List<Question> questions = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId);
         List<Long> questionIds = questions.stream().map(Question::getId).toList();
         List<Answer> allAnswers = answerRepository.findAllByQuestionIdInAndDeletedAtIsNull(questionIds);
 
@@ -123,7 +123,7 @@ public class ReportAggregationService {
     @Recover
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public List<Report> recover(Exception e, Long testId) {
-        int questionCount = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId).size();
+        long questionCount = questionRepository.countByTestIdAndDeletedAtIsNull(testId);
         long reportCount = reportRepository.countByTestId(testId);
 
         if (e instanceof DataIntegrityViolationException || reportCount > 0) {

--- a/src/main/java/server/MATE/domain/report/service/ReportService.java
+++ b/src/main/java/server/MATE/domain/report/service/ReportService.java
@@ -1,6 +1,11 @@
 package server.MATE.domain.report.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.MATE.domain.question.dto.response.QuestionSummaryItem;
@@ -17,10 +22,7 @@ import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -33,15 +35,14 @@ public class ReportService {
     public ReportResponse getReport(Long testId, Long makerId) {
         Test test = testRepository.findByIdAndDeletedAtIsNull(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
-
         if (!test.getMakerId().equals(makerId)) throw new BaseException(BaseErrorCode.TEST_005);
 
         List<Question> questions = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId);
-
         List<QuestionSummaryItem> questionSummaries = questions.stream()
                 .map(q -> new QuestionSummaryItem(q.getId(), q.getSequence(), q.getTitle(), q.getQuestionType()))
                 .toList();
 
+        // 테스트가 진행 중이고, 리포트 집계가 시작되지 않은 상태. reports를 빈 리스트로 반환
         if (test.getTestStatus() == TestStatus.IN_PROGRESS) {
             return new ReportResponse(
                     TestStatus.IN_PROGRESS,
@@ -53,8 +54,8 @@ public class ReportService {
             );
         }
 
+        // 테스트가 완료이지만, 리포트 집계가 끝나지 않음. reportStatus를 업데이트하고 reports를 빈 리스트로 반환
         ReportStatus reportStatus = test.getReportStatus() != null ? test.getReportStatus() : ReportStatus.PENDING;
-
         if (reportStatus != ReportStatus.COMPLETED) {
             return new ReportResponse(
                     TestStatus.COMPLETED,
@@ -66,7 +67,21 @@ public class ReportService {
             );
         }
 
+        // 테스트가 완료이고, 리포트 집계가 끝난 상태. 질문별 집계 결과를 반환
         List<Report> aggregations = reportRepository.findAllByTestId(testId);
+
+        if (aggregations.size() != questions.size()) {
+            log.error("테스트 {} 리포트 조회 중 완전성 불일치 감지: questionCount={}, reportCount={}",
+                    testId, questions.size(), aggregations.size());
+            return new ReportResponse(
+                    TestStatus.COMPLETED,
+                    ReportStatus.FAILED,
+                    questions.size(),
+                    test.getPplCount(),
+                    questionSummaries,
+                    List.of()
+            );
+        }
 
         Map<Long, Map<String, Object>> resultByQuestionId = aggregations.stream()
                 .collect(Collectors.toMap(Report::getQuestionId, Report::getResult));

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -7,9 +7,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.report.entity.Report;
 import server.MATE.domain.report.repository.ReportRepository;
 import server.MATE.domain.report.service.ReportAggregationService;
+import server.MATE.domain.test.entity.ReportStatus;
 import server.MATE.domain.test.entity.TestStatus;
+
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -670,6 +675,52 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         JsonNode data = reportData(actors.testId(), actors.makerToken());
         assertThat(data.path("testStatus").asText()).isEqualTo("COMPLETED");
         assertThat(data.path("reportStatus").asText()).isEqualTo("IN_PROGRESS");
+        assertThat(data.path("reports")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("부분 생성된 리포트가 있으면 집계는 FAILED로 처리된다")
+    void aggregate_whenReportsPartiallyExist_marksFailed() throws Exception {
+        TestActors actors = createActors();
+        createTwoSubjectiveQuestions(actors.testId(), actors.makerToken());
+        JsonNode questions = getQuestionsArray(actors.testId(), actors.makerToken());
+
+        reportRepository.save(Report.builder()
+                .testId(actors.testId())
+                .questionId(questions.get(0).path("questionId").asLong())
+                .questionType(QuestionType.SUBJECTIVE)
+                .result(Map.of("texts", java.util.List.of("partial")))
+                .build());
+
+        completeTestStatusOnly(actors.testId());
+        reportAggregationService.aggregate(actors.testId());
+
+        server.MATE.domain.test.entity.Test updated = testRepository.findById(actors.testId()).orElseThrow();
+        assertThat(updated.getReportStatus()).isEqualTo(ReportStatus.FAILED);
+    }
+
+    @Test
+    @DisplayName("reportStatus가 COMPLETED여도 리포트 수가 질문 수와 다르면 조회 시 FAILED와 빈 reports를 반환한다")
+    void getReport_whenCompletedButReportsAreIncomplete_returnsFailedAndEmptyReports() throws Exception {
+        TestActors actors = createActors();
+        createTwoSubjectiveQuestions(actors.testId(), actors.makerToken());
+        JsonNode questions = getQuestionsArray(actors.testId(), actors.makerToken());
+
+        reportRepository.save(Report.builder()
+                .testId(actors.testId())
+                .questionId(questions.get(0).path("questionId").asLong())
+                .questionType(QuestionType.SUBJECTIVE)
+                .result(Map.of("texts", java.util.List.of("partial")))
+                .build());
+
+        server.MATE.domain.test.entity.Test test = testRepository.findById(actors.testId()).orElseThrow();
+        test.complete();
+        test.completeReportAggregation();
+        testRepository.save(test);
+
+        JsonNode data = reportData(actors.testId(), actors.makerToken());
+        assertThat(data.path("testStatus").asText()).isEqualTo("COMPLETED");
+        assertThat(data.path("reportStatus").asText()).isEqualTo("FAILED");
         assertThat(data.path("reports")).isEmpty();
     }
 


### PR DESCRIPTION
## 📍 요약
- 부분 생성된 리포트도 완료로 오판할 수 있던 집계 상태 판정을, 질문 수 대비 리포트 수 검증 기반으로 보완함

## 🔗 관련 이슈
- Closes #125 

## 📌 변경 사항
- [ ] 기능
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- ReportAggregationService에서 existsByTestId() 대신 질문 수와 리포트 수를 비교해 COMPLETED / FAILED를 판정하도록 수정
- ReportService 조회 경로에서 reportStatus=COMPLETED여도 리포트가 불완전하면 FAILED + reports=[]를 반환하도록 방어 로직 추가
- 부분 생성 리포트 집계/조회 실패 케이스에 대한 통합 테스트 추가

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew test --tests server.MATE.integration.ReportEndToEndIntegrationTest
