### PR TITLE
feat: PDF 통계 파일 생성에 필요한 리포트 응답 필드 추가

### DIFF
--- a/src/main/java/server/MATE/domain/report/controller/ReportController.java
+++ b/src/main/java/server/MATE/domain/report/controller/ReportController.java
@@ -67,7 +67,7 @@ public class ReportController {
                             ),
                             @ExampleObject(
                                     name = "COMPLETED - SUBJECTIVE",
-                                    summary = "주관식 (SUBJECTIVE) — texts: 응답 텍스트 목록",
+                                    summary = "주관식 (SUBJECTIVE) — aiSummary: AI 3줄 요약, topAnswers: 많이 언급된 답변 최대 6개, texts: 전체 응답 텍스트 목록",
                                     value = """
                                             {
                                               "success": true,
@@ -88,6 +88,8 @@ public class ReportController {
                                                     "title": "서비스에서 불편한 점은?",
                                                     "type": "SUBJECTIVE",
                                                     "result": {
+                                                      "aiSummary": "AI 요약 준비 중입니다.",
+                                                      "topAnswers": ["로딩이 느립니다.", "버튼이 너무 작아요."],
                                                       "texts": [
                                                         "로딩이 느립니다.",
                                                         "버튼이 너무 작아요.",
@@ -102,7 +104,7 @@ public class ReportController {
                             ),
                             @ExampleObject(
                                     name = "COMPLETED - OBJECTIVE",
-                                    summary = "객관식 (OBJECTIVE) — options: 선택지별 count/ratio, otherTexts: 기타 응답 (isOther=true 시)",
+                                    summary = "객관식 (OBJECTIVE) — options: 선택지별 count/ratio, isOther=true 시 aiSummary/topAnswers/otherTexts 포함",
                                     value = """
                                             {
                                               "success": true,
@@ -128,6 +130,8 @@ public class ReportController {
                                                         { "optionId": 102, "content": "검색", "count": 3, "ratio": 0.3 },
                                                         { "optionId": 103, "content": "기타", "count": 1, "ratio": 0.1 }
                                                       ],
+                                                      "aiSummary": "AI 요약 준비 중입니다.",
+                                                      "topAnswers": ["알림 기능을 자주 씁니다."],
                                                       "otherTexts": ["알림 기능을 자주 씁니다."]
                                                     }
                                                   }
@@ -138,7 +142,7 @@ public class ReportController {
                             ),
                             @ExampleObject(
                                     name = "COMPLETED - FIVE_SECOND (주관식)",
-                                    summary = "5초 테스트 주관식 (FIVE_SECOND, isObjective=false) — texts: 응답 텍스트 목록",
+                                    summary = "5초 테스트 주관식 (FIVE_SECOND, isObjective=false) — aiSummary/topAnswers/texts 포함",
                                     value = """
                                             {
                                               "success": true,
@@ -159,6 +163,8 @@ public class ReportController {
                                                     "title": "화면에서 가장 먼저 눈에 띈 것은?",
                                                     "type": "FIVE_SECOND",
                                                     "result": {
+                                                      "aiSummary": "AI 요약 준비 중입니다.",
+                                                      "topAnswers": ["상단 배너가 눈에 들어왔어요."],
                                                       "texts": [
                                                         "상단 배너가 눈에 들어왔어요.",
                                                         "검색창이 먼저 보였습니다."
@@ -172,7 +178,7 @@ public class ReportController {
                             ),
                             @ExampleObject(
                                     name = "COMPLETED - FIVE_SECOND (객관식)",
-                                    summary = "5초 테스트 객관식 (FIVE_SECOND, isObjective=true) — options: 선택지별 count/ratio, otherTexts: 기타 응답 (isOther=true 시)",
+                                    summary = "5초 테스트 객관식 (FIVE_SECOND, isObjective=true) — options: 선택지별 count/ratio, isOther=true 시 aiSummary/topAnswers/otherTexts 포함",
                                     value = """
                                             {
                                               "success": true,
@@ -196,7 +202,10 @@ public class ReportController {
                                                       "options": [
                                                         { "optionId": 201, "content": "검색창", "count": 4, "ratio": 0.667 },
                                                         { "optionId": 202, "content": "배너", "count": 2, "ratio": 0.333 }
-                                                      ]
+                                                      ],
+                                                      "aiSummary": "AI 요약 준비 중입니다.",
+                                                      "topAnswers": ["하단 버튼이요"],
+                                                      "otherTexts": ["하단 버튼이요"]
                                                     }
                                                   }
                                                 ]
@@ -206,7 +215,7 @@ public class ReportController {
                             ),
                             @ExampleObject(
                                     name = "COMPLETED - SCALE",
-                                    summary = "척도 (SCALE) — average: 평균, distribution: 점수별 응답 수",
+                                    summary = "척도 (SCALE) — average: 평균, mostVoted: 최다 득표 점수, endValue: 양 끝 라벨, distribution: 점수별 응답 수",
                                     value = """
                                             {
                                               "success": true,
@@ -228,6 +237,11 @@ public class ReportController {
                                                     "type": "SCALE",
                                                     "result": {
                                                       "average": 3.8,
+                                                      "mostVoted": 4,
+                                                      "endValue": {
+                                                        "minLabel": "전혀 아니다",
+                                                        "maxLabel": "매우 그렇다"
+                                                      },
                                                       "distribution": [
                                                         { "score": 1, "count": 0 },
                                                         { "score": 2, "count": 1 },

--- a/src/main/java/server/MATE/domain/report/service/handler/FiveSecondReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/FiveSecondReportHandler.java
@@ -77,6 +77,8 @@ public class FiveSecondReportHandler implements ReportHandler {
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("options", options);
         if (Boolean.TRUE.equals(fiveSecond.getIsOther())) {
+            result.put("aiSummary", "AI 요약 준비 중입니다.");
+            result.put("topAnswers", ReportHandlerUtils.topAnswers(otherTexts));
             result.put("otherTexts", otherTexts);
         }
         return result;
@@ -87,6 +89,10 @@ public class FiveSecondReportHandler implements ReportHandler {
                 .sorted(Comparator.comparing(Answer::getCreatedAt))
                 .map(a -> (String) a.getAnswer().get("text"))
                 .toList();
-        return Map.of("texts", texts);
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("aiSummary", "AI 요약 준비 중입니다.");
+        result.put("topAnswers", ReportHandlerUtils.topAnswers(texts));
+        result.put("texts", texts);
+        return result;
     }
 }

--- a/src/main/java/server/MATE/domain/report/service/handler/ObjectiveReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/ObjectiveReportHandler.java
@@ -75,6 +75,8 @@ public class ObjectiveReportHandler implements ReportHandler {
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("options", options);
         if (objective.isOther()) {
+            result.put("aiSummary", "AI 요약 준비 중입니다.");
+            result.put("topAnswers", ReportHandlerUtils.topAnswers(otherTexts));
             result.put("otherTexts", otherTexts);
         }
         return result;

--- a/src/main/java/server/MATE/domain/report/service/handler/ReportHandlerUtils.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/ReportHandlerUtils.java
@@ -3,6 +3,7 @@ package server.MATE.domain.report.service.handler;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 final class ReportHandlerUtils {
 
@@ -12,6 +13,18 @@ final class ReportHandlerUtils {
     static double toRatio(int count, int total) {
         if (total == 0) return 0.0;
         return Math.round(count * 1000.0 / total) / 1000.0;
+    }
+
+    // TODO: AI 연동 후 의미론적 유사도 기반 그룹핑으로 교체
+    static List<String> topAnswers(List<String> texts) {
+        return texts.stream()
+                .filter(t -> t != null && !t.isBlank())
+                .collect(Collectors.groupingBy(String::trim, Collectors.counting()))
+                .entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .limit(6)
+                .map(Map.Entry::getKey)
+                .toList();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/server/MATE/domain/report/service/handler/ScaleReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/ScaleReportHandler.java
@@ -60,12 +60,24 @@ public class ScaleReportHandler implements ReportHandler {
         double average = total == 0 ? 0.0 : Math.round(sum * 10.0 / total) / 10.0;
 
         List<Map<String, Object>> distribution = new ArrayList<>();
+        int mostVotedScore = 0;
+        int maxCount = 0;
         for (int i = 1; i <= range; i++) {
             distribution.add(Map.of("score", i, "count", counts[i]));
+            if (counts[i] > maxCount) {
+                maxCount = counts[i];
+                mostVotedScore = i;
+            }
         }
+
+        Map<String, Object> endValue = new LinkedHashMap<>();
+        endValue.put("minLabel", scale.getMinLabel());
+        endValue.put("maxLabel", scale.getMaxLabel());
 
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("average", average);
+        result.put("mostVoted", mostVotedScore);
+        result.put("endValue", endValue);
         result.put("distribution", distribution);
         return result;
     }

--- a/src/main/java/server/MATE/domain/report/service/handler/SubjectiveReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/SubjectiveReportHandler.java
@@ -34,6 +34,10 @@ public class SubjectiveReportHandler implements ReportHandler {
                 .sorted(Comparator.comparing(Answer::getCreatedAt))
                 .map(a -> (String) a.getAnswer().get("text"))
                 .toList();
-        return Map.of("texts", texts);
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("aiSummary", "AI 요약 준비 중입니다.");
+        result.put("topAnswers", ReportHandlerUtils.topAnswers(texts));
+        result.put("texts", texts);
+        return result;
     }
 }

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -104,7 +104,10 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
 
         JsonNode result = reportData(actors.testId(), actors.makerToken()).path("reports").get(0);
         assertThat(result.path("type").asText()).isEqualTo("SUBJECTIVE");
-        JsonNode texts = result.path("result").path("texts");
+        JsonNode resultData = result.path("result");
+        assertThat(resultData.path("aiSummary").asText()).isEqualTo("AI 요약 준비 중입니다.");
+        assertThat(resultData.path("topAnswers").isArray()).isTrue();
+        JsonNode texts = resultData.path("texts");
         assertThat(texts).hasSize(1);
         assertThat(texts.get(0).asText()).isEqualTo("주관식 응답");
     }
@@ -156,6 +159,10 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
 
         JsonNode result = reportData(actors.testId(), actors.makerToken()).path("reports").get(0).path("result");
         assertThat(result.path("average").asDouble()).isEqualTo(4.0);
+        assertThat(result.path("mostVoted").asInt()).isEqualTo(4);
+        JsonNode endValue = result.path("endValue");
+        assertThat(endValue.path("minLabel").asText()).isNotBlank();
+        assertThat(endValue.path("maxLabel").asText()).isNotBlank();
         JsonNode distribution = result.path("distribution");
         assertThat(distribution).hasSize(5);
         assertThat(distribution.get(3).path("score").asInt()).isEqualTo(4);
@@ -180,7 +187,10 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
 
         JsonNode result = reportData(actors.testId(), actors.makerToken()).path("reports").get(0);
         assertThat(result.path("type").asText()).isEqualTo("FIVE_SECOND");
-        JsonNode texts = result.path("result").path("texts");
+        JsonNode resultData = result.path("result");
+        assertThat(resultData.path("aiSummary").asText()).isEqualTo("AI 요약 준비 중입니다.");
+        assertThat(resultData.path("topAnswers").isArray()).isTrue();
+        JsonNode texts = resultData.path("texts");
         assertThat(texts).hasSize(1);
         assertThat(texts.get(0).asText()).isEqualTo("5초 주관 응답");
     }
@@ -806,6 +816,8 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         completeTest(actors.testId());
 
         JsonNode result = reportData(actors.testId(), actors.makerToken()).path("reports").get(0).path("result");
+        assertThat(result.path("aiSummary").asText()).isEqualTo("AI 요약 준비 중입니다.");
+        assertThat(result.path("topAnswers").isArray()).isTrue();
         JsonNode otherTexts = result.path("otherTexts");
         assertThat(otherTexts).hasSize(1);
         assertThat(otherTexts.get(0).asText()).isEqualTo("직접 입력 응답");
@@ -1180,6 +1192,8 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         completeTest(actors.testId());
 
         JsonNode result = reportData(actors.testId(), actors.makerToken()).path("reports").get(0).path("result");
+        assertThat(result.path("aiSummary").asText()).isEqualTo("AI 요약 준비 중입니다.");
+        assertThat(result.path("topAnswers").isArray()).isTrue();
         JsonNode otherTexts = result.path("otherTexts");
         assertThat(otherTexts).hasSize(1);
         assertThat(otherTexts.get(0).asText()).isEqualTo("5초 기타 응답");


### PR DESCRIPTION
## 📍 요약
- PDF 통계 파일 생성에 필요한 리포트 응답 필드 추가

## 🔗 관련 이슈
- Closes #141

## 📌 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## ✅ 작업 내용
- 주관식(SUBJECTIVE), 5초 테스트 주관식에 `aiSummary`, `topAnswers` 필드 추가
- 객관식(OBJECTIVE), 5초 테스트 객관식의 기타(isOther=true) 응답에 `aiSummary`, `topAnswers` 필드 추가
- 척도(SCALE)에 `mostVoted`(최다 득표 점수), `endValue`(양 끝 라벨) 필드 추가
- `topAnswers`: 동일 텍스트 기준 빈도순 상위 6개 반환 (AI 연동 시 의미론적 유사도 기반으로 교체 예정)
- `aiSummary`: 현재 "AI 요약 준비 중입니다." 고정값 반환

## 테스트
- [x] 로컬 테스트 완료
