### PR TITLE
fix: Answer 생성 시 서비스와 핸들러의 검증 책임을 분리

### DIFF
--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -11,8 +11,19 @@ import server.MATE.domain.answer.repository.AnswerRepository;
 import server.MATE.domain.answer.service.handler.AnswerCreateHandler;
 import server.MATE.domain.participation.entity.Participation;
 import server.MATE.domain.participation.repository.ParticipationRepository;
-import server.MATE.domain.question.entity.*;
-import server.MATE.domain.question.repository.*;
+import server.MATE.domain.question.dto.response.AnswerQuestionTypeView;
+import server.MATE.domain.question.entity.CardSorting;
+import server.MATE.domain.question.entity.FiveSecond;
+import server.MATE.domain.question.entity.Objective;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.entity.Scale;
+import server.MATE.domain.question.entity.TreeTest;
+import server.MATE.domain.question.repository.CardSortingRepository;
+import server.MATE.domain.question.repository.FiveSecondRepository;
+import server.MATE.domain.question.repository.ObjectiveRepository;
+import server.MATE.domain.question.repository.QuestionRepository;
+import server.MATE.domain.question.repository.ScaleRepository;
+import server.MATE.domain.question.repository.TreeTestRepository;
 import server.MATE.domain.test.entity.Test;
 import server.MATE.domain.test.event.TestCompletedEvent;
 import server.MATE.domain.test.repository.TestRepository;
@@ -73,15 +84,16 @@ public class AnswerService {
             throw new BaseException(BaseErrorCode.PARTICIPATION_003);
         }
 
-        Map<Long, Question> questionMap = questionRepository
-                .findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId)
+        Map<Long, AnswerQuestionTypeView> questionMap = questionRepository
+                .findAnswerQuestionTypeViewsByTestId(testId)
                 .stream()
-                .collect(Collectors.toMap(Question::getId, q -> q));
+                .collect(Collectors.toMap(AnswerQuestionTypeView::questionId, view -> view));
 
         if (questionMap.size() != request.answers().size()) {
             throw new BaseException(BaseErrorCode.ANSWER_008);
         }
 
+        // 요청한 answer들을 질문 기준으로 검증하고 유형별 questionId를 수집
         Map<QuestionType, List<Long>> idsByType = new EnumMap<>(QuestionType.class);
         Set<Long> processedQuestionIds = new HashSet<>();
         for (AnswerCreateItem item : request.answers()) {
@@ -89,12 +101,12 @@ public class AnswerService {
                 throw new BaseException(BaseErrorCode.ANSWER_003);
             }
 
-            Question question = questionMap.get(item.questionId());
+            AnswerQuestionTypeView question = questionMap.get(item.questionId());
             if (question == null) {
                 throw new BaseException(BaseErrorCode.ANSWER_002);
             }
 
-            if (question.getQuestionType() != item.type()) {
+            if (question.questionType() != item.type()) {
                 throw new BaseException(BaseErrorCode.ANSWER_001);
             }
 
@@ -105,11 +117,13 @@ public class AnswerService {
             idsByType.computeIfAbsent(item.type(), key -> new ArrayList<>()).add(item.questionId());
         }
 
+        // 질문 유형별 상세 검증에 필요한 context를 만들고 handler validate를 실행
         AnswerCreateContext context = buildContext(idsByType);
         for (AnswerCreateItem item : request.answers()) {
             handlerMap.get(item.type()).validate(item, context);
         }
 
+        // 모든 검증 완료 시 participation과 answer를 저장
         Participation participation = Participation.builder()
                 .testId(testId)
                 .testerId(testerId)
@@ -121,6 +135,7 @@ public class AnswerService {
             answers.add(handlerMap.get(item.type()).build(participation.getId(), item, context));
         }
 
+        // 응답 저장 후 참여자 수를 갱신하고, 목표 인원 도달 시 테스트 완료 및 리포트 집계 이벤트 발행
         answerRepository.saveAll(answers);
         test.incrementPplCount();
         if (test.getPplCount() >= test.getGoalPpl()) {

--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -82,12 +82,7 @@ public class AnswerService {
             throw new BaseException(BaseErrorCode.ANSWER_008);
         }
 
-        Participation participation = Participation.builder()
-                .testId(testId)
-                .testerId(testerId)
-                .build();
-        participationRepository.save(participation);
-
+        Map<QuestionType, List<Long>> idsByType = new EnumMap<>(QuestionType.class);
         Set<Long> processedQuestionIds = new HashSet<>();
         for (AnswerCreateItem item : request.answers()) {
             if (!processedQuestionIds.add(item.questionId())) {
@@ -106,9 +101,20 @@ public class AnswerService {
             if (!handlerMap.containsKey(item.type())) {
                 throw new BaseException(BaseErrorCode.COMMON_999);
             }
+
+            idsByType.computeIfAbsent(item.type(), key -> new ArrayList<>()).add(item.questionId());
         }
 
-        AnswerCreateContext context = buildContext(request.answers());
+        AnswerCreateContext context = buildContext(idsByType);
+        for (AnswerCreateItem item : request.answers()) {
+            handlerMap.get(item.type()).validate(item, context);
+        }
+
+        Participation participation = Participation.builder()
+                .testId(testId)
+                .testerId(testerId)
+                .build();
+        participationRepository.save(participation);
 
         List<Answer> answers = new ArrayList<>();
         for (AnswerCreateItem item : request.answers()) {
@@ -125,12 +131,7 @@ public class AnswerService {
         return AnswerBatchCreateResponse.from(participation);
     }
 
-    private AnswerCreateContext buildContext(List<AnswerCreateItem> items) {
-        Map<QuestionType, List<Long>> idsByType = new EnumMap<>(QuestionType.class);
-        for (AnswerCreateItem item : items) {
-            idsByType.computeIfAbsent(item.type(), k -> new ArrayList<>()).add(item.questionId());
-        }
-
+    private AnswerCreateContext buildContext(Map<QuestionType, List<Long>> idsByType) {
         Map<Long, Objective> objectives = fetchByType(idsByType, QuestionType.OBJECTIVE,
                 ids -> objectiveRepository.findAllByIdIn(ids), Objective::getId);
 

--- a/src/main/java/server/MATE/domain/answer/service/handler/AbTestAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/AbTestAnswerCreateHandler.java
@@ -18,6 +18,10 @@ public class AbTestAnswerCreateHandler implements AnswerCreateHandler {
     }
 
     @Override
+    public void validate(AnswerCreateItem item, AnswerCreateContext context) {
+    }
+
+    @Override
     public Answer build(Long participationId, AnswerCreateItem item, AnswerCreateContext context) {
         AbTestAnswerCreateRequest request = (AbTestAnswerCreateRequest) item;
 

--- a/src/main/java/server/MATE/domain/answer/service/handler/AnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/AnswerCreateHandler.java
@@ -9,5 +9,7 @@ public interface AnswerCreateHandler {
 
     QuestionType supports();
 
+    void validate(AnswerCreateItem item, AnswerCreateContext context);
+
     Answer build(Long participationId, AnswerCreateItem item, AnswerCreateContext context);
 }

--- a/src/main/java/server/MATE/domain/answer/service/handler/CardSortingAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/CardSortingAnswerCreateHandler.java
@@ -23,9 +23,10 @@ public class CardSortingAnswerCreateHandler implements AnswerCreateHandler {
     }
 
     @Override
-    public Answer build(Long participationId, AnswerCreateItem item, AnswerCreateContext context) {
+    public void validate(AnswerCreateItem item, AnswerCreateContext context) {
         CardSortingAnswerCreateRequest request = (CardSortingAnswerCreateRequest) item;
 
+        // 최소 1개 이상의 groups를 요청해야 함
         if (request.groups() == null || request.groups().isEmpty()) throw new BaseException(BaseErrorCode.ANSWER_005);
 
         CardSorting cardSorting = context.cardSortings().get(request.questionId());
@@ -37,19 +38,28 @@ public class CardSortingAnswerCreateHandler implements AnswerCreateHandler {
         Set<String> assignedCards = new HashSet<>();
         Set<String> usedCategories = new HashSet<>();
         for (CardSortingAnswerCreateRequest.GroupItem group : request.groups()) {
+
+            // 카테고리는 질문의 category만 사용할 수 있고 중복을 허용하지 않음
             if (group == null || group.category() == null || !validCategories.contains(group.category())) {
                 throw new BaseException(BaseErrorCode.ANSWER_004);
             }
             if (!usedCategories.add(group.category())) throw new BaseException(BaseErrorCode.ANSWER_004);
             if (group.cardNames() == null) throw new BaseException(BaseErrorCode.ANSWER_004);
             for (String cardName : group.cardNames()) {
+
+                // 카드는 질문의 card만 사용할 수 있고 한 번만 배치 허용
                 if (!validCards.contains(cardName)) throw new BaseException(BaseErrorCode.ANSWER_004);
                 if (!assignedCards.add(cardName)) throw new BaseException(BaseErrorCode.ANSWER_004);
             }
         }
 
+        // 모든 카드는 예외없이 한 번씩 배치되어야 함
         if (assignedCards.size() != validCards.size()) throw new BaseException(BaseErrorCode.ANSWER_005);
+    }
 
+    @Override
+    public Answer build(Long participationId, AnswerCreateItem item, AnswerCreateContext context) {
+        CardSortingAnswerCreateRequest request = (CardSortingAnswerCreateRequest) item;
         return Answer.builder()
                 .participationId(participationId)
                 .questionId(request.questionId())

--- a/src/main/java/server/MATE/domain/answer/service/handler/FiveSecondAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/FiveSecondAnswerCreateHandler.java
@@ -26,20 +26,19 @@ public class FiveSecondAnswerCreateHandler implements AnswerCreateHandler {
     }
 
     @Override
-    public Answer build(Long participationId, AnswerCreateItem item, AnswerCreateContext context) {
+    public void validate(AnswerCreateItem item, AnswerCreateContext context) {
         FiveSecondAnswerCreateRequest request = (FiveSecondAnswerCreateRequest) item;
 
         FiveSecond fiveSecond = context.fiveSeconds().get(request.questionId());
         if (fiveSecond == null) throw new BaseException(BaseErrorCode.QUESTION_005);
 
-        Map<String, Object> answerMap;
-
         if (!fiveSecond.isObjective()) {
+            // 주관식 5초 테스트 응답일 때, text만 허용함
             if (request.text() == null || request.text().isBlank()) throw new BaseException(BaseErrorCode.ANSWER_005);
             if (request.optionIds() != null && !request.optionIds().isEmpty()) throw new BaseException(BaseErrorCode.ANSWER_004);
             if (request.otherText() != null && !request.otherText().isBlank()) throw new BaseException(BaseErrorCode.ANSWER_004);
-            answerMap = Map.of("text", request.text().trim());
         } else {
+            // 객관식 5초 테스트 응답일 때, optionIds 기준으로 응답해야 함
             if (request.text() != null && !request.text().isBlank()) throw new BaseException(BaseErrorCode.ANSWER_004);
             List<Long> selectedOptionIds = request.optionIds() != null ? request.optionIds() : List.of();
 
@@ -56,19 +55,25 @@ public class FiveSecondAnswerCreateHandler implements AnswerCreateHandler {
             boolean hasOtherText = request.otherText() != null && !request.otherText().isBlank();
             boolean selectedOtherOption = otherOptionId != null && selectedOptionIds.contains(otherOptionId);
 
+            // 객관식 5초 테스트 응답은 최소 1개 이상의 옵션(선지)를 가져야 함
             if (selectedOptionIds.isEmpty()) throw new BaseException(BaseErrorCode.ANSWER_005);
 
+            // 기타 option 선택 여부와 otherText 입력 여부가 일치해야 함
             if (!Boolean.TRUE.equals(fiveSecond.getIsOther()) && (hasOtherText || selectedOtherOption)) {
                 throw new BaseException(BaseErrorCode.ANSWER_004);
             }
 
+            // 기타 option 선택 시, otherText를 가져야 함
             if (selectedOtherOption != hasOtherText) {
                 throw new BaseException(BaseErrorCode.ANSWER_004);
             }
 
+            // 질문의 옵션(선지)만 중복 없이 선택해야 함
             validateSelectedOptions(selectedOptionIds, validOptionIds);
 
             int selectedCount = selectedOptionIds.size();
+
+            // 단일/복수 선택 설정에 맞는 선택 개수만 허용함
             if (!Boolean.TRUE.equals(fiveSecond.getIsDuplicate())) {
                 if (selectedCount != 1) throw new BaseException(BaseErrorCode.ANSWER_006);
             } else {
@@ -76,9 +81,21 @@ public class FiveSecondAnswerCreateHandler implements AnswerCreateHandler {
                 int max = fiveSecond.getMaxSelect() != null ? fiveSecond.getMaxSelect() : validOptionIds.size();
                 if (selectedCount < min || selectedCount > max) throw new BaseException(BaseErrorCode.ANSWER_006);
             }
+        }
+    }
 
+    @Override
+    public Answer build(Long participationId, AnswerCreateItem item, AnswerCreateContext context) {
+        FiveSecondAnswerCreateRequest request = (FiveSecondAnswerCreateRequest) item;
+        FiveSecond fiveSecond = context.fiveSeconds().get(request.questionId());
+        Map<String, Object> answerMap;
+
+        if (!fiveSecond.isObjective()) {
+            answerMap = Map.of("text", request.text().trim());
+        } else {
+            boolean hasOtherText = request.otherText() != null && !request.otherText().isBlank();
             answerMap = new LinkedHashMap<>();
-            answerMap.put("optionIds", selectedOptionIds);
+            answerMap.put("optionIds", request.optionIds() != null ? request.optionIds() : List.of());
             if (hasOtherText) {
                 answerMap.put("otherText", request.otherText().trim());
             }

--- a/src/main/java/server/MATE/domain/answer/service/handler/FiveSecondAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/FiveSecondAnswerCreateHandler.java
@@ -69,7 +69,12 @@ public class FiveSecondAnswerCreateHandler implements AnswerCreateHandler {
             }
 
             // 질문의 옵션(선지)만 중복 없이 선택해야 함
-            validateSelectedOptions(selectedOptionIds, validOptionIds);
+            if (selectedOptionIds.size() != Set.copyOf(selectedOptionIds).size()) {
+                throw new BaseException(BaseErrorCode.ANSWER_004);
+            }
+            if (!validOptionIds.containsAll(selectedOptionIds)) {
+                throw new BaseException(BaseErrorCode.ANSWER_004);
+            }
 
             int selectedCount = selectedOptionIds.size();
 
@@ -107,14 +112,5 @@ public class FiveSecondAnswerCreateHandler implements AnswerCreateHandler {
                 .questionType(QuestionType.FIVE_SECOND)
                 .answer(answerMap)
                 .build();
-    }
-
-    private void validateSelectedOptions(List<Long> selectedOptionIds, Set<Long> validOptionIds) {
-        if (selectedOptionIds.size() != Set.copyOf(selectedOptionIds).size()) {
-            throw new BaseException(BaseErrorCode.ANSWER_004);
-        }
-        if (!validOptionIds.containsAll(selectedOptionIds)) {
-            throw new BaseException(BaseErrorCode.ANSWER_004);
-        }
     }
 }

--- a/src/main/java/server/MATE/domain/answer/service/handler/ObjectiveAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/ObjectiveAnswerCreateHandler.java
@@ -26,7 +26,7 @@ public class ObjectiveAnswerCreateHandler implements AnswerCreateHandler {
     }
 
     @Override
-    public Answer build(Long participationId, AnswerCreateItem item, AnswerCreateContext context) {
+    public void validate(AnswerCreateItem item, AnswerCreateContext context) {
         ObjectiveAnswerCreateRequest request = (ObjectiveAnswerCreateRequest) item;
 
         Objective objective = context.objectives().get(request.questionId());
@@ -46,36 +46,42 @@ public class ObjectiveAnswerCreateHandler implements AnswerCreateHandler {
         boolean hasOtherText = request.otherText() != null && !request.otherText().isBlank();
         boolean selectedOtherOption = otherOptionId != null && selectedOptionIds.contains(otherOptionId);
 
-        // 객관식 응답은 최소 1개 이상의 선택지가 필요함
+        // 객관식 응답은 최소 1개 이상의 옵션(선지)가 필요함
         if (selectedOptionIds.isEmpty()) {
             throw new BaseException(BaseErrorCode.ANSWER_005);
         }
 
-        // 기타 선택지를 허용하지 않는 문항에는 기타 option, otherText를 함께 사용할 수 없음
+        // 기타 option 선택 여부와 otherText 입력 여부가 일치해야 함
         if (!objective.isOther() && (hasOtherText || selectedOtherOption)) {
             throw new BaseException(BaseErrorCode.ANSWER_004);
         }
 
-        // 기타 option 선택 여부와 otherText 입력 여부는 반드시 함께 일치해야 함
+        // 기타 option 선택 시, otherText를 가져야 함
         if (selectedOtherOption != hasOtherText) {
             throw new BaseException(BaseErrorCode.ANSWER_004);
         }
 
+        // 질문의 옵션(선지)만 중복 없이 선택해야 함
         validateSelectedOptions(selectedOptionIds, validOptionIds);
 
         int selectedCount = selectedOptionIds.size();
-        // 단일 선택 객관식은 정확히 1개의 선택지만 허용함
+
+        // 단일/복수 선택 설정에 맞는 선택 개수만 허용함
         if (!objective.isDuplicate()) {
             if (selectedCount != 1) throw new BaseException(BaseErrorCode.ANSWER_006);
         } else {
             int min = objective.getMinSelect() != null ? objective.getMinSelect() : 1;
             int max = objective.getMaxSelect() != null ? objective.getMaxSelect() : validOptionIds.size();
-            // 복수 선택 객관식은 min/max 범위 내에서만 선택할 수 있음
             if (selectedCount < min || selectedCount > max) throw new BaseException(BaseErrorCode.ANSWER_006);
         }
+    }
 
+    @Override
+    public Answer build(Long participationId, AnswerCreateItem item, AnswerCreateContext context) {
+        ObjectiveAnswerCreateRequest request = (ObjectiveAnswerCreateRequest) item;
+        boolean hasOtherText = request.otherText() != null && !request.otherText().isBlank();
         Map<String, Object> answerMap = new LinkedHashMap<>();
-        answerMap.put("optionIds", selectedOptionIds);
+        answerMap.put("optionIds", request.optionIds());
         if (hasOtherText) answerMap.put("otherText", request.otherText().trim());
 
         return Answer.builder()

--- a/src/main/java/server/MATE/domain/answer/service/handler/ObjectiveAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/ObjectiveAnswerCreateHandler.java
@@ -62,7 +62,12 @@ public class ObjectiveAnswerCreateHandler implements AnswerCreateHandler {
         }
 
         // 질문의 옵션(선지)만 중복 없이 선택해야 함
-        validateSelectedOptions(selectedOptionIds, validOptionIds);
+        if (selectedOptionIds.size() != Set.copyOf(selectedOptionIds).size()) {
+            throw new BaseException(BaseErrorCode.ANSWER_004);
+        }
+        if (!validOptionIds.containsAll(selectedOptionIds)) {
+            throw new BaseException(BaseErrorCode.ANSWER_004);
+        }
 
         int selectedCount = selectedOptionIds.size();
 
@@ -90,16 +95,5 @@ public class ObjectiveAnswerCreateHandler implements AnswerCreateHandler {
                 .questionType(QuestionType.OBJECTIVE)
                 .answer(answerMap)
                 .build();
-    }
-
-    private void validateSelectedOptions(List<Long> selectedOptionIds, Set<Long> validOptionIds) {
-        // 동일한 선택지를 중복 선택할 수 없음
-        if (selectedOptionIds.size() != Set.copyOf(selectedOptionIds).size()) {
-            throw new BaseException(BaseErrorCode.ANSWER_004);
-        }
-        // 현재 문항에 존재하지 않는 선택지는 응답할 수 없음
-        if (!validOptionIds.containsAll(selectedOptionIds)) {
-            throw new BaseException(BaseErrorCode.ANSWER_004);
-        }
     }
 }

--- a/src/main/java/server/MATE/domain/answer/service/handler/ScaleAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/ScaleAnswerCreateHandler.java
@@ -21,16 +21,21 @@ public class ScaleAnswerCreateHandler implements AnswerCreateHandler {
     }
 
     @Override
-    public Answer build(Long participationId, AnswerCreateItem item, AnswerCreateContext context) {
+    public void validate(AnswerCreateItem item, AnswerCreateContext context) {
         ScaleAnswerCreateRequest request = (ScaleAnswerCreateRequest) item;
 
         Scale scale = context.scales().get(request.questionId());
         if (scale == null) throw new BaseException(BaseErrorCode.QUESTION_005);
 
+        // 척도형 응답은 질문의 range 범위 안의 값만 허용함
         if (request.value() < 1 || request.value() > scale.getRange()) {
             throw new BaseException(BaseErrorCode.ANSWER_007);
         }
+    }
 
+    @Override
+    public Answer build(Long participationId, AnswerCreateItem item, AnswerCreateContext context) {
+        ScaleAnswerCreateRequest request = (ScaleAnswerCreateRequest) item;
         return Answer.builder()
                 .participationId(participationId)
                 .questionId(request.questionId())

--- a/src/main/java/server/MATE/domain/answer/service/handler/SubjectiveAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/SubjectiveAnswerCreateHandler.java
@@ -18,6 +18,10 @@ public class SubjectiveAnswerCreateHandler implements AnswerCreateHandler {
     }
 
     @Override
+    public void validate(AnswerCreateItem item, AnswerCreateContext context) {
+    }
+
+    @Override
     public Answer build(Long participationId, AnswerCreateItem item, AnswerCreateContext context) {
         SubjectiveAnswerCreateRequest request = (SubjectiveAnswerCreateRequest) item;
         return Answer.builder()

--- a/src/main/java/server/MATE/domain/answer/service/handler/TreeTestAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/TreeTestAnswerCreateHandler.java
@@ -23,11 +23,12 @@ public class TreeTestAnswerCreateHandler implements AnswerCreateHandler {
     }
 
     @Override
-    public Answer build(Long participationId, AnswerCreateItem item, AnswerCreateContext context) {
+    public void validate(AnswerCreateItem item, AnswerCreateContext context) {
         TreeTestAnswerCreateRequest request = (TreeTestAnswerCreateRequest) item;
 
         List<Long> path = request.path();
 
+        // 요청한 마지막 nodeId는 path의 마지막 노드와 일치해야 함
         if (!request.nodeId().equals(path.getLast())) {
             throw new BaseException(BaseErrorCode.ANSWER_004);
         }
@@ -38,13 +39,21 @@ public class TreeTestAnswerCreateHandler implements AnswerCreateHandler {
         Map<Long, TreeTest> nodeMap = nodes.stream()
                 .collect(Collectors.toMap(TreeTest::getId, n -> n));
 
+        // path가 루트부터 부모-자식 관계를 올바르게 이어져야 함
         validatePath(path, nodeMap);
 
         TreeTest node = nodeMap.get(request.nodeId());
         boolean isLeaf = nodes.stream()
                 .noneMatch(n -> n.getParent() != null && n.getParent().getId().equals(node.getId()));
-        if (!isLeaf) throw new BaseException(BaseErrorCode.ANSWER_004);
 
+        // 응답은 자식이 없는 leaf 노드만 최종 선택할 수 있음
+        if (!isLeaf) throw new BaseException(BaseErrorCode.ANSWER_004);
+    }
+
+    @Override
+    public Answer build(Long participationId, AnswerCreateItem item, AnswerCreateContext context) {
+        TreeTestAnswerCreateRequest request = (TreeTestAnswerCreateRequest) item;
+        List<Long> path = request.path();
         return Answer.builder()
                 .participationId(participationId)
                 .questionId(request.questionId())

--- a/src/main/java/server/MATE/domain/answer/service/handler/TreeTestAnswerCreateHandler.java
+++ b/src/main/java/server/MATE/domain/answer/service/handler/TreeTestAnswerCreateHandler.java
@@ -40,7 +40,9 @@ public class TreeTestAnswerCreateHandler implements AnswerCreateHandler {
                 .collect(Collectors.toMap(TreeTest::getId, n -> n));
 
         // path가 루트부터 부모-자식 관계를 올바르게 이어져야 함
-        validatePath(path, nodeMap);
+        if (!isValidPath(path, nodeMap)) {
+            throw new BaseException(BaseErrorCode.ANSWER_004);
+        }
 
         TreeTest node = nodeMap.get(request.nodeId());
         boolean isLeaf = nodes.stream()
@@ -62,18 +64,19 @@ public class TreeTestAnswerCreateHandler implements AnswerCreateHandler {
                 .build();
     }
 
-    private void validatePath(List<Long> path, Map<Long, TreeTest> nodeMap) {
+    private boolean isValidPath(List<Long> path, Map<Long, TreeTest> nodeMap) {
         for (int i = 0; i < path.size(); i++) {
             TreeTest current = nodeMap.get(path.get(i));
-            if (current == null) throw new BaseException(BaseErrorCode.ANSWER_004);
+            if (current == null) return false;
 
             if (i == 0) {
-                if (current.getParent() != null) throw new BaseException(BaseErrorCode.ANSWER_004);
+                if (current.getParent() != null) return false;
             } else {
                 if (current.getParent() == null || !current.getParent().getId().equals(path.get(i - 1))) {
-                    throw new BaseException(BaseErrorCode.ANSWER_004);
+                    return false;
                 }
             }
         }
+        return true;
     }
 }

--- a/src/main/java/server/MATE/domain/question/dto/response/AnswerQuestionTypeView.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/AnswerQuestionTypeView.java
@@ -1,0 +1,9 @@
+package server.MATE.domain.question.dto.response;
+
+import server.MATE.domain.question.entity.QuestionType;
+
+public record AnswerQuestionTypeView(
+        Long questionId,
+        QuestionType questionType
+) {
+}

--- a/src/main/java/server/MATE/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/QuestionRepository.java
@@ -2,6 +2,7 @@ package server.MATE.domain.question.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import server.MATE.domain.question.dto.response.AnswerQuestionTypeView;
 import server.MATE.domain.question.dto.response.QuestionSummaryItem;
 import server.MATE.domain.question.entity.Question;
 
@@ -18,6 +19,17 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     long countByTestIdAndDeletedAtIsNull(Long testId);
 
     List<Question> findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(Long testId);
+
+    @Query("""
+            select new server.MATE.domain.question.dto.response.AnswerQuestionTypeView(
+                q.id,
+                q.questionType
+            )
+            from Question q
+            where q.testId = :testId
+              and q.deletedAt is null
+            """)
+    List<AnswerQuestionTypeView> findAnswerQuestionTypeViewsByTestId(Long testId);
 
     @Query("""
             select new server.MATE.domain.question.dto.response.QuestionSummaryItem(

--- a/src/main/java/server/MATE/domain/question/service/handler/ObjectiveQuestionCreateHandler.java
+++ b/src/main/java/server/MATE/domain/question/service/handler/ObjectiveQuestionCreateHandler.java
@@ -35,7 +35,7 @@ public class ObjectiveQuestionCreateHandler extends AbstractQuestionCreateHandle
         int optionCount = item.options() == null ? 0 : item.options().size();
         int effectiveOptionCount = optionCount + (item.isOther() ? 1 : 0);
 
-        // 객관식은 기본 선택지를 최소 2개 이상 가져야 하며, 기타 포함 총 선택지는 10개를 초과할 수 없음
+        // 객관식은 기본 옵션(선지)을 최소 2개 이상 가져야 하며, 기타 포함 총 옵션(선지)은 10개를 초과할 수 없음
         if (optionCount < 2 || effectiveOptionCount > 10) {
             throw new BaseException(BaseErrorCode.COMMON_002);
         }
@@ -61,7 +61,7 @@ public class ObjectiveQuestionCreateHandler extends AbstractQuestionCreateHandle
             throw new BaseException(BaseErrorCode.QUESTION_002);
         }
 
-        // min/max 선택 개수는 전체 선택지 개수를 초과할 수 없음
+        // min/max 선택 개수는 전체 옵션(선지) 개수를 초과할 수 없음
         if (max != null && max > effectiveOptionCount) {
             throw new BaseException(BaseErrorCode.QUESTION_003);
         }

--- a/src/test/java/server/MATE/domain/answer/service/handler/FiveSecondAnswerCreateHandlerTest.java
+++ b/src/test/java/server/MATE/domain/answer/service/handler/FiveSecondAnswerCreateHandlerTest.java
@@ -34,6 +34,7 @@ class FiveSecondAnswerCreateHandlerTest {
         FiveSecondAnswerCreateRequest request =
                 new FiveSecondAnswerCreateRequest(1L, null, List.of(2001L, 2099L), "하단 CTA 버튼");
 
+        handler.validate(request, context(fiveSecond));
         Answer answer = handler.build(10L, request, context(fiveSecond));
 
         assertThat(answer.getQuestionType()).isEqualTo(QuestionType.FIVE_SECOND);
@@ -51,7 +52,7 @@ class FiveSecondAnswerCreateHandlerTest {
         FiveSecondAnswerCreateRequest request =
                 new FiveSecondAnswerCreateRequest(1L, null, List.of(2001L), "하단 CTA 버튼");
 
-        assertThatThrownBy(() -> handler.build(10L, request, context(fiveSecond)))
+        assertThatThrownBy(() -> handler.validate(request, context(fiveSecond)))
                 .isInstanceOf(BaseException.class)
                 .extracting(ex -> ((BaseException) ex).getErrorCode())
                 .isEqualTo(BaseErrorCode.ANSWER_004);
@@ -66,7 +67,7 @@ class FiveSecondAnswerCreateHandlerTest {
         FiveSecondAnswerCreateRequest request =
                 new FiveSecondAnswerCreateRequest(1L, null, List.of(2099L), null);
 
-        assertThatThrownBy(() -> handler.build(10L, request, context(fiveSecond)))
+        assertThatThrownBy(() -> handler.validate(request, context(fiveSecond)))
                 .isInstanceOf(BaseException.class)
                 .extracting(ex -> ((BaseException) ex).getErrorCode())
                 .isEqualTo(BaseErrorCode.ANSWER_004);
@@ -80,7 +81,7 @@ class FiveSecondAnswerCreateHandlerTest {
         FiveSecondAnswerCreateRequest request =
                 new FiveSecondAnswerCreateRequest(1L, "첫 인상", null, "불필요한 기타 텍스트");
 
-        assertThatThrownBy(() -> handler.build(10L, request, context(fiveSecond)))
+        assertThatThrownBy(() -> handler.validate(request, context(fiveSecond)))
                 .isInstanceOf(BaseException.class)
                 .extracting(ex -> ((BaseException) ex).getErrorCode())
                 .isEqualTo(BaseErrorCode.ANSWER_004);

--- a/src/test/java/server/MATE/domain/answer/service/handler/ObjectiveAnswerCreateHandlerTest.java
+++ b/src/test/java/server/MATE/domain/answer/service/handler/ObjectiveAnswerCreateHandlerTest.java
@@ -32,6 +32,7 @@ class ObjectiveAnswerCreateHandlerTest {
 
         ObjectiveAnswerCreateRequest request = new ObjectiveAnswerCreateRequest(1L, List.of(1001L, 1999L), "직접 입력");
 
+        handler.validate(request, context(objective));
         Answer answer = handler.build(10L, request, context(objective));
 
         assertThat(answer.getQuestionType()).isEqualTo(QuestionType.OBJECTIVE);
@@ -48,7 +49,7 @@ class ObjectiveAnswerCreateHandlerTest {
 
         ObjectiveAnswerCreateRequest request = new ObjectiveAnswerCreateRequest(1L, List.of(1001L), "직접 입력");
 
-        assertThatThrownBy(() -> handler.build(10L, request, context(objective)))
+        assertThatThrownBy(() -> handler.validate(request, context(objective)))
                 .isInstanceOf(BaseException.class)
                 .extracting(ex -> ((BaseException) ex).getErrorCode())
                 .isEqualTo(BaseErrorCode.ANSWER_004);
@@ -62,7 +63,7 @@ class ObjectiveAnswerCreateHandlerTest {
 
         ObjectiveAnswerCreateRequest request = new ObjectiveAnswerCreateRequest(1L, List.of(1999L), null);
 
-        assertThatThrownBy(() -> handler.build(10L, request, context(objective)))
+        assertThatThrownBy(() -> handler.validate(request, context(objective)))
                 .isInstanceOf(BaseException.class)
                 .extracting(ex -> ((BaseException) ex).getErrorCode())
                 .isEqualTo(BaseErrorCode.ANSWER_004);


### PR DESCRIPTION
## 📍 요약
- Answer 생성 시 공통 검증과 질문 유형별 검증/생성 책임을 분리하고, 공통 검증에 필요한 질문 조회를 questionId, questionType projection으로 범위를 축소

## 🔗 관련 이슈
- Closes #130 

## 📌 변경 사항
- [ ] 기능
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->

- AnswerCreateHandler에 validate()와 build()의 책임을 분리하고, AnswerService가 공통 검증 → context 생성 → handler 검증 → answer 생성 순서로 흐르도록 설계
- 질문 유형별 answer handler에서 검증과 Answer 생성 로직을 분리
- AnswerService의 질문 조회를 엔티티 전체 조회에서 AnswerQuestionTypeView projection 조회로 변경하고, repository에 전용 조회 메서드 추가

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew test --tests server.MATE.domain.answer.service.handler.ObjectiveAnswerCreateHandlerTest --tests server.MATE.domain.answer.service.handler.FiveSecondAnswerCreateHandlerTest --tests server.MATE.integration.QuestionAnswerEndToEndIntegrationTest --tests server.MATE.integration.QuestionAnswerEndToEndFailureIntegrationTest --tests server.MATE.integration.ReportEndToEndIntegrationTest
