### PR TITLE
chore: 질문·리포트 엔티티 BaseEntity 상속 추가

### DIFF
--- a/src/main/java/server/MATE/domain/question/entity/CardSorting.java
+++ b/src/main/java/server/MATE/domain/question/entity/CardSorting.java
@@ -11,12 +11,13 @@ import org.hibernate.type.SqlTypes;
 
 import java.util.ArrayList;
 import java.util.List;
+import server.MATE.global.common.entity.BaseEntity;
 
 @Getter
 @Entity
 @Table(name = "card_sorting")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CardSorting {
+public class CardSorting extends BaseEntity {
 
     @Id
     private Long id;

--- a/src/main/java/server/MATE/domain/question/entity/FiveSecond.java
+++ b/src/main/java/server/MATE/domain/question/entity/FiveSecond.java
@@ -8,12 +8,13 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import server.MATE.global.common.entity.BaseEntity;
 
 @Getter
 @Entity
 @Table(name = "five_second")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FiveSecond {
+public class FiveSecond extends BaseEntity {
 
     @Id
     private Long id;

--- a/src/main/java/server/MATE/domain/question/entity/FiveSecondOption.java
+++ b/src/main/java/server/MATE/domain/question/entity/FiveSecondOption.java
@@ -5,12 +5,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import server.MATE.global.common.entity.BaseEntity;
 
 @Getter
 @Entity
 @Table(name = "five_second_option")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FiveSecondOption {
+public class FiveSecondOption extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/server/MATE/domain/question/entity/Objective.java
+++ b/src/main/java/server/MATE/domain/question/entity/Objective.java
@@ -8,12 +8,13 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import server.MATE.global.common.entity.BaseEntity;
 
 @Getter
 @Entity
 @Table(name = "objective")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Objective {
+public class Objective extends BaseEntity {
 
     @Id
     private Long id;

--- a/src/main/java/server/MATE/domain/question/entity/ObjectiveOption.java
+++ b/src/main/java/server/MATE/domain/question/entity/ObjectiveOption.java
@@ -5,12 +5,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import server.MATE.global.common.entity.BaseEntity;
 
 @Getter
 @Entity
 @Table(name = "objective_option")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ObjectiveOption {
+public class ObjectiveOption extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/server/MATE/domain/question/entity/Subjective.java
+++ b/src/main/java/server/MATE/domain/question/entity/Subjective.java
@@ -5,12 +5,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import server.MATE.global.common.entity.BaseEntity;
 
 @Getter
 @Entity
 @Table(name = "subjective")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Subjective {
+public class Subjective extends BaseEntity {
 
     @Id
     private Long id;

--- a/src/main/java/server/MATE/domain/question/entity/TreeTest.java
+++ b/src/main/java/server/MATE/domain/question/entity/TreeTest.java
@@ -7,12 +7,13 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import server.MATE.global.common.entity.BaseEntity;
 
 @Getter
 @Entity
 @Table(name = "tree_test")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class TreeTest {
+public class TreeTest extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/server/MATE/domain/report/entity/Report.java
+++ b/src/main/java/server/MATE/domain/report/entity/Report.java
@@ -10,13 +10,14 @@ import org.hibernate.type.SqlTypes;
 import server.MATE.domain.question.entity.QuestionType;
 
 import java.util.Map;
+import server.MATE.global.common.entity.BaseEntity;
 
 @Getter
 @Entity
 @Table(name = "report",
         uniqueConstraints = @UniqueConstraint(columnNames = {"test_id", "question_id"}))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Report {
+public class Report extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
  ## 📍 요약
  - BaseEntity를 상속받지 않은 8개 엔티티에 extends BaseEntity 추가
  
  ## 🔗 관련 이슈
  - Closes #139
  
  ## 📌 변경 사항
  - [ ] 기능
  - [ ] 버그 수정
  - [ ] 리팩토링
  - [ ] 문서
  - [ ] 테스트
  - [x] 기타
  
  ## ✅ 작업 내용
  - CardSorting, FiveSecond, FiveSecondOption, Objective, ObjectiveOption, Subjective, TreeTest, Report에 extends BaseEntity 추가
  
  ## 테스트
  - 로컬 테스트 완료
  - ./gradlew compileJava 통과 확인
  - 기존 테스트 코드 영향 없음 확인
  - ⚠️  dev/prod DB에 created_at, updated_at 컬럼 ALTER TABLE 필요
