### PR TITLE
test: 응답과 리포트 E2E 통합 테스트 보완

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ dependencies {
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.awaitility:awaitility'
 	testRuntimeOnly 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	

--- a/src/main/java/server/MATE/MateApplication.java
+++ b/src/main/java/server/MATE/MateApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
+@EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
 @SpringBootApplication
 public class MateApplication {
 

--- a/src/main/java/server/MATE/domain/test/entity/Test.java
+++ b/src/main/java/server/MATE/domain/test/entity/Test.java
@@ -49,7 +49,7 @@ public class Test extends BaseEntity {
     private TestStatus testStatus;
 
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "varchar(20) default 'PENDING'")
+    @Column(nullable = false, length = 20)
     private ReportStatus reportStatus = ReportStatus.PENDING;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/server/MATE/global/config/JpaAuditingConfig.java
+++ b/src/main/java/server/MATE/global/config/JpaAuditingConfig.java
@@ -1,0 +1,18 @@
+package server.MATE.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Configuration
+public class JpaAuditingConfig {
+
+    @Bean(name = "auditingDateTimeProvider")
+    public DateTimeProvider auditingDateTimeProvider(Clock clock) {
+        return () -> Optional.of(LocalDateTime.now(clock));
+    }
+}

--- a/src/test/java/server/MATE/domain/report/service/ReportAggregationServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/ReportAggregationServiceTest.java
@@ -80,6 +80,23 @@ class ReportAggregationServiceTest {
     }
 
     @Test
+    void recover_일반_예외여도_완전한_리포트가_이미_존재하면_COMPLETED로_복구하고_기존_리포트를_반환한다() {
+        Report report1 = report(101L);
+        Report report2 = report(102L);
+
+        given(questionRepository.countByTestIdAndDeletedAtIsNull(TEST_ID)).willReturn(2L);
+        given(reportRepository.countByTestId(TEST_ID)).willReturn(2L);
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(reportRepository.findAllByTestId(TEST_ID)).willReturn(List.of(report1, report2));
+
+        List<Report> recovered = reportAggregationService.recover(
+                new RuntimeException("aggregate failed"), TEST_ID);
+
+        assertThat(recovered).containsExactly(report1, report2);
+        assertThat(test.getReportStatus()).isEqualTo(ReportStatus.COMPLETED);
+    }
+
+    @Test
     void recover_부분_생성된_리포트만_존재하면_FAILED로_복구하고_빈_리스트를_반환한다() {
         given(questionRepository.countByTestIdAndDeletedAtIsNull(TEST_ID)).willReturn(3L);
         given(reportRepository.countByTestId(TEST_ID)).willReturn(1L);

--- a/src/test/java/server/MATE/domain/report/service/ReportAggregationServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/ReportAggregationServiceTest.java
@@ -1,6 +1,7 @@
 package server.MATE.domain.report.service;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -63,7 +64,8 @@ class ReportAggregationServiceTest {
     }
 
     @Test
-    void recover_완전한_리포트가_이미_존재하면_COMPLETED로_복구하고_기존_리포트를_반환한다() {
+    @DisplayName("완전한 리포트가 이미 존재하면 COMPLETED로 복구하고 기존 리포트를 반환한다")
+    void recover_whenCompleteReportsAlreadyExist_returnsExistingReportsAndMarksCompleted() {
         Report report1 = report(101L);
         Report report2 = report(102L);
 
@@ -80,7 +82,8 @@ class ReportAggregationServiceTest {
     }
 
     @Test
-    void recover_일반_예외여도_완전한_리포트가_이미_존재하면_COMPLETED로_복구하고_기존_리포트를_반환한다() {
+    @DisplayName("일반 예외여도 완전한 리포트가 이미 존재하면 COMPLETED로 복구하고 기존 리포트를 반환한다")
+    void recover_whenGenericExceptionButReportsAreComplete_returnsExistingReportsAndMarksCompleted() {
         Report report1 = report(101L);
         Report report2 = report(102L);
 
@@ -97,7 +100,8 @@ class ReportAggregationServiceTest {
     }
 
     @Test
-    void recover_부분_생성된_리포트만_존재하면_FAILED로_복구하고_빈_리스트를_반환한다() {
+    @DisplayName("부분 생성된 리포트만 존재하면 FAILED로 복구하고 빈 리스트를 반환한다")
+    void recover_whenReportsArePartiallyCreated_returnsEmptyListAndMarksFailed() {
         given(questionRepository.countByTestIdAndDeletedAtIsNull(TEST_ID)).willReturn(3L);
         given(reportRepository.countByTestId(TEST_ID)).willReturn(1L);
         given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
@@ -110,7 +114,8 @@ class ReportAggregationServiceTest {
     }
 
     @Test
-    void recover_일반_예외이고_리포트가_없으면_FAILED로_복구하고_빈_리스트를_반환한다() {
+    @DisplayName("일반 예외이고 리포트가 없으면 FAILED로 복구하고 빈 리스트를 반환한다")
+    void recover_whenGenericExceptionAndNoReportsExist_returnsEmptyListAndMarksFailed() {
         given(questionRepository.countByTestIdAndDeletedAtIsNull(TEST_ID)).willReturn(2L);
         given(reportRepository.countByTestId(TEST_ID)).willReturn(0L);
         given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));

--- a/src/test/java/server/MATE/domain/report/service/ReportAggregationServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/ReportAggregationServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
+import server.MATE.domain.answer.repository.AnswerRepository;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.repository.QuestionRepository;
 import server.MATE.domain.report.entity.Report;
@@ -29,7 +30,7 @@ class ReportAggregationServiceTest {
     private QuestionRepository questionRepository;
 
     @Mock
-    private server.MATE.domain.answer.repository.AnswerRepository answerRepository;
+    private AnswerRepository answerRepository;
 
     @Mock
     private ReportRepository reportRepository;

--- a/src/test/java/server/MATE/domain/report/service/ReportAggregationServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/ReportAggregationServiceTest.java
@@ -1,0 +1,116 @@
+package server.MATE.domain.report.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.QuestionRepository;
+import server.MATE.domain.report.entity.Report;
+import server.MATE.domain.report.repository.ReportRepository;
+import server.MATE.domain.test.entity.ReportStatus;
+import server.MATE.domain.test.repository.TestRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ReportAggregationServiceTest {
+
+    @Mock
+    private QuestionRepository questionRepository;
+
+    @Mock
+    private server.MATE.domain.answer.repository.AnswerRepository answerRepository;
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @Mock
+    private TestRepository testRepository;
+
+    private ReportAggregationService reportAggregationService;
+
+    private server.MATE.domain.test.entity.Test test;
+    private final Long TEST_ID = 10L;
+
+    @BeforeEach
+    void setUp() {
+        reportAggregationService = new ReportAggregationService(
+                questionRepository,
+                answerRepository,
+                reportRepository,
+                testRepository,
+                List.of()
+        );
+
+        test = server.MATE.domain.test.entity.Test.builder()
+                .makerId(1L)
+                .title("테스트")
+                .description("설명")
+                .serviceName("서비스")
+                .serviceDescription("서비스 설명")
+                .imageKeys(List.of())
+                .build();
+        ReflectionTestUtils.setField(test, "id", TEST_ID);
+    }
+
+    @Test
+    void recover_완전한_리포트가_이미_존재하면_COMPLETED로_복구하고_기존_리포트를_반환한다() {
+        Report report1 = report(101L);
+        Report report2 = report(102L);
+
+        given(questionRepository.countByTestIdAndDeletedAtIsNull(TEST_ID)).willReturn(2L);
+        given(reportRepository.countByTestId(TEST_ID)).willReturn(2L);
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(reportRepository.findAllByTestId(TEST_ID)).willReturn(List.of(report1, report2));
+
+        List<Report> recovered = reportAggregationService.recover(
+                new DataIntegrityViolationException("duplicate key"), TEST_ID);
+
+        assertThat(recovered).containsExactly(report1, report2);
+        assertThat(test.getReportStatus()).isEqualTo(ReportStatus.COMPLETED);
+    }
+
+    @Test
+    void recover_부분_생성된_리포트만_존재하면_FAILED로_복구하고_빈_리스트를_반환한다() {
+        given(questionRepository.countByTestIdAndDeletedAtIsNull(TEST_ID)).willReturn(3L);
+        given(reportRepository.countByTestId(TEST_ID)).willReturn(1L);
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+
+        List<Report> recovered = reportAggregationService.recover(
+                new DataIntegrityViolationException("duplicate key"), TEST_ID);
+
+        assertThat(recovered).isEmpty();
+        assertThat(test.getReportStatus()).isEqualTo(ReportStatus.FAILED);
+    }
+
+    @Test
+    void recover_일반_예외이고_리포트가_없으면_FAILED로_복구하고_빈_리스트를_반환한다() {
+        given(questionRepository.countByTestIdAndDeletedAtIsNull(TEST_ID)).willReturn(2L);
+        given(reportRepository.countByTestId(TEST_ID)).willReturn(0L);
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+
+        List<Report> recovered = reportAggregationService.recover(
+                new RuntimeException("aggregate failed"), TEST_ID);
+
+        assertThat(recovered).isEmpty();
+        assertThat(test.getReportStatus()).isEqualTo(ReportStatus.FAILED);
+    }
+
+    private Report report(Long questionId) {
+        return Report.builder()
+                .testId(TEST_ID)
+                .questionId(questionId)
+                .questionType(QuestionType.SUBJECTIVE)
+                .result(Map.of("texts", List.of("응답")))
+                .build();
+    }
+}

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -16,6 +16,7 @@ import server.MATE.domain.test.entity.ReportStatus;
 import server.MATE.domain.test.entity.TestStatus;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -965,6 +966,136 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
                 .path("reports").get(0).path("result").path("pathFrequency");
         assertThat(pathFrequency).hasSize(1);
         assertThat(pathFrequency.get(0).path("count").asInt()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("SUBJECTIVE와 FIVE_SECOND 주관식 리포트의 texts는 createdAt 오름차순으로 정렬된다")
+    void getReport_withSubjectiveTexts_returnsCreatedAtAscendingOrder() throws Exception {
+        TestActors actors = createActors();
+        String tester2Token = createAdditionalTester();
+        performCreateQuestion(actors.testId(), actors.makerToken(), """
+                {
+                  "questions": [
+                    { "type": "SUBJECTIVE", "title": "주관식 질문", "description": "설명", "imageKey": null },
+                    {
+                      "type": "FIVE_SECOND",
+                      "title": "5초 주관식",
+                      "description": "설명",
+                      "imageKey": "five-second-image",
+                      "imageRatio": "9:16",
+                      "isObjective": false,
+                      "isDuplicate": null,
+                      "minSelect": null,
+                      "maxSelect": null,
+                      "isOther": null,
+                      "options": []
+                    }
+                  ]
+                }
+                """);
+        JsonNode questions = getQuestionsArray(actors.testId(), actors.makerToken());
+        Long subjectiveQuestionId = questions.get(0).path("questionId").asLong();
+        Long fiveSecondQuestionId = questions.get(1).path("questionId").asLong();
+
+        submitAnswer(actors.testId(), actors.testerToken(), """
+                {
+                  "answers": [
+                    { "type": "SUBJECTIVE", "questionId": %d, "text": "빠른 주관식 응답" },
+                    { "type": "FIVE_SECOND", "questionId": %d, "text": "빠른 5초 응답" }
+                  ]
+                }
+                """.formatted(subjectiveQuestionId, fiveSecondQuestionId));
+        Thread.sleep(20L);
+        submitAnswer(actors.testId(), tester2Token, """
+                {
+                  "answers": [
+                    { "type": "SUBJECTIVE", "questionId": %d, "text": "늦은 주관식 응답" },
+                    { "type": "FIVE_SECOND", "questionId": %d, "text": "늦은 5초 응답" }
+                  ]
+                }
+                """.formatted(subjectiveQuestionId, fiveSecondQuestionId));
+
+        completeTest(actors.testId());
+
+        JsonNode reports = reportData(actors.testId(), actors.makerToken()).path("reports");
+        JsonNode subjectiveTexts = reports.get(0).path("result").path("texts");
+        JsonNode fiveSecondTexts = reports.get(1).path("result").path("texts");
+
+        assertThat(subjectiveTexts).hasSize(2);
+        assertThat(subjectiveTexts.get(0).asText()).isEqualTo("빠른 주관식 응답");
+        assertThat(subjectiveTexts.get(1).asText()).isEqualTo("늦은 주관식 응답");
+
+        assertThat(fiveSecondTexts).hasSize(2);
+        assertThat(fiveSecondTexts.get(0).asText()).isEqualTo("빠른 5초 응답");
+        assertThat(fiveSecondTexts.get(1).asText()).isEqualTo("늦은 5초 응답");
+    }
+
+    @Test
+    @DisplayName("TREE_TEST 리포트는 path와 pathLabels를 함께 조립한다")
+    void getReport_withTreeTestAnswers_returnsPathAndPathLabels() throws Exception {
+        TestActors actors = createActors();
+        createTreeTestQuestion(actors.testId(), actors.makerToken());
+        JsonNode questionNode = getSingleQuestion(actors.testId(), actors.makerToken());
+        Long questionId = questionNode.path("questionId").asLong();
+        Long rootNodeId = questionNode.path("features").get(0).path("treeTestId").asLong();
+        Long childNodeId = questionNode.path("features").get(0).path("children").get(0).path("treeTestId").asLong();
+        Long leafNodeId = questionNode.path("features").get(0).path("children").get(0)
+                .path("children").get(0).path("treeTestId").asLong();
+
+        submitAnswer(actors.testId(), actors.testerToken(), """
+                {
+                  "answers": [
+                    { "type": "TREE_TEST", "questionId": %d, "nodeId": %d, "path": [%d, %d, %d] }
+                  ]
+                }
+                """.formatted(questionId, leafNodeId, rootNodeId, childNodeId, leafNodeId));
+        completeTest(actors.testId());
+
+        JsonNode pathFrequency = reportData(actors.testId(), actors.makerToken())
+                .path("reports").get(0).path("result").path("pathFrequency");
+
+        assertThat(pathFrequency).hasSize(1);
+        assertThat(pathFrequency.get(0).path("path")).hasSize(3);
+        assertThat(pathFrequency.get(0).path("path").get(0).asLong()).isEqualTo(rootNodeId);
+        assertThat(pathFrequency.get(0).path("path").get(1).asLong()).isEqualTo(childNodeId);
+        assertThat(pathFrequency.get(0).path("path").get(2).asLong()).isEqualTo(leafNodeId);
+        assertThat(pathFrequency.get(0).path("pathLabels")).hasSize(3);
+        assertThat(pathFrequency.get(0).path("pathLabels").get(0).asText()).isEqualTo("마이페이지");
+        assertThat(pathFrequency.get(0).path("pathLabels").get(1).asText()).isEqualTo("설정");
+        assertThat(pathFrequency.get(0).path("pathLabels").get(2).asText()).isEqualTo("알림 설정");
+    }
+
+    @Test
+    @DisplayName("완전한 리포트가 이미 있으면 aggregate 재호출 시 상태와 결과를 그대로 유지한다")
+    void aggregate_whenReportAlreadyCompleted_keepsStatusAndExistingReports() throws Exception {
+        TestActors actors = createActors();
+        createSingleSubjectiveQuestion(actors.testId(), actors.makerToken());
+        Long questionId = getSingleQuestion(actors.testId(), actors.makerToken()).path("questionId").asLong();
+
+        submitAnswer(actors.testId(), actors.testerToken(), """
+                {
+                  "answers": [
+                    { "type": "SUBJECTIVE", "questionId": %d, "text": "기존 응답" }
+                  ]
+                }
+                """.formatted(questionId));
+        completeTest(actors.testId());
+
+        List<Report> existingReports = reportRepository.findAllByTestId(actors.testId());
+        JsonNode before = reportData(actors.testId(), actors.makerToken());
+
+        List<Report> reusedReports = reportAggregationService.aggregate(actors.testId());
+
+        server.MATE.domain.test.entity.Test updated = testRepository.findById(actors.testId()).orElseThrow();
+        JsonNode after = reportData(actors.testId(), actors.makerToken());
+
+        assertThat(updated.getReportStatus()).isEqualTo(ReportStatus.COMPLETED);
+        assertThat(reusedReports).hasSize(1);
+        assertThat(existingReports).hasSize(1);
+        assertThat(reusedReports.get(0).getId()).isEqualTo(existingReports.get(0).getId());
+        assertThat(reusedReports.get(0).getResult()).isEqualTo(existingReports.get(0).getResult());
+        assertThat(reportRepository.findAllByTestId(actors.testId())).hasSize(1);
+        assertThat(after).isEqualTo(before);
     }
 
     @Test

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.context.ActiveProfiles;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.report.entity.Report;
@@ -15,7 +14,6 @@ import server.MATE.domain.report.service.ReportAggregationService;
 import server.MATE.domain.test.entity.ReportStatus;
 import server.MATE.domain.test.entity.TestStatus;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -1253,43 +1251,6 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         assertThat(data.path("reports")).isEmpty();
     }
 
-    @Test
-    @DisplayName("soft delete 된 질문은 questionCount, questions, reports에서 모두 제외된다")
-    void getReport_whenQuestionSoftDeleted_excludesDeletedQuestionEverywhere() throws Exception {
-        TestActors actors = createActors();
-        createTwoSubjectiveQuestions(actors.testId(), actors.makerToken());
-        JsonNode questions = getQuestionsArray(actors.testId(), actors.makerToken());
-        Long activeQuestionId = questions.get(0).path("questionId").asLong();
-        Long deletedQuestionId = questions.get(1).path("questionId").asLong();
-
-        softDeleteQuestion(deletedQuestionId);
-
-        submitAnswer(actors.testId(), actors.testerToken(), """
-                {
-                  "answers": [
-                    { "type": "SUBJECTIVE", "questionId": %d, "text": "남은 질문 응답" }
-                  ]
-                }
-                """.formatted(activeQuestionId));
-        completeTest(actors.testId());
-
-        JsonNode data = reportData(actors.testId(), actors.makerToken());
-        JsonNode questionItems = data.path("questions");
-        JsonNode reports = data.path("reports");
-
-        assertThat(data.path("questionCount").asInt()).isEqualTo(1);
-        assertThat(questionItems).hasSize(1);
-        assertThat(questionItems.get(0).path("questionId").asLong()).isEqualTo(activeQuestionId);
-        assertThat(questionItems.get(0).path("sequence").asLong()).isEqualTo(1L);
-
-        assertThat(reports).hasSize(1);
-        assertThat(reports.get(0).path("questionId").asLong()).isEqualTo(activeQuestionId);
-        assertThat(reports.get(0).path("sequence").asLong()).isEqualTo(1L);
-        assertThat(reports.get(0).path("result").path("texts").get(0).asText()).isEqualTo("남은 질문 응답");
-        assertThat(reports).allSatisfy(report ->
-                assertThat(report.path("questionId").asLong()).isNotEqualTo(deletedQuestionId));
-    }
-
     private JsonNode reportData(Long testId, String token) throws Exception {
         var result = mockMvc.perform(
                         get("/api/v1/tests/{testId}/report", testId)
@@ -1342,12 +1303,6 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
             throw new RuntimeException(e);
         }
         testRepository.save(test);
-    }
-
-    private void softDeleteQuestion(Long questionId) {
-        server.MATE.domain.question.entity.Question question = questionRepository.findById(questionId).orElseThrow();
-        ReflectionTestUtils.setField(question, "deletedAt", LocalDateTime.now());
-        questionRepository.save(question);
     }
 
     private String createAdditionalTester() {

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -351,6 +351,114 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
     }
 
     @Test
+    @DisplayName("응답이 없는 SUBJECTIVE 질문의 리포트는 texts가 빈 리스트다")
+    void getReport_withNoSubjectiveAnswers_returnsEmptyTexts() throws Exception {
+        TestActors actors = createActors();
+        createSingleSubjectiveQuestion(actors.testId(), actors.makerToken());
+        completeTest(actors.testId());
+
+        JsonNode texts = reportData(actors.testId(), actors.makerToken())
+                .path("reports").get(0).path("result").path("texts");
+        assertThat(texts.isArray()).isTrue();
+        assertThat(texts).isEmpty();
+    }
+
+    @Test
+    @DisplayName("응답이 없는 FIVE_SECOND 주관식 질문의 리포트는 texts가 빈 리스트다")
+    void getReport_withNoFiveSecondSubjectiveAnswers_returnsEmptyTexts() throws Exception {
+        TestActors actors = createActors();
+        createFiveSecondSubjectiveQuestion(actors.testId(), actors.makerToken());
+        completeTest(actors.testId());
+
+        JsonNode texts = reportData(actors.testId(), actors.makerToken())
+                .path("reports").get(0).path("result").path("texts");
+        assertThat(texts.isArray()).isTrue();
+        assertThat(texts).isEmpty();
+    }
+
+    @Test
+    @DisplayName("응답이 없는 FIVE_SECOND 객관식 질문의 리포트는 모든 선택지 count와 ratio가 0이다")
+    void getReport_withNoFiveSecondObjectiveAnswers_returnsZeroCounts() throws Exception {
+        TestActors actors = createActors();
+        createFiveSecondObjectiveQuestion(actors.testId(), actors.makerToken(), false, null, null, false);
+        completeTest(actors.testId());
+
+        JsonNode options = reportData(actors.testId(), actors.makerToken())
+                .path("reports").get(0).path("result").path("options");
+        assertThat(options.isArray()).isTrue();
+        for (JsonNode option : options) {
+            assertThat(option.path("count").asInt()).isEqualTo(0);
+            assertThat(option.path("ratio").asDouble()).isEqualTo(0.0);
+        }
+    }
+
+    @Test
+    @DisplayName("응답이 없는 AB_TEST 질문의 리포트는 A/B count와 ratio가 모두 0이다")
+    void getReport_withNoAbTestAnswers_returnsZeroCountsAndRatios() throws Exception {
+        TestActors actors = createActors();
+        createAbTestQuestion(actors.testId(), actors.makerToken());
+        completeTest(actors.testId());
+
+        JsonNode result = reportData(actors.testId(), actors.makerToken())
+                .path("reports").get(0).path("result");
+        assertThat(result.path("A").path("count").asInt()).isEqualTo(0);
+        assertThat(result.path("A").path("ratio").asDouble()).isEqualTo(0.0);
+        assertThat(result.path("B").path("count").asInt()).isEqualTo(0);
+        assertThat(result.path("B").path("ratio").asDouble()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("응답이 없는 CARD_SORTING 질문의 리포트는 초기 구조를 유지하고 모든 count와 ratio가 0이다")
+    void getReport_withNoCardSortingAnswers_returnsInitialStructureWithZeroCounts() throws Exception {
+        TestActors actors = createActors();
+        createCardSortingQuestion(actors.testId(), actors.makerToken());
+        completeTest(actors.testId());
+
+        JsonNode result = reportData(actors.testId(), actors.makerToken())
+                .path("reports").get(0).path("result");
+
+        JsonNode byCategory = result.path("byCategory");
+        assertThat(byCategory).hasSize(2);
+        for (JsonNode category : byCategory) {
+            JsonNode cards = category.path("cards");
+            assertThat(cards).hasSize(4);
+            for (JsonNode card : cards) {
+                assertThat(card.path("count").asInt()).isEqualTo(0);
+                assertThat(card.path("ratio").asDouble()).isEqualTo(0.0);
+            }
+        }
+
+        JsonNode byCard = result.path("byCard");
+        assertThat(byCard).hasSize(4);
+        for (JsonNode card : byCard) {
+            JsonNode categories = card.path("categories");
+            assertThat(categories.path("쇼핑").asInt()).isEqualTo(0);
+            assertThat(categories.path("정보").asInt()).isEqualTo(0);
+        }
+    }
+
+    @Test
+    @DisplayName("응답이 없는 TREE_TEST 질문의 리포트는 pathFrequency가 빈 리스트고 leaf node count와 ratio가 0이다")
+    void getReport_withNoTreeTestAnswers_returnsEmptyPathFrequencyAndZeroLeafCounts() throws Exception {
+        TestActors actors = createActors();
+        createTreeTestQuestion(actors.testId(), actors.makerToken());
+        completeTest(actors.testId());
+
+        JsonNode result = reportData(actors.testId(), actors.makerToken())
+                .path("reports").get(0).path("result");
+
+        JsonNode nodeFrequency = result.path("nodeFrequency");
+        assertThat(nodeFrequency.isArray()).isTrue();
+        assertThat(nodeFrequency).hasSize(1);
+        assertThat(nodeFrequency.get(0).path("count").asInt()).isEqualTo(0);
+        assertThat(nodeFrequency.get(0).path("ratio").asDouble()).isEqualTo(0.0);
+
+        JsonNode pathFrequency = result.path("pathFrequency");
+        assertThat(pathFrequency.isArray()).isTrue();
+        assertThat(pathFrequency).isEmpty();
+    }
+
+    @Test
     @DisplayName("리포트의 questions 필드는 sequence 오름차순으로 질문 목록을 반환한다")
     void getReport_questions_returnedInSequenceOrder() throws Exception {
         TestActors actors = createActors();

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -4,8 +4,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.ActiveProfiles;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.report.entity.Report;
@@ -13,7 +17,11 @@ import server.MATE.domain.report.repository.ReportRepository;
 import server.MATE.domain.report.service.ReportAggregationService;
 import server.MATE.domain.test.entity.ReportStatus;
 import server.MATE.domain.test.entity.TestStatus;
+import server.MATE.support.time.MutableClock;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
@@ -24,13 +32,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
+@Import(ReportEndToEndIntegrationTest.TestClockConfig.class)
 class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
+
+    private static final Instant DEFAULT_TEST_INSTANT = Instant.parse("2026-01-01T00:00:00Z");
 
     @Autowired
     private ReportAggregationService reportAggregationService;
 
     @Autowired
     private ReportRepository reportRepository;
+
+    @Autowired
+    private MutableClock mutableClock;
 
     @Test
     @DisplayName("IN_PROGRESS 테스트의 리포트는 reports가 빈 리스트다")
@@ -969,6 +983,8 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
     @Test
     @DisplayName("SUBJECTIVE와 FIVE_SECOND 주관식 리포트의 texts는 createdAt 오름차순으로 정렬된다")
     void getReport_withSubjectiveTexts_returnsCreatedAtAscendingOrder() throws Exception {
+        mutableClock.setInstant(DEFAULT_TEST_INSTANT);
+
         TestActors actors = createActors();
         String tester2Token = createAdditionalTester();
         performCreateQuestion(actors.testId(), actors.makerToken(), """
@@ -1003,7 +1019,7 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
                   ]
                 }
                 """.formatted(subjectiveQuestionId, fiveSecondQuestionId));
-        Thread.sleep(20L);
+        mutableClock.advance(Duration.ofSeconds(1));
         submitAnswer(actors.testId(), tester2Token, """
                 {
                   "answers": [
@@ -1026,6 +1042,16 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         assertThat(fiveSecondTexts).hasSize(2);
         assertThat(fiveSecondTexts.get(0).asText()).isEqualTo("빠른 5초 응답");
         assertThat(fiveSecondTexts.get(1).asText()).isEqualTo("늦은 5초 응답");
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class TestClockConfig {
+
+        @Bean
+        @Primary
+        MutableClock mutableClock() {
+            return new MutableClock(DEFAULT_TEST_INSTANT, ZoneId.systemDefault());
+        }
     }
 
     @Test

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -435,6 +435,209 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
     }
 
     @Test
+    @DisplayName("전체 질문 유형이 혼재할 때 reports가 sequence 순서로 조립되고 각 유형별 핵심 집계 필드를 포함한다")
+    void getReport_withAllQuestionTypes_reportsAssembledInSequenceOrder() throws Exception {
+        TestActors actors = createActors();
+        performCreateQuestion(actors.testId(), actors.makerToken(), """
+                {
+                  "questions": [
+                    { "type": "SUBJECTIVE", "title": "주관식 질문", "description": "설명", "imageKey": null },
+                    {
+                      "type": "OBJECTIVE",
+                      "title": "객관식 질문",
+                      "description": "설명",
+                      "isDuplicate": false,
+                      "maxSelect": null,
+                      "minSelect": null,
+                      "isOther": false,
+                      "options": [
+                        { "content": "검색", "imageKey": null },
+                        { "content": "결제", "imageKey": null }
+                      ]
+                    },
+                    {
+                      "type": "FIVE_SECOND",
+                      "title": "5초 주관식",
+                      "description": "설명",
+                      "imageKey": "five-second-image",
+                      "imageRatio": "9:16",
+                      "isObjective": false,
+                      "isDuplicate": null,
+                      "minSelect": null,
+                      "maxSelect": null,
+                      "isOther": null,
+                      "options": []
+                    },
+                    {
+                      "type": "FIVE_SECOND",
+                      "title": "5초 객관식",
+                      "description": "설명",
+                      "imageKey": "five-second-image",
+                      "imageRatio": "9:16",
+                      "isObjective": true,
+                      "isDuplicate": false,
+                      "minSelect": null,
+                      "maxSelect": null,
+                      "isOther": false,
+                      "options": [
+                        { "content": "검색창" },
+                        { "content": "배너" }
+                      ]
+                    },
+                    {
+                      "type": "SCALE",
+                      "title": "척도 질문",
+                      "description": "설명",
+                      "imageKey": null,
+                      "minLabel": "낮음",
+                      "maxLabel": "높음",
+                      "range": 5
+                    },
+                    {
+                      "type": "AB_TEST",
+                      "title": "AB 질문",
+                      "description": "설명",
+                      "aImageKey": "a-image",
+                      "bImageKey": "b-image",
+                      "imageRatio": "9:16"
+                    },
+                    {
+                      "type": "CARD_SORTING",
+                      "title": "카드 소팅",
+                      "description": "설명",
+                      "cards": ["홈", "검색", "장바구니", "공지사항"],
+                      "categories": ["쇼핑", "정보"]
+                    },
+                    {
+                      "type": "TREE_TEST",
+                      "title": "트리 질문",
+                      "description": "설명",
+                      "features": [
+                        {
+                          "label": "마이페이지",
+                          "children": [
+                            {
+                              "label": "설정",
+                              "children": [
+                                {
+                                  "label": "알림 설정",
+                                  "children": []
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+        JsonNode questions = getQuestionsArray(actors.testId(), actors.makerToken());
+        assertThat(questions).hasSize(8);
+
+        JsonNode objectiveQuestion = questions.get(1);
+        Long objectiveOptionId = objectiveQuestion.path("options").get(0).path("objectiveOptionId").asLong();
+
+        JsonNode fiveSecondObjectiveQuestion = questions.get(3);
+        Long fiveSecondOptionId = fiveSecondObjectiveQuestion.path("options").get(0).path("fiveSecondOptionId").asLong();
+
+        JsonNode treeQuestion = questions.get(7);
+        Long treeQuestionId = treeQuestion.path("questionId").asLong();
+        Long rootNodeId = treeQuestion.path("features").get(0).path("treeTestId").asLong();
+        Long childNodeId = treeQuestion.path("features").get(0).path("children").get(0).path("treeTestId").asLong();
+        Long leafNodeId = treeQuestion.path("features").get(0).path("children").get(0)
+                .path("children").get(0).path("treeTestId").asLong();
+
+        submitAnswer(actors.testId(), actors.testerToken(), """
+                {
+                  "answers": [
+                    { "type": "SUBJECTIVE", "questionId": %d, "text": "주관식 응답" },
+                    { "type": "OBJECTIVE", "questionId": %d, "optionIds": [%d] },
+                    { "type": "FIVE_SECOND", "questionId": %d, "text": "5초 주관 응답" },
+                    { "type": "FIVE_SECOND", "questionId": %d, "optionIds": [%d] },
+                    { "type": "SCALE", "questionId": %d, "value": 4 },
+                    { "type": "AB_TEST", "questionId": %d, "selected": "A" },
+                    {
+                      "type": "CARD_SORTING",
+                      "questionId": %d,
+                      "groups": [
+                        { "category": "쇼핑", "cardNames": ["홈", "장바구니"] },
+                        { "category": "정보", "cardNames": ["검색", "공지사항"] }
+                      ]
+                    },
+                    { "type": "TREE_TEST", "questionId": %d, "nodeId": %d, "path": [%d, %d, %d] }
+                  ]
+                }
+                """.formatted(
+                questions.get(0).path("questionId").asLong(),
+                objectiveQuestion.path("questionId").asLong(),
+                objectiveOptionId,
+                questions.get(2).path("questionId").asLong(),
+                fiveSecondObjectiveQuestion.path("questionId").asLong(),
+                fiveSecondOptionId,
+                questions.get(4).path("questionId").asLong(),
+                questions.get(5).path("questionId").asLong(),
+                questions.get(6).path("questionId").asLong(),
+                treeQuestionId,
+                leafNodeId,
+                rootNodeId,
+                childNodeId,
+                leafNodeId
+        ));
+        completeTest(actors.testId());
+
+        JsonNode data = reportData(actors.testId(), actors.makerToken());
+        JsonNode reports = data.path("reports");
+
+        assertThat(data.path("questionCount").asInt()).isEqualTo(8);
+        assertThat(reports).hasSize(8);
+
+        for (int i = 0; i < reports.size(); i++) {
+            assertThat(reports.get(i).path("sequence").asInt()).isEqualTo(i + 1);
+        }
+
+        JsonNode subjectiveReport = reports.get(0);
+        assertThat(subjectiveReport.path("type").asText()).isEqualTo("SUBJECTIVE");
+        assertThat(subjectiveReport.path("result").path("texts").get(0).asText()).isEqualTo("주관식 응답");
+
+        JsonNode objectiveReport = reports.get(1);
+        assertThat(objectiveReport.path("type").asText()).isEqualTo("OBJECTIVE");
+        assertThat(objectiveReport.path("result").path("options").isArray()).isTrue();
+        assertThat(objectiveReport.path("result").path("options").get(0).path("count").asInt()).isEqualTo(1);
+
+        JsonNode fiveSecondSubjectiveReport = reports.get(2);
+        assertThat(fiveSecondSubjectiveReport.path("type").asText()).isEqualTo("FIVE_SECOND");
+        assertThat(fiveSecondSubjectiveReport.path("result").path("texts").get(0).asText()).isEqualTo("5초 주관 응답");
+
+        JsonNode fiveSecondObjectiveReport = reports.get(3);
+        assertThat(fiveSecondObjectiveReport.path("type").asText()).isEqualTo("FIVE_SECOND");
+        assertThat(fiveSecondObjectiveReport.path("result").path("options").isArray()).isTrue();
+        assertThat(fiveSecondObjectiveReport.path("result").path("options").get(0).path("count").asInt()).isEqualTo(1);
+
+        JsonNode scaleReport = reports.get(4);
+        assertThat(scaleReport.path("type").asText()).isEqualTo("SCALE");
+        assertThat(scaleReport.path("result").path("average").asDouble()).isEqualTo(4.0);
+        assertThat(scaleReport.path("result").path("distribution").isArray()).isTrue();
+
+        JsonNode abTestReport = reports.get(5);
+        assertThat(abTestReport.path("type").asText()).isEqualTo("AB_TEST");
+        assertThat(abTestReport.path("result").path("A").path("count").asInt()).isEqualTo(1);
+        assertThat(abTestReport.path("result").path("A").path("ratio").asDouble()).isEqualTo(1.0);
+
+        JsonNode cardSortingReport = reports.get(6);
+        assertThat(cardSortingReport.path("type").asText()).isEqualTo("CARD_SORTING");
+        assertThat(cardSortingReport.path("result").path("byCategory").isArray()).isTrue();
+        assertThat(cardSortingReport.path("result").path("byCard").isArray()).isTrue();
+
+        JsonNode treeTestReport = reports.get(7);
+        assertThat(treeTestReport.path("type").asText()).isEqualTo("TREE_TEST");
+        assertThat(treeTestReport.path("result").path("nodeFrequency").isArray()).isTrue();
+        assertThat(treeTestReport.path("result").path("pathFrequency").isArray()).isTrue();
+        assertThat(treeTestReport.path("result").path("pathFrequency").get(0).path("count").asInt()).isEqualTo(1);
+    }
+
+    @Test
     @DisplayName("goalPpl=1에서 응답 제출만으로 비동기 이벤트 경로를 통해 리포트가 완료된다")
     void getReport_whenGoalPplIsOne_reportCompletesViaAsyncEventFlow() throws Exception {
         TestActors actors = createActors();

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -435,8 +435,8 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
     }
 
     @Test
-    @DisplayName("pplCount가 goalPpl에 도달하면 테스트가 자동으로 COMPLETED 전환되고 백그라운드 집계가 시작된다")
-    void getReport_whenPplCountReachesGoalPpl_autoCompletesAndAggregationStarts() throws Exception {
+    @DisplayName("goalPpl=1에서 응답 제출만으로 비동기 이벤트 경로를 통해 리포트가 완료된다")
+    void getReport_whenGoalPplIsOne_reportCompletesViaAsyncEventFlow() throws Exception {
         TestActors actors = createActors();
         setGoalPpl(actors.testId(), 1);
         createSingleSubjectiveQuestion(actors.testId(), actors.makerToken());
@@ -450,9 +450,14 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
                 }
                 """.formatted(questionId));
 
-        JsonNode data = reportData(actors.testId(), actors.makerToken());
+        JsonNode data = awaitCompletedReportData(actors.testId(), actors.makerToken());
         assertThat(data.path("testStatus").asText()).isEqualTo("COMPLETED");
-        assertThat(data.path("reportStatus").asText()).isIn("IN_PROGRESS", "COMPLETED");
+        assertThat(data.path("reportStatus").asText()).isEqualTo("COMPLETED");
+        assertThat(data.path("reports")).hasSize(1);
+        assertThat(data.path("reports").get(0).path("type").asText()).isEqualTo("SUBJECTIVE");
+        assertThat(data.path("reports").get(0).path("result").path("texts")).hasSize(1);
+        assertThat(data.path("reports").get(0).path("result").path("texts").get(0).asText())
+                .isEqualTo("자동완료 응답");
     }
 
     @Test
@@ -733,6 +738,23 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         JsonNode body = parseBody(result);
         assertThat(body.path("success").asBoolean()).isTrue();
         return body.path("data");
+    }
+
+    private JsonNode awaitCompletedReportData(Long testId, String token) throws Exception {
+        long deadline = System.currentTimeMillis() + 5_000L;
+        JsonNode latest = null;
+
+        while (System.currentTimeMillis() < deadline) {
+            latest = reportData(testId, token);
+            if ("COMPLETED".equals(latest.path("reportStatus").asText())) {
+                return latest;
+            }
+            Thread.sleep(100L);
+        }
+
+        assertThat(latest).as("report should complete via async event flow").isNotNull();
+        assertThat(latest.path("reportStatus").asText()).isEqualTo("COMPLETED");
+        return latest;
     }
 
     private void completeTest(Long testId) {

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -1288,21 +1289,21 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         return body.path("data");
     }
 
-    private JsonNode awaitCompletedReportData(Long testId, String token) throws Exception {
-        long deadline = System.currentTimeMillis() + 5_000L;
-        JsonNode latest = null;
+    private JsonNode awaitCompletedReportData(Long testId, String token) {
+        return await("report should complete via async event flow")
+                .atMost(Duration.ofSeconds(5))
+                .pollInterval(Duration.ofMillis(100))
+                .ignoreExceptions()
+                .until(() -> reportDataUnchecked(testId, token),
+                        data -> "COMPLETED".equals(data.path("reportStatus").asText()));
+    }
 
-        while (System.currentTimeMillis() < deadline) {
-            latest = reportData(testId, token);
-            if ("COMPLETED".equals(latest.path("reportStatus").asText())) {
-                return latest;
-            }
-            Thread.sleep(100L);
+    private JsonNode reportDataUnchecked(Long testId, String token) {
+        try {
+            return reportData(testId, token);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
-
-        assertThat(latest).as("report should complete via async event flow").isNotNull();
-        assertThat(latest.path("reportStatus").asText()).isEqualTo("COMPLETED");
-        return latest;
     }
 
     private void completeTest(Long testId) {

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.context.ActiveProfiles;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.report.entity.Report;
@@ -14,6 +15,7 @@ import server.MATE.domain.report.service.ReportAggregationService;
 import server.MATE.domain.test.entity.ReportStatus;
 import server.MATE.domain.test.entity.TestStatus;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -932,6 +934,43 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         assertThat(data.path("reports")).isEmpty();
     }
 
+    @Test
+    @DisplayName("soft delete 된 질문은 questionCount, questions, reports에서 모두 제외된다")
+    void getReport_whenQuestionSoftDeleted_excludesDeletedQuestionEverywhere() throws Exception {
+        TestActors actors = createActors();
+        createTwoSubjectiveQuestions(actors.testId(), actors.makerToken());
+        JsonNode questions = getQuestionsArray(actors.testId(), actors.makerToken());
+        Long activeQuestionId = questions.get(0).path("questionId").asLong();
+        Long deletedQuestionId = questions.get(1).path("questionId").asLong();
+
+        softDeleteQuestion(deletedQuestionId);
+
+        submitAnswer(actors.testId(), actors.testerToken(), """
+                {
+                  "answers": [
+                    { "type": "SUBJECTIVE", "questionId": %d, "text": "남은 질문 응답" }
+                  ]
+                }
+                """.formatted(activeQuestionId));
+        completeTest(actors.testId());
+
+        JsonNode data = reportData(actors.testId(), actors.makerToken());
+        JsonNode questionItems = data.path("questions");
+        JsonNode reports = data.path("reports");
+
+        assertThat(data.path("questionCount").asInt()).isEqualTo(1);
+        assertThat(questionItems).hasSize(1);
+        assertThat(questionItems.get(0).path("questionId").asLong()).isEqualTo(activeQuestionId);
+        assertThat(questionItems.get(0).path("sequence").asLong()).isEqualTo(1L);
+
+        assertThat(reports).hasSize(1);
+        assertThat(reports.get(0).path("questionId").asLong()).isEqualTo(activeQuestionId);
+        assertThat(reports.get(0).path("sequence").asLong()).isEqualTo(1L);
+        assertThat(reports.get(0).path("result").path("texts").get(0).asText()).isEqualTo("남은 질문 응답");
+        assertThat(reports).allSatisfy(report ->
+                assertThat(report.path("questionId").asLong()).isNotEqualTo(deletedQuestionId));
+    }
+
     private JsonNode reportData(Long testId, String token) throws Exception {
         var result = mockMvc.perform(
                         get("/api/v1/tests/{testId}/report", testId)
@@ -984,6 +1023,12 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
             throw new RuntimeException(e);
         }
         testRepository.save(test);
+    }
+
+    private void softDeleteQuestion(Long questionId) {
+        server.MATE.domain.question.entity.Question question = questionRepository.findById(questionId).orElseThrow();
+        ReflectionTestUtils.setField(question, "deletedAt", LocalDateTime.now());
+        questionRepository.save(question);
     }
 
     private String createAdditionalTester() {

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -857,6 +857,86 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
     }
 
     @Test
+    @DisplayName("CARD_SORTING byCategory.cards는 count 내림차순으로 정렬되고 동점 rank와 ratio를 유지한다")
+    void getReport_withCardSortingAnswers_byCategoryCardsSortedWithTieRankAndRatio() throws Exception {
+        TestActors actors = createActors();
+        String tester2Token = createAdditionalTester();
+        String tester3Token = createAdditionalTester();
+        createCardSortingQuestion(actors.testId(), actors.makerToken());
+        Long questionId = getSingleQuestion(actors.testId(), actors.makerToken()).path("questionId").asLong();
+
+        submitAnswer(actors.testId(), actors.testerToken(), """
+                {
+                  "answers": [{
+                    "type": "CARD_SORTING", "questionId": %d,
+                    "groups": [
+                      { "category": "쇼핑", "cardNames": ["홈", "검색", "장바구니"] },
+                      { "category": "정보", "cardNames": ["공지사항"] }
+                    ]
+                  }]
+                }
+                """.formatted(questionId));
+        submitAnswer(actors.testId(), tester2Token, """
+                {
+                  "answers": [{
+                    "type": "CARD_SORTING", "questionId": %d,
+                    "groups": [
+                      { "category": "쇼핑", "cardNames": ["홈", "장바구니", "공지사항"] },
+                      { "category": "정보", "cardNames": ["검색"] }
+                    ]
+                  }]
+                }
+                """.formatted(questionId));
+        submitAnswer(actors.testId(), tester3Token, """
+                {
+                  "answers": [{
+                    "type": "CARD_SORTING", "questionId": %d,
+                    "groups": [
+                      { "category": "쇼핑", "cardNames": ["홈", "검색", "공지사항"] },
+                      { "category": "정보", "cardNames": ["장바구니"] }
+                    ]
+                  }]
+                }
+                """.formatted(questionId));
+        completeTest(actors.testId());
+
+        JsonNode byCategory = reportData(actors.testId(), actors.makerToken())
+                .path("reports").get(0).path("result").path("byCategory");
+
+        JsonNode shopping = null;
+        for (JsonNode category : byCategory) {
+            if ("쇼핑".equals(category.path("category").asText())) {
+                shopping = category;
+                break;
+            }
+        }
+
+        assertThat(shopping).isNotNull();
+        JsonNode cards = shopping.path("cards");
+        assertThat(cards).hasSize(4);
+
+        assertThat(cards.get(0).path("cardName").asText()).isEqualTo("홈");
+        assertThat(cards.get(0).path("rank").asInt()).isEqualTo(1);
+        assertThat(cards.get(0).path("count").asInt()).isEqualTo(3);
+        assertThat(cards.get(0).path("ratio").asDouble()).isEqualTo(1.0);
+
+        assertThat(cards.get(1).path("cardName").asText()).isEqualTo("검색");
+        assertThat(cards.get(1).path("rank").asInt()).isEqualTo(2);
+        assertThat(cards.get(1).path("count").asInt()).isEqualTo(2);
+        assertThat(cards.get(1).path("ratio").asDouble()).isEqualTo(0.667);
+
+        assertThat(cards.get(2).path("cardName").asText()).isEqualTo("장바구니");
+        assertThat(cards.get(2).path("rank").asInt()).isEqualTo(2);
+        assertThat(cards.get(2).path("count").asInt()).isEqualTo(2);
+        assertThat(cards.get(2).path("ratio").asDouble()).isEqualTo(0.667);
+
+        assertThat(cards.get(3).path("cardName").asText()).isEqualTo("공지사항");
+        assertThat(cards.get(3).path("rank").asInt()).isEqualTo(2);
+        assertThat(cards.get(3).path("count").asInt()).isEqualTo(2);
+        assertThat(cards.get(3).path("ratio").asDouble()).isEqualTo(0.667);
+    }
+
+    @Test
     @DisplayName("TREE_TEST에서 동일 경로를 여러 참여자가 선택하면 pathFrequency count가 누적된다")
     void getReport_withSamePathSelectedByMultipleParticipants_pathFrequencyAccumulates() throws Exception {
         TestActors actors = createActors();

--- a/src/test/java/server/MATE/support/time/MutableClock.java
+++ b/src/test/java/server/MATE/support/time/MutableClock.java
@@ -1,0 +1,40 @@
+package server.MATE.support.time;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public class MutableClock extends Clock {
+
+    private Instant instant;
+    private final ZoneId zone;
+
+    public MutableClock(Instant instant, ZoneId zone) {
+        this.instant = instant;
+        this.zone = zone;
+    }
+
+    @Override
+    public ZoneId getZone() {
+        return zone;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+        return new MutableClock(instant, zone);
+    }
+
+    @Override
+    public Instant instant() {
+        return instant;
+    }
+
+    public void setInstant(Instant instant) {
+        this.instant = instant;
+    }
+
+    public void advance(Duration duration) {
+        this.instant = this.instant.plus(duration);
+    }
+}


### PR DESCRIPTION
## 📍 요약
- 리포트 비동기 집계, 전체 유형 집계, 복구, 빈 응답, Card Sorting 규칙, 정렬, 재집계 안정성 테스트를 추가

## 🔗 관련 이슈
- Closes #132

## 📌 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- 비동기 이벤트 기반 리포트 완료 E2E, 전체 질문 유형 혼합 리포트 E2E, recover() 경로 검증 테스트를 추가했습니다.
- 빈 응답 분기, Card Sorting 정렬/동점 rank/ratio, 텍스트 정렬, TREE_TEST 경로 조립, 재집계 idempotency 검증을 추가하고 질문 삭제 정책에 맞게 관련 계획 문서를 정리했습니다.

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew test --tests server.MATE.integration.ReportEndToEndIntegrationTest --tests server.MATE.domain.report.service.ReportAggregationServiceTest
