### PR TITLE
fix: 내 테스트 조회 시 id, 개수 필드 추가

### DIFF
--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -53,22 +53,23 @@ public class TestController {
     }
 
     @Operation(
-            summary = "내가 생성한 테스트 목록 조회",
+            summary = "내 테스트 목록 조회",
             description = """
-                    현재 로그인한 사용자가 생성한 테스트 목록을 최신순으로 조회합니다.
+                    현재 로그인한 사용자가 생성한 테스트 목록을 최신순으로 조회합니다. 테스트 탭 MKTT_01 화면에 해당하는 api 입니다.<br>
                     승인 상태와 관계없이 삭제되지 않은 테스트를 모두 반환합니다.
-
+                    
+                    - **testCount**: 테스트 개수
                     - **testStatus**: `IN_PROGRESS`(진행 중), `COMPLETED`(완료)
                     - **title**: 테스트 제목
                     - **pplCount**: 현재 참여 인원
                     """
     )
-    @GetMapping("/mine")
-    public ResponseEntity<ApiResponse<List<MyTestSummaryResponse>>> listMyTests(
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<MyTestSummaryResponse>> listMyTests(
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser
     ) {
-        List<MyTestSummaryResponse> data = testService.listMyTests(authenticatedUser.getId());
-        return ResponseEntity.ok(ApiResponse.ok("내가 생성한 테스트 목록을 조회했습니다.", data));
+        MyTestSummaryResponse data = testService.listMyTests(authenticatedUser.getId());
+        return ResponseEntity.ok(ApiResponse.ok("내 테스트 목록을 조회했습니다.", data));
     }
 
     @Operation(

--- a/src/main/java/server/MATE/domain/test/dto/response/MyTestSummaryItem.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/MyTestSummaryItem.java
@@ -6,6 +6,8 @@ import server.MATE.domain.test.entity.TestStatus;
 
 @Schema(description = "내가 생성한 테스트 목록 노출용 요약 항목")
 public record MyTestSummaryItem(
+        @Schema(description = "테스트 ID", example = "1")
+        Long id,
         @Schema(description = "진행 상태", example = "IN_PROGRESS")
         TestStatus testStatus,
         @Schema(description = "테스트 제목", example = "승인된테스트1")
@@ -15,6 +17,7 @@ public record MyTestSummaryItem(
 ) {
     public static MyTestSummaryItem from(Test test) {
         return new MyTestSummaryItem(
+                test.getId(),
                 test.getTestStatus(),
                 test.getTitle(),
                 test.getPplCount()

--- a/src/main/java/server/MATE/domain/test/dto/response/MyTestSummaryItem.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/MyTestSummaryItem.java
@@ -1,0 +1,23 @@
+package server.MATE.domain.test.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.entity.TestStatus;
+
+@Schema(description = "내가 생성한 테스트 목록 노출용 요약 항목")
+public record MyTestSummaryItem(
+        @Schema(description = "진행 상태", example = "IN_PROGRESS")
+        TestStatus testStatus,
+        @Schema(description = "테스트 제목", example = "승인된테스트1")
+        String title,
+        @Schema(description = "현재 참여 인원", example = "12")
+        Long pplCount
+) {
+    public static MyTestSummaryItem from(Test test) {
+        return new MyTestSummaryItem(
+                test.getTestStatus(),
+                test.getTitle(),
+                test.getPplCount()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/test/dto/response/MyTestSummaryResponse.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/MyTestSummaryResponse.java
@@ -1,23 +1,17 @@
 package server.MATE.domain.test.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import server.MATE.domain.test.entity.Test;
-import server.MATE.domain.test.entity.TestStatus;
 
-@Schema(description = "내가 생성한 테스트 목록 노출용 요약")
+import java.util.List;
+
+@Schema(description = "내가 생성한 테스트 목록 조회 응답")
 public record MyTestSummaryResponse(
-        @Schema(description = "진행 상태", example = "IN_PROGRESS")
-        TestStatus testStatus,
-        @Schema(description = "테스트 제목", example = "승인된테스트1")
-        String title,
-        @Schema(description = "현재 참여 인원", example = "12")
-        Long pplCount
+        @Schema(description = "테스트 개수", example = "3")
+        int testCount,
+        @Schema(description = "테스트 목록")
+        List<MyTestSummaryItem> tests
 ) {
-    public static MyTestSummaryResponse from(Test test) {
-        return new MyTestSummaryResponse(
-                test.getTestStatus(),
-                test.getTitle(),
-                test.getPplCount()
-        );
+    public static MyTestSummaryResponse from(List<MyTestSummaryItem> tests) {
+        return new MyTestSummaryResponse(tests.size(), tests);
     }
 }

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -11,6 +11,7 @@ import server.MATE.domain.test.dto.response.TestCreateResponse;
 import server.MATE.domain.test.dto.response.TestDetailResponse;
 import server.MATE.domain.test.dto.response.TestLikeResponse;
 import server.MATE.domain.test.dto.response.LikedTestSummaryResponse;
+import server.MATE.domain.test.dto.response.MyTestSummaryItem;
 import server.MATE.domain.test.dto.response.MyTestSummaryResponse;
 import server.MATE.domain.test.dto.response.TestSummaryResponse;
 import server.MATE.domain.test.dto.response.TestUpdateResponse;
@@ -49,11 +50,12 @@ public class TestService {
     }
 
     @Transactional(readOnly = true)
-    public List<MyTestSummaryResponse> listMyTests(Long makerId) {
+    public MyTestSummaryResponse listMyTests(Long makerId) {
         List<Test> tests = testRepository.findAllByMakerIdAndDeletedAtIsNullOrderByCreatedAtDesc(makerId);
-        return tests.stream()
-                .map(MyTestSummaryResponse::from)
+        List<MyTestSummaryItem> items = tests.stream()
+                .map(MyTestSummaryItem::from)
                 .toList();
+        return MyTestSummaryResponse.from(items);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -126,12 +126,13 @@ class TestServiceTest {
         given(testRepository.findAllByMakerIdAndDeletedAtIsNullOrderByCreatedAtDesc(MAKER_ID))
                 .willReturn(List.of(myTest));
 
-        List<MyTestSummaryResponse> responses = testService.listMyTests(MAKER_ID);
+        MyTestSummaryResponse response = testService.listMyTests(MAKER_ID);
 
-        assertThat(responses).hasSize(1);
-        assertThat(responses.getFirst().title()).isEqualTo("내 테스트");
-        assertThat(responses.getFirst().testStatus()).isEqualTo(TestStatus.IN_PROGRESS);
-        assertThat(responses.getFirst().pplCount()).isZero();
+        assertThat(response.testCount()).isEqualTo(1);
+        assertThat(response.tests()).hasSize(1);
+        assertThat(response.tests().getFirst().title()).isEqualTo("내 테스트");
+        assertThat(response.tests().getFirst().testStatus()).isEqualTo(TestStatus.IN_PROGRESS);
+        assertThat(response.tests().getFirst().pplCount()).isZero();
     }
 
     @Test

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -130,6 +130,7 @@ class TestServiceTest {
 
         assertThat(response.testCount()).isEqualTo(1);
         assertThat(response.tests()).hasSize(1);
+        assertThat(response.tests().getFirst().id()).isEqualTo(TEST_ID);
         assertThat(response.tests().getFirst().title()).isEqualTo("내 테스트");
         assertThat(response.tests().getFirst().testStatus()).isEqualTo(TestStatus.IN_PROGRESS);
         assertThat(response.tests().getFirst().pplCount()).isZero();


### PR DESCRIPTION
## 📍 요약
- 내 테스트 조회시 테스트 id, 개수를 포함하도록 DTO 구조를 수정함

## 🔗 관련 이슈
- Closes #136 

## 📌 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [x] 문서
- [ ] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- 기존 MyTestSummaryResponse를 MyTestSummaryItem으로 수정
- MyTestSummaryResponse를 목록 래퍼 응답으로 변경하고 testCount, tests 필드 추가

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew test --tests server.MATE.domain.test.service.TestServiceTest
