### PR TITLE
fix: 테스트 등록 draft과 payment 엔티티 구현

### DIFF
--- a/src/main/java/server/MATE/domain/payment/entity/PayMethod.java
+++ b/src/main/java/server/MATE/domain/payment/entity/PayMethod.java
@@ -1,0 +1,6 @@
+package server.MATE.domain.payment.entity;
+
+public enum PayMethod {
+    TOSS_MONEY,
+    CARD
+}

--- a/src/main/java/server/MATE/domain/payment/entity/PayStatus.java
+++ b/src/main/java/server/MATE/domain/payment/entity/PayStatus.java
@@ -1,0 +1,11 @@
+package server.MATE.domain.payment.entity;
+
+public enum PayStatus {
+    PAY_STANDBY,
+    PAY_CREATED,
+    PAY_SUCCEEDED,
+    PAY_FAILED,
+    REFUND_PENDING,
+    REFUNDED,
+    REFUND_FAILED
+}

--- a/src/main/java/server/MATE/domain/payment/entity/Payment.java
+++ b/src/main/java/server/MATE/domain/payment/entity/Payment.java
@@ -1,0 +1,114 @@
+package server.MATE.domain.payment.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.MATE.global.common.entity.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(
+        name = "payment",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = "order_no")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long draftId;
+
+    private Long testId;
+
+    @Column(nullable = false)
+    private Long makerId;
+
+    @Column(name = "order_no", nullable = false, length = 50)
+    private String orderNo;
+
+    private String payToken;
+
+    private String transactionId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private PayStatus payStatus;
+
+    @Column(nullable = false)
+    private Integer goalPpl;
+
+    @Column(nullable = false)
+    private Integer reward;
+
+    @Column(nullable = false)
+    private Integer amount;
+
+    private Integer paidAmount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private PayMethod payMethod;
+
+    @Column(length = 10)
+    private String accountBankCode;
+
+    @Column(length = 10)
+    private String cardCompanyCode;
+
+    @Column(nullable = false)
+    private Boolean isTestPayment;
+
+    private LocalDateTime approvalTime;
+
+    @Builder
+    public Payment(Long draftId,
+                   Long testId,
+                   Long makerId,
+                   String orderNo,
+                   String payToken,
+                   String transactionId,
+                   PayStatus payStatus,
+                   Integer goalPpl,
+                   Integer reward,
+                   Integer amount,
+                   Integer paidAmount,
+                   PayMethod payMethod,
+                   String accountBankCode,
+                   String cardCompanyCode,
+                   Boolean isTestPayment,
+                   LocalDateTime approvalTime) {
+        this.draftId = draftId;
+        this.testId = testId;
+        this.makerId = makerId;
+        this.orderNo = orderNo;
+        this.payToken = payToken;
+        this.transactionId = transactionId;
+        this.payStatus = payStatus == null ? PayStatus.PAY_STANDBY : payStatus;
+        this.goalPpl = goalPpl;
+        this.reward = reward;
+        this.amount = amount;
+        this.paidAmount = paidAmount;
+        this.payMethod = payMethod;
+        this.accountBankCode = accountBankCode;
+        this.cardCompanyCode = cardCompanyCode;
+        this.isTestPayment = isTestPayment == null ? Boolean.TRUE : isTestPayment;
+        this.approvalTime = approvalTime;
+    }
+}

--- a/src/main/java/server/MATE/domain/payment/entity/PaymentRefund.java
+++ b/src/main/java/server/MATE/domain/payment/entity/PaymentRefund.java
@@ -1,0 +1,65 @@
+package server.MATE.domain.payment.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.MATE.global.common.entity.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(
+        name = "payment_refund",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = "refund_no")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentRefund extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long paymentId;
+
+    @Column(name = "refund_no", nullable = false)
+    private String refundNo;
+
+    @Column(nullable = false)
+    private String reason;
+
+    @Column(nullable = false)
+    private Integer refundedAmount;
+
+    @Column(nullable = false)
+    private String transactionId;
+
+    @Column(nullable = false)
+    private LocalDateTime approvalTime;
+
+    @Builder
+    public PaymentRefund(Long paymentId,
+                         String refundNo,
+                         String reason,
+                         Integer refundedAmount,
+                         String transactionId,
+                         LocalDateTime approvalTime) {
+        this.paymentId = paymentId;
+        this.refundNo = refundNo;
+        this.reason = reason;
+        this.refundedAmount = refundedAmount;
+        this.transactionId = transactionId;
+        this.approvalTime = approvalTime;
+    }
+}

--- a/src/main/java/server/MATE/domain/payment/repository/PaymentRefundRepository.java
+++ b/src/main/java/server/MATE/domain/payment/repository/PaymentRefundRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface PaymentRefundRepository extends JpaRepository<PaymentRefund, Long> {
 
-    List<PaymentRefund> findAllByPaymentIdOrderByRefundedAtDesc(Long paymentId);
+    List<PaymentRefund> findAllByPaymentIdOrderByApprovalTimeDesc(Long paymentId);
 
     Optional<PaymentRefund> findByRefundNo(String refundNo);
 }

--- a/src/main/java/server/MATE/domain/payment/repository/PaymentRefundRepository.java
+++ b/src/main/java/server/MATE/domain/payment/repository/PaymentRefundRepository.java
@@ -1,0 +1,14 @@
+package server.MATE.domain.payment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.MATE.domain.payment.entity.PaymentRefund;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PaymentRefundRepository extends JpaRepository<PaymentRefund, Long> {
+
+    List<PaymentRefund> findAllByPaymentIdOrderByRefundedAtDesc(Long paymentId);
+
+    Optional<PaymentRefund> findByRefundNo(String refundNo);
+}

--- a/src/main/java/server/MATE/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/server/MATE/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,15 @@
+package server.MATE.domain.payment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.MATE.domain.payment.entity.Payment;
+
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    Optional<Payment> findByIdAndMakerId(Long id, Long makerId);
+
+    Optional<Payment> findByOrderNo(String orderNo);
+
+    Optional<Payment> findByDraftId(Long draftId);
+}

--- a/src/main/java/server/MATE/domain/testdraft/entity/TestDraft.java
+++ b/src/main/java/server/MATE/domain/testdraft/entity/TestDraft.java
@@ -1,0 +1,128 @@
+package server.MATE.domain.testdraft.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import server.MATE.global.common.entity.BaseEntity;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Entity
+@Table(
+        name = "test_draft",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = "order_no")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TestDraft extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long makerId;
+
+    @Column(length = 17)
+    private String title;
+
+    @Column(length = 60)
+    private String description;
+
+    @Column(length = 17)
+    private String serviceName;
+
+    @Column(length = 70)
+    private String serviceDescription;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json")
+    private List<String> imageKeys = new ArrayList<>();
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json")
+    private List<String> categories = new ArrayList<>();
+
+    private Integer goalPpl;
+
+    private Integer reward;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> questionsPayload;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private TestDraftStatus status;
+
+    private Long publishedTestId;
+
+    @Column(name = "order_no", length = 50)
+    private String orderNo;
+
+    private Integer expectedAmount;
+
+    private String payToken;
+
+    private LocalDateTime expiresAt;
+
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public TestDraft(Long makerId,
+                     String title,
+                     String description,
+                     String serviceName,
+                     String serviceDescription,
+                     List<String> imageKeys,
+                     List<String> categories,
+                     Integer goalPpl,
+                     Integer reward,
+                     Map<String, Object> questionsPayload,
+                     TestDraftStatus status,
+                     Long publishedTestId,
+                     String orderNo,
+                     Integer expectedAmount,
+                     String payToken,
+                     LocalDateTime expiresAt,
+                     LocalDateTime deletedAt) {
+        this.makerId = makerId;
+        this.title = title;
+        this.description = description;
+        this.serviceName = serviceName;
+        this.serviceDescription = serviceDescription;
+        if (imageKeys != null) {
+            this.imageKeys = new ArrayList<>(imageKeys);
+        }
+        if (categories != null) {
+            this.categories = new ArrayList<>(categories);
+        }
+        this.goalPpl = goalPpl;
+        this.reward = reward;
+        this.questionsPayload = questionsPayload;
+        this.status = status == null ? TestDraftStatus.DRAFT : status;
+        this.publishedTestId = publishedTestId;
+        this.orderNo = orderNo;
+        this.expectedAmount = expectedAmount;
+        this.payToken = payToken;
+        this.expiresAt = expiresAt;
+        this.deletedAt = deletedAt;
+    }
+}

--- a/src/main/java/server/MATE/domain/testdraft/entity/TestDraftStatus.java
+++ b/src/main/java/server/MATE/domain/testdraft/entity/TestDraftStatus.java
@@ -1,0 +1,11 @@
+package server.MATE.domain.testdraft.entity;
+
+public enum TestDraftStatus {
+    DRAFT,
+    PAYMENT_CREATED,
+    PAYMENT_FAILED,
+    PUBLISHING,
+    PUBLISHED,
+    PUBLISH_FAILED,
+    EXPIRED
+}

--- a/src/main/java/server/MATE/domain/testdraft/repository/TestDraftRepository.java
+++ b/src/main/java/server/MATE/domain/testdraft/repository/TestDraftRepository.java
@@ -1,0 +1,19 @@
+package server.MATE.domain.testdraft.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.MATE.domain.testdraft.entity.TestDraft;
+import server.MATE.domain.testdraft.entity.TestDraftStatus;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TestDraftRepository extends JpaRepository<TestDraft, Long> {
+
+    Optional<TestDraft> findByIdAndDeletedAtIsNull(Long id);
+
+    List<TestDraft> findAllByMakerIdAndDeletedAtIsNullOrderByUpdatedAtDesc(Long makerId);
+
+    List<TestDraft> findAllByStatusAndDeletedAtIsNull(TestDraftStatus status);
+
+    Optional<TestDraft> findByOrderNoAndDeletedAtIsNull(String orderNo);
+}


### PR DESCRIPTION
## 📍 요약
- 현재 구현된 플로우로는 결제 실패 시 롤백 로직에서 추가적인 쓰기 작업이 발생하고, 외부 결제를 DB 트랜잭션 처럼 사용하지 못함. 테스트 draft를 임시 관리하는 방법으로 플로우를 전면 수정 및 트랜잭션을 분리하여 해결함.

## 🔗 관련 이슈
- Closes #146

## 📌 변경 사항
- [x] 기능
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- TestDraft와 Payment, PaymentRefund JPA 엔티티를 추가함

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew compileJava
