### PR TITLE
fix: Report 조회 시 질문 조회 경로가 분리되어 정합성 불일치 버그 수정

### DIFF
--- a/src/main/java/server/MATE/domain/report/service/ReportService.java
+++ b/src/main/java/server/MATE/domain/report/service/ReportService.java
@@ -9,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.MATE.domain.question.dto.response.QuestionSummaryItem;
-import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.repository.QuestionRepository;
 import server.MATE.domain.report.dto.response.ReportItem;
 import server.MATE.domain.report.dto.response.ReportResponse;
@@ -37,17 +36,15 @@ public class ReportService {
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
         if (!test.getMakerId().equals(makerId)) throw new BaseException(BaseErrorCode.TEST_005);
 
-        List<Question> questions = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId);
-        List<QuestionSummaryItem> questionSummaries = questions.stream()
-                .map(q -> new QuestionSummaryItem(q.getId(), q.getSequence(), q.getTitle(), q.getQuestionType()))
-                .toList();
+        List<QuestionSummaryItem> questionSummaries = questionRepository.findQuestionSummariesByTestId(testId);
+        int questionCount = questionSummaries.size();
 
         // 테스트가 진행 중이고, 리포트 집계가 시작되지 않은 상태. reports를 빈 리스트로 반환
         if (test.getTestStatus() == TestStatus.IN_PROGRESS) {
             return new ReportResponse(
                     TestStatus.IN_PROGRESS,
                     ReportStatus.PENDING,
-                    questions.size(),
+                    questionCount,
                     test.getPplCount(),
                     questionSummaries,
                     List.of()
@@ -60,7 +57,7 @@ public class ReportService {
             return new ReportResponse(
                     TestStatus.COMPLETED,
                     reportStatus,
-                    questions.size(),
+                    questionCount,
                     test.getPplCount(),
                     questionSummaries,
                     List.of()
@@ -70,13 +67,13 @@ public class ReportService {
         // 테스트가 완료이고, 리포트 집계가 끝난 상태. 질문별 집계 결과를 반환
         List<Report> aggregations = reportRepository.findAllByTestId(testId);
 
-        if (aggregations.size() != questions.size()) {
+        if (aggregations.size() != questionCount) {
             log.error("테스트 {} 리포트 조회 중 완전성 불일치 감지: questionCount={}, reportCount={}",
-                    testId, questions.size(), aggregations.size());
+                    testId, questionCount, aggregations.size());
             return new ReportResponse(
                     TestStatus.COMPLETED,
                     ReportStatus.FAILED,
-                    questions.size(),
+                    questionCount,
                     test.getPplCount(),
                     questionSummaries,
                     List.of()
@@ -86,20 +83,21 @@ public class ReportService {
         Map<Long, Map<String, Object>> resultByQuestionId = aggregations.stream()
                 .collect(Collectors.toMap(Report::getQuestionId, Report::getResult));
 
-        List<ReportItem> reports = questions.stream()
-                .map(q -> new ReportItem(
-                        q.getId(),
-                        q.getSequence(),
-                        q.getTitle(),
-                        q.getQuestionType(),
-                        resultByQuestionId.get(q.getId())
+        // questions에서 사용한 projection을 reports에서 재사용
+        List<ReportItem> reports = questionSummaries.stream()
+                .map(question -> new ReportItem(
+                        question.questionId(),
+                        question.sequence(),
+                        question.title(),
+                        question.type(),
+                        resultByQuestionId.get(question.questionId())
                 ))
                 .toList();
 
         return new ReportResponse(
                 TestStatus.COMPLETED,
                 ReportStatus.COMPLETED,
-                questions.size(),
+                questionCount,
                 test.getPplCount(),
                 questionSummaries,
                 reports


### PR DESCRIPTION
## 📍 요약
- Report 조회에서 질문을 projection으로 통일하여 질문 목록과 리포트의 정렬/정합성 기준을 일치시킴

## 🔗 관련 이슈
- Closes #126 

## 📌 변경 사항
- [ ] 기능
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->

- ReportService에서 Question 엔티티 조회를 제거하고 findQuestionSummariesByTestId() projection 조회를 사용하도록 수정
- 같은 질문 projection 결과로 questions, reports, questionCount를 함께 조립하도록 정리

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew test --tests server.MATE.integration.ReportEndToEndIntegrationTest
