### PR TITLE
feat: 테스트 이미지 응답 URL 제공, Azure 이중 컨테이너 분리 및 파일 크기 제한

### DIFF
--- a/deploy/apps/mate/externalsecret-mate-env.yaml
+++ b/deploy/apps/mate/externalsecret-mate-env.yaml
@@ -32,9 +32,12 @@ spec:
     - secretKey: AZURE_CONNECTION
       remoteRef:
         key: azure-storage-connection-string
-    - secretKey: AZURE_CONTAINER_NAME
+    - secretKey: AZURE_PUBLIC_CONTAINER_NAME
       remoteRef:
-        key: azure-container-name
+        key: azure-public-container-name
+    - secretKey: AZURE_PRIVATE_CONTAINER_NAME
+      remoteRef:
+        key: azure-private-container-name
     - secretKey: CORS_ALLOWED_ORIGINS
       remoteRef:
         key: cors-allowed-origins

--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -77,7 +77,7 @@ public class TestController {
                     현재 로그인한 사용자가 찜한 테스트 목록을 찜한 시각 최신순으로 조회합니다.
                     삭제되지 않았고 관리자 승인(`ACCEPTED`)이 완료된 테스트만 반환합니다.
 
-                    - **thumbnailKey**: 썸네일 이미지 키
+                    - **thumbnailUrl**: 썸네일 Public URL (만료 없음, 이미지 없으면 null)
                     - **title**: 테스트명
                     - **description**: 테스트 한 줄 소개
                     - **reward**: 보상 금액(머니)

--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -37,7 +37,7 @@ public class TestController {
                     전체 테스트 요약 목록을 최신순으로 조회합니다. 발견 탭 HM_01 57 화면에 해당하는 api 입니다.
                     테스트 등록 후 관리자 승인(`approvalStatus`)이 완료(`ACCEPTED`)되어야 조회됩니다.
 
-                    - **thumbnailKey**: 업로드된 이미지 키 목록 중 첫 번째, 없으면 null을 반환
+                    - **thumbnailUrl**: 업로드된 이미지 중 첫 번째의 Public URL, 없으면 null을 반환
                     - **description**: 테스트 한 줄 소개
                     - **reward**: 보상 금액(머니)
                     """
@@ -114,7 +114,7 @@ public class TestController {
 
             이미지 처리
             - `imageKeys`를 전달하면 기존 이미지 목록이 전체 교체됩니다.
-            - 기존 목록에서 제거된 이미지는 트랜잭션 커밋 후 S3에서 영구 삭제됩니다.
+            - 기존 목록에서 제거된 이미지는 트랜잭션 커밋 후 Azure Blob Storage에서 영구 삭제됩니다.
             - `imageKeys`를 `null`로 보내면 이미지는 변경되지 않습니다.
             """)
     @PatchMapping("/{testId}")

--- a/src/main/java/server/MATE/domain/test/dto/response/ImageInfo.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/ImageInfo.java
@@ -1,0 +1,13 @@
+package server.MATE.domain.test.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "이미지 키와 렌더링용 URL 쌍")
+public record ImageInfo(
+        @Schema(description = "파일 키 (이미지 수정/삭제 요청 시 사용)", example = "media/uuid.jpg")
+        String imageKey,
+
+        @Schema(description = "이미지 렌더링용 URL (media/ 키는 Public URL, 그 외는 SAS URL로 30분 만료)", example = "https://…")
+        String imageUrl
+) {
+}

--- a/src/main/java/server/MATE/domain/test/dto/response/LikedTestSummaryResponse.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/LikedTestSummaryResponse.java
@@ -3,12 +3,11 @@ package server.MATE.domain.test.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import server.MATE.domain.test.entity.Test;
 
-import java.util.List;
 
 @Schema(description = "내가 찜한 테스트 목록 노출용 요약")
 public record LikedTestSummaryResponse(
-        @Schema(description = "첫 번째 이미지 키. 없으면 null")
-        String thumbnailKey,
+        @Schema(description = "썸네일 Public URL (만료 없음, 이미지 없으면 null)")
+        String thumbnailUrl,
         @Schema(description = "테스트명", example = "남이만든테스트1")
         String title,
         @Schema(description = "테스트 한 줄 소개")
@@ -16,11 +15,9 @@ public record LikedTestSummaryResponse(
         @Schema(description = "보상 금액(머니)", example = "600")
         Integer reward
 ) {
-    public static LikedTestSummaryResponse from(Test test) {
-        List<String> imageKeys = test.getImageKeys();
-        String thumbnailKey = (imageKeys == null || imageKeys.isEmpty()) ? null : imageKeys.getFirst();
+    public static LikedTestSummaryResponse from(Test test, String thumbnailUrl) {
         return new LikedTestSummaryResponse(
-                thumbnailKey,
+                thumbnailUrl,
                 test.getTitle(),
                 test.getDescription(),
                 test.getReward()

--- a/src/main/java/server/MATE/domain/test/dto/response/TestCreateResponse.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/TestCreateResponse.java
@@ -1,5 +1,6 @@
 package server.MATE.domain.test.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import server.MATE.domain.test.entity.*;
 
 import java.time.LocalDateTime;
@@ -13,14 +14,15 @@ public record TestCreateResponse(
         List<String> categories,
         String serviceName,
         String serviceDescription,
-        List<String> imageKeys,
+        @Schema(description = "이미지 키·URL 쌍 목록 (key: 수정 요청용, url: 렌더링용, 30분 만료)")
+        List<ImageInfo> images,
         TestStatus testStatus,
         ApprovalStatus approvalStatus,
         Integer goalPpl,
         Integer reward,
         LocalDateTime createdAt
 ) {
-    public static TestCreateResponse from(Test test) {
+    public static TestCreateResponse from(Test test, List<ImageInfo> images) {
         return new TestCreateResponse(
                 test.getId(),
                 test.getMakerId(),
@@ -32,7 +34,7 @@ public record TestCreateResponse(
                         .toList(),
                 test.getServiceName(),
                 test.getServiceDescription(),
-                test.getImageKeys(),
+                images,
                 test.getTestStatus(),
                 test.getApprovalStatus(),
                 test.getGoalPpl(),

--- a/src/main/java/server/MATE/domain/test/dto/response/TestDetailResponse.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/TestDetailResponse.java
@@ -1,5 +1,6 @@
 package server.MATE.domain.test.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import server.MATE.domain.test.entity.Category;
 import server.MATE.domain.test.entity.Test;
 import server.MATE.domain.test.entity.TestCategory;
@@ -11,24 +12,24 @@ public record TestDetailResponse(
         Long id,
         String title,
         List<String> categories,
-        List<String> imageKeys,
+        @Schema(description = "이미지 키·URL 쌍 목록 (key: 수정 요청용, url: 렌더링용, 30분 만료)")
+        List<ImageInfo> images,
         Integer reward,
         String description,
         String serviceName,
         String serviceDescription
 ) {
-    public static TestDetailResponse from(Test test) {
+    public static TestDetailResponse from(Test test, List<ImageInfo> images) {
         List<String> categoryCodes = test.getCategories().stream()
                 .filter(testCategory -> testCategory.getDeletedAt() == null)
                 .map(TestCategory::getCategory)
                 .map(Category::name)
                 .toList();
-        List<String> keys = List.copyOf(test.getImageKeys());
         return new TestDetailResponse(
                 test.getId(),
                 test.getTitle(),
                 categoryCodes,
-                keys,
+                images,
                 test.getReward(),
                 test.getDescription(),
                 test.getServiceName(),

--- a/src/main/java/server/MATE/domain/test/dto/response/TestSummaryResponse.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/TestSummaryResponse.java
@@ -9,8 +9,8 @@ import java.util.List;
 public record TestSummaryResponse(
         @Schema(description = "테스트 ID", example = "1")
         Long id,
-        /** 등록된 이미지 중 첫 번째 키. 없으면 null */
-        String thumbnailKey,
+        @Schema(description = "썸네일 Public URL (만료 없음, 이미지 없으면 null)")
+        String thumbnailUrl,
         String title,
         String description,
         Integer reward,
@@ -18,16 +18,14 @@ public record TestSummaryResponse(
         Boolean isLiked,
         List<String> categories
 ) {
-    public static TestSummaryResponse from(Test test, boolean isLiked) {
-        List<String> keys = test.getImageKeys();
-        String thumbnailKey = keys.isEmpty() ? null : keys.getFirst();
+    public static TestSummaryResponse from(Test test, boolean isLiked, String thumbnailUrl) {
         List<String> categories = test.getCategories().stream()
                 .filter(testCategory -> testCategory.getDeletedAt() == null)
                 .map(testCategory -> testCategory.getCategory().name())
                 .toList();
         return new TestSummaryResponse(
                 test.getId(),
-                thumbnailKey,
+                thumbnailUrl,
                 test.getTitle(),
                 test.getDescription(),
                 test.getReward(),

--- a/src/main/java/server/MATE/domain/test/dto/response/TestUpdateResponse.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/TestUpdateResponse.java
@@ -1,9 +1,9 @@
 package server.MATE.domain.test.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import server.MATE.domain.test.entity.*;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 public record TestUpdateResponse(
@@ -14,14 +14,15 @@ public record TestUpdateResponse(
         List<String> categories,
         String serviceName,
         String serviceDescription,
-        List<String> imageKeys,
+        @Schema(description = "이미지 키·URL 쌍 목록 (key: 수정 요청용, url: 렌더링용, 30분 만료)")
+        List<ImageInfo> images,
         TestStatus testStatus,
         ApprovalStatus approvalStatus,
         Integer goalPpl,
         Integer reward,
         LocalDateTime updatedAt
 ) {
-    public static TestUpdateResponse from(Test test) {
+    public static TestUpdateResponse from(Test test, List<ImageInfo> images) {
         return new TestUpdateResponse(
                 test.getId(),
                 test.getMakerId(),
@@ -33,7 +34,7 @@ public record TestUpdateResponse(
                         .toList(),
                 test.getServiceName(),
                 test.getServiceDescription(),
-                new ArrayList<>(test.getImageKeys()),
+                images,
                 test.getTestStatus(),
                 test.getApprovalStatus(),
                 test.getGoalPpl(),

--- a/src/main/java/server/MATE/domain/test/entity/Test.java
+++ b/src/main/java/server/MATE/domain/test/entity/Test.java
@@ -49,7 +49,6 @@ public class Test extends BaseEntity {
     private TestStatus testStatus;
 
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "varchar(20) default 'PENDING'")
     private ReportStatus reportStatus = ReportStatus.PENDING;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.MATE.domain.test.dto.request.TestCreateRequest;
 import server.MATE.domain.test.dto.request.TestUpdateRequest;
+import server.MATE.domain.test.dto.response.ImageInfo;
 import server.MATE.domain.test.dto.response.TestCreateResponse;
 import server.MATE.domain.test.dto.response.TestDetailResponse;
 import server.MATE.domain.test.dto.response.TestLikeResponse;
@@ -18,6 +19,7 @@ import server.MATE.domain.test.repository.TestLikeRepository;
 import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
+import server.MATE.global.storage.FileStorageService;
 import server.MATE.global.storage.event.FileCleanupEvent;
 import server.MATE.global.storage.event.FileDeleteEvent;
 
@@ -35,6 +37,7 @@ public class TestService {
     private final TestRepository testRepository;
     private final TestLikeRepository testLikeRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final FileStorageService fileStorageService;
     private final Clock clock;
 
     @Transactional(readOnly = true)
@@ -43,7 +46,7 @@ public class TestService {
         Set<Long> likedTestIds = findLikedTestIds(userId, tests);
 
         return tests.stream()
-                .map(test -> TestSummaryResponse.from(test, likedTestIds.contains(test.getId())))
+                .map(test -> TestSummaryResponse.from(test, likedTestIds.contains(test.getId()), toThumbnailUrl(test.getImageKeys())))
                 .toList();
     }
 
@@ -51,7 +54,7 @@ public class TestService {
     public TestDetailResponse getTest(Long testId) {
         Test test = testRepository.findByIdAndApprovalStatusAndDeletedAtIsNull(testId, ApprovalStatus.ACCEPTED)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
-        return TestDetailResponse.from(test);
+        return TestDetailResponse.from(test, toImageInfos(test.getImageKeys()));
     }
 
     public TestCreateResponse createTest(TestCreateRequest request, Long makerId) {
@@ -70,7 +73,7 @@ public class TestService {
         eventPublisher.publishEvent(new FileCleanupEvent(imageKeys));
         testRepository.save(test);
 
-        return TestCreateResponse.from(test);
+        return TestCreateResponse.from(test, toImageInfos(test.getImageKeys()));
     }
 
     public TestUpdateResponse updateTest(Long testId, TestUpdateRequest request, Long makerId) {
@@ -111,7 +114,7 @@ public class TestService {
         );
 
         testRepository.saveAndFlush(test);
-        return TestUpdateResponse.from(test);
+        return TestUpdateResponse.from(test, toImageInfos(test.getImageKeys()));
     }
 
     public void deleteTest(Long testId, Long makerId) {
@@ -156,6 +159,16 @@ public class TestService {
                 });
 
         return new TestLikeResponse(test.getId(), false, test.getLikeCount());
+    }
+
+    private List<ImageInfo> toImageInfos(List<String> keys) {
+        return keys.stream()
+                .map(key -> new ImageInfo(key, fileStorageService.generateDownloadUrl(key)))
+                .toList();
+    }
+
+    private String toThumbnailUrl(List<String> keys) {
+        return keys.isEmpty() ? null : fileStorageService.generateDownloadUrl(keys.getFirst());
     }
 
     private Set<Long> findLikedTestIds(Long userId, List<Test> tests) {

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -60,7 +60,7 @@ public class TestService {
     public List<LikedTestSummaryResponse> listLikedTests(Long userId) {
         List<Test> tests = testRepository.findLikedTestsByUserId(userId, ApprovalStatus.ACCEPTED);
         return tests.stream()
-                .map(LikedTestSummaryResponse::from)
+                .map(test -> LikedTestSummaryResponse.from(test, toThumbnailUrl(test.getImageKeys())))
                 .toList();
     }
 

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -72,6 +72,7 @@ public enum BaseErrorCode implements ErrorCode {
     // File
     FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_001", "파일 업로드에 실패했습니다."),
     FILE_002(HttpStatus.BAD_REQUEST, "FILE_002", "지원하지 않는 파일 형식입니다. 허용되는 확장자를 확인해주세요."),
+    FILE_003(HttpStatus.BAD_REQUEST, "FILE_003", "파일 크기가 허용 범위를 초과했습니다. 최대 50MB까지 업로드할 수 있습니다."),
 
     ;
 

--- a/src/main/java/server/MATE/global/config/properties/AzureBlobProperties.java
+++ b/src/main/java/server/MATE/global/config/properties/AzureBlobProperties.java
@@ -11,7 +11,8 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "azure.storage")
 public class AzureBlobProperties {
     private String connectionString;
-    private String containerName;
+    private String publicContainerName;
+    private String privateContainerName;
     private int uploadSasExpiryMinutes = 10;
     private int downloadSasExpiryMinutes = 30;
 }

--- a/src/main/java/server/MATE/global/storage/AzureBlobFileStorageService.java
+++ b/src/main/java/server/MATE/global/storage/AzureBlobFileStorageService.java
@@ -6,11 +6,12 @@ import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.sas.BlobSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Service;
 import server.MATE.global.config.properties.AzureBlobProperties;
 import server.MATE.global.storage.condition.AzureStorageConfiguredCondition;
-import org.springframework.context.annotation.Conditional;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -21,12 +22,25 @@ import java.util.List;
 public class AzureBlobFileStorageService implements FileStorageService {
 
     private final AzureBlobProperties properties;
-    private volatile BlobContainerClient containerClient;
+    private BlobContainerClient publicContainerClient;
+    private BlobContainerClient privateContainerClient;
+
+    @PostConstruct
+    public void init() {
+        BlobServiceClient serviceClient = new BlobServiceClientBuilder()
+                .connectionString(properties.getConnectionString())
+                .buildClient();
+
+        publicContainerClient = serviceClient.getBlobContainerClient(properties.getPublicContainerName());
+        publicContainerClient.createIfNotExists();
+
+        privateContainerClient = serviceClient.getBlobContainerClient(properties.getPrivateContainerName());
+        privateContainerClient.createIfNotExists();
+    }
 
     @Override
     public String generatePresignedUrl(String key) {
-        BlobContainerClient containerClient = getContainerClient();
-        BlobClient blobClient = containerClient.getBlobClient(key);
+        BlobClient blobClient = getContainerClient(key).getBlobClient(key);
         BlobSasPermission permission = new BlobSasPermission()
                 .setCreatePermission(true)
                 .setWritePermission(true)
@@ -39,10 +53,11 @@ public class AzureBlobFileStorageService implements FileStorageService {
 
     @Override
     public String generateDownloadUrl(String key) {
-        BlobContainerClient containerClient = getContainerClient();
-        BlobClient blobClient = containerClient.getBlobClient(key);
-        BlobSasPermission permission = new BlobSasPermission()
-                .setReadPermission(true);
+        BlobClient blobClient = getContainerClient(key).getBlobClient(key);
+        if (isPublic(key)) {
+            return blobClient.getBlobUrl();
+        }
+        BlobSasPermission permission = new BlobSasPermission().setReadPermission(true);
         BlobServiceSasSignatureValues values = new BlobServiceSasSignatureValues(
                 OffsetDateTime.now().plusMinutes(properties.getDownloadSasExpiryMinutes()), permission);
         return blobClient.getBlobUrl() + "?" + blobClient.generateSas(values);
@@ -50,27 +65,15 @@ public class AzureBlobFileStorageService implements FileStorageService {
 
     @Override
     public void deleteFiles(List<String> keys) {
-        BlobContainerClient containerClient = getContainerClient();
-        keys.forEach(key -> containerClient.getBlobClient(key).deleteIfExists());
+        keys.forEach(key -> getContainerClient(key).getBlobClient(key).deleteIfExists());
     }
 
-    private BlobContainerClient getContainerClient() {
-        BlobContainerClient current = containerClient;
-        if (current != null) {
-            return current;
-        }
+    private BlobContainerClient getContainerClient(String key) {
+        return isPublic(key) ? publicContainerClient : privateContainerClient;
+    }
 
-        synchronized (this) {
-            if (containerClient == null) {
-                BlobServiceClient serviceClient = new BlobServiceClientBuilder()
-                        .connectionString(properties.getConnectionString())
-                        .buildClient();
-                BlobContainerClient created = serviceClient.getBlobContainerClient(properties.getContainerName());
-                created.createIfNotExists();
-                containerClient = created;
-            }
-            return containerClient;
-        }
+    private boolean isPublic(String key) {
+        return key.startsWith("media/");
     }
 
     private String resolveContentType(String key) {

--- a/src/main/java/server/MATE/global/storage/FileController.java
+++ b/src/main/java/server/MATE/global/storage/FileController.java
@@ -26,6 +26,8 @@ public class FileController {
 
     private final FileStorageService fileStorageService;
 
+    private static final long MAX_FILE_SIZE_BYTES = 50L * 1024 * 1024;
+
     @Operation(summary = "파일 업로드 URL 발급", description = """
             파일 업로드용 Presigned URL을 발급합니다. 클라이언트는 서버를 경유하지 않고 Azure Blob Storage에 직접 업로드합니다.
 
@@ -41,17 +43,25 @@ public class FileController {
 
             **[URL 유효시간]** 10분
 
+            **[파일 크기 제한]** 최대 50MB
+
             **[에러 코드]**
             | 코드 | HTTP | 설명 |
             |------|------|------|
-            | COMMON_004 | 400 | extension 파라미터 누락 |
+            | COMMON_004 | 400 | extension 또는 fileSizeBytes 파라미터 누락 |
             | FILE_002 | 400 | 지원하지 않는 파일 형식 |
+            | FILE_003 | 400 | 파일 크기 50MB 초과 |
             """)
     @PostMapping("/presigned-url/upload")
     public ResponseEntity<ApiResponse<UploadUrlResponse>> generateUploadUrl(
             @Parameter(description = "파일 확장자 (점 없이 입력, 예: jpg, pdf)", example = "jpg")
-            @RequestParam String extension
+            @RequestParam String extension,
+            @Parameter(description = "파일 크기 (bytes)", example = "1048576")
+            @RequestParam long fileSizeBytes
     ) {
+        if (fileSizeBytes > MAX_FILE_SIZE_BYTES) {
+            throw new BaseException(BaseErrorCode.FILE_003);
+        }
         String ext = extension.toLowerCase();
         String fileKey = switch (ext) {
             case "jpg", "jpeg", "png" -> "media/" + UUID.randomUUID() + "." + ext;

--- a/src/main/java/server/MATE/global/storage/NoopFileStorageService.java
+++ b/src/main/java/server/MATE/global/storage/NoopFileStorageService.java
@@ -20,7 +20,7 @@ public class NoopFileStorageService implements FileStorageService {
 
     @Override
     public String generateDownloadUrl(String key) {
-        throw new BaseException(BaseErrorCode.COMMON_999, STORAGE_NOT_CONFIGURED_MESSAGE);
+        return key;
     }
 
     @Override

--- a/src/main/java/server/MATE/global/storage/condition/AzureStorageConfiguredCondition.java
+++ b/src/main/java/server/MATE/global/storage/condition/AzureStorageConfiguredCondition.java
@@ -10,8 +10,11 @@ public class AzureStorageConfiguredCondition implements Condition {
     @Override
     public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
         String connectionString = context.getEnvironment().getProperty("azure.storage.connection-string");
-        String containerName = context.getEnvironment().getProperty("azure.storage.container-name");
+        String publicContainerName = context.getEnvironment().getProperty("azure.storage.public-container-name");
+        String privateContainerName = context.getEnvironment().getProperty("azure.storage.private-container-name");
 
-        return StringUtils.hasText(connectionString) && StringUtils.hasText(containerName);
+        return StringUtils.hasText(connectionString)
+                && StringUtils.hasText(publicContainerName)
+                && StringUtils.hasText(privateContainerName);
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -47,7 +47,8 @@ discord:
 azure:
   storage:
     connection-string: ${AZURE_CONNECTION:}
-    container-name: ${AZURE_CONTAINER_NAME:}
+    public-container-name: ${AZURE_PUBLIC_CONTAINER_NAME:}
+    private-container-name: ${AZURE_PRIVATE_CONTAINER_NAME:}
     upload-sas-expiry-minutes: ${AZURE_UPLOAD_SAS_EXPIRY_MINUTES:10}
     download-sas-expiry-minutes: ${AZURE_DOWNLOAD_SAS_EXPIRY_MINUTES:30}
 

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -145,7 +145,7 @@ class TestServiceTest {
         assertThat(responses.getFirst().title()).isEqualTo("기존 제목");
         assertThat(responses.getFirst().description()).isEqualTo("기존 소개");
         assertThat(responses.getFirst().reward()).isEqualTo(300);
-        assertThat(responses.getFirst().thumbnailKey()).isEqualTo("old-key-1");
+        assertThat(responses.getFirst().thumbnailUrl()).isEqualTo("https://example.com/url");
     }
 
     @Test

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -17,6 +17,7 @@ import server.MATE.domain.test.entity.Category;
 import server.MATE.domain.test.entity.TestLike;
 import server.MATE.domain.test.repository.TestLikeRepository;
 import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.global.storage.FileStorageService;
 import server.MATE.global.storage.event.FileCleanupEvent;
 import server.MATE.global.storage.event.FileDeleteEvent;
 
@@ -26,6 +27,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -40,6 +42,9 @@ class TestServiceTest {
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private FileStorageService fileStorageService;
 
     @Mock
     private Clock clock;
@@ -63,6 +68,7 @@ class TestServiceTest {
                 .build();
         ReflectionTestUtils.setField(test, "id", TEST_ID);
         test.addCategories(List.of(Category.FOOD));
+        lenient().when(fileStorageService.generateDownloadUrl(anyString())).thenReturn("https://example.com/url");
     }
 
     @Test


### PR DESCRIPTION
  ## 📍 요약
  - 테스트 이미지 응답을 key에서 {imageKey, imageUrl} 쌍으로 변경하고, Azure 컨테이너를 Public/Private으로 분리하여 이미지는 고정 URL로, 리포트는 SAS URL로 서빙. 파일 업로드 크기 50MB 제한 추가.
  
  ## 🔗 관련 이슈
  - Closes #124
  - Closes #123
  
  ## 📌 변경 사항
  - [x] 기능 
  
  ## ✅ 작업 내용
  - ImageInfo 레코드 추가 (imageKey: 수정 요청용, imageUrl: 렌더링용)
  - TestSummaryResponse: thumbnailKey → thumbnailUrl
  - TestDetailResponse/CreateResponse/UpdateResponse: imageKeys → images: List<ImageInfo>
  - Azure Blob Storage를 mate-public(이미지, Public URL)과 mate-private(리포트, SAS URL)으로 분리
  - AzureBlobFileStorageService @PostConstruct로 Eager 초기화 (DCL 제거)
  - 파일 업로드 URL 발급 시 fileSizeBytes 파라미터 추가, 50MB 초과 시 FILE_003 에러 반환
  
  ## 테스트
  - [x] 로컬 테스트 완료
  - 테스트 방법:
    - ./gradlew test