### PR TITLE
feat: 테스트 draft 관련 API 구현

### DIFF
--- a/src/main/java/server/MATE/domain/testdraft/controller/TestDraftController.java
+++ b/src/main/java/server/MATE/domain/testdraft/controller/TestDraftController.java
@@ -1,0 +1,84 @@
+package server.MATE.domain.testdraft.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import server.MATE.domain.testdraft.dto.request.TestDraftUpdateRequest;
+import server.MATE.domain.testdraft.dto.response.MyTestDraftResponse;
+import server.MATE.domain.testdraft.dto.response.TestDraftResponse;
+import server.MATE.domain.testdraft.service.TestDraftService;
+import server.MATE.global.common.response.ApiResponse;
+import server.MATE.global.security.principal.AuthenticatedUser;
+
+@Tag(name = "[TEST DRAFT] 테스트 초안 API", description = "테스트 초안 관련 API")
+@RestController
+@RequestMapping("/api/v1/test-drafts")
+@SecurityRequirement(name = "JWT")
+@RequiredArgsConstructor
+public class TestDraftController {
+
+    private final TestDraftService testDraftService;
+
+    @Operation(summary = "테스트 초안 등록", description = "빈 테스트 초안을 등록하고 draftId를 반환합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<TestDraftResponse>> createDraft(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        TestDraftResponse response = testDraftService.createDraft(authenticatedUser.getId());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created("테스트 초안을 등록했습니다.", response));
+    }
+
+    @Operation(summary = "테스트 초안 상세 조회", description = "내가 생성한 테스트 초안을 상세 조회합니다.")
+    @GetMapping("/{draftId}")
+    public ResponseEntity<ApiResponse<TestDraftResponse>> getDraft(
+            @PathVariable Long draftId,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        TestDraftResponse response = testDraftService.getDraft(draftId, authenticatedUser.getId());
+        return ResponseEntity.ok(ApiResponse.ok("테스트 초안을 조회했습니다.", response));
+    }
+
+    @Operation(summary = "내 테스트 초안 목록 조회", description = "현재 로그인한 사용자가 생성한 테스트 초안 목록을 최신 수정순으로 조회합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<MyTestDraftResponse>> listMyDrafts(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        MyTestDraftResponse response = testDraftService.listMyDrafts(authenticatedUser.getId());
+        return ResponseEntity.ok(ApiResponse.ok("내 테스트 초안 목록을 조회했습니다.", response));
+    }
+
+    @Operation(summary = "테스트 초안 수정", description = "테스트 초안의 기본 정보, 질문 payload, 목표 인원, 리워드를 수정합니다.")
+    @PatchMapping("/{draftId}")
+    public ResponseEntity<ApiResponse<TestDraftResponse>> updateDraft(
+            @PathVariable Long draftId,
+            @RequestBody @Valid TestDraftUpdateRequest request,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        TestDraftResponse response = testDraftService.updateDraft(draftId, authenticatedUser.getId(), request);
+        return ResponseEntity.ok(ApiResponse.ok("테스트 초안을 수정했습니다.", response));
+    }
+
+    @Operation(summary = "테스트 초안 삭제", description = "특정 테스트 초안을 hard delete 합니다.")
+    @DeleteMapping("/{draftId}")
+    public ResponseEntity<ApiResponse<Void>> deleteDraft(
+            @PathVariable Long draftId,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        testDraftService.deleteDraft(draftId, authenticatedUser.getId());
+        return ResponseEntity.ok(ApiResponse.ok("테스트 초안을 삭제했습니다.", null));
+    }
+}

--- a/src/main/java/server/MATE/domain/testdraft/dto/request/TestDraftUpdateRequest.java
+++ b/src/main/java/server/MATE/domain/testdraft/dto/request/TestDraftUpdateRequest.java
@@ -1,0 +1,37 @@
+package server.MATE.domain.testdraft.dto.request;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import server.MATE.domain.test.entity.Category;
+
+import java.util.List;
+
+public record TestDraftUpdateRequest(
+        @Size(max = 17, message = "테스트 이름은 최대 17자까지 입력 가능합니다.")
+        String title,
+
+        @Size(max = 60, message = "테스트 한줄 소개는 최대 60자까지 입력 가능합니다.")
+        String description,
+
+        @Size(max = 17, message = "서비스 이름은 최대 17자까지 입력 가능합니다.")
+        String serviceName,
+
+        @Size(max = 70, message = "서비스 소개는 최대 70자까지 입력 가능합니다.")
+        String serviceDescription,
+
+        @Size(max = 10, message = "이미지는 최대 10개까지 등록 가능합니다.")
+        List<@Size(min = 1, message = "이미지 키는 비어 있을 수 없습니다.") String> imageKeys,
+
+        @Size(min = 1, max = 3, message = "카테고리는 1개에서 3개까지 선택 가능합니다.")
+        List<Category> categories,
+
+        @Min(value = 1, message = "목표 인원은 1명 이상이어야 합니다.")
+        Integer goalPpl,
+
+        @Min(value = 0, message = "리워드는 0원 이상이어야 합니다.")
+        Integer reward,
+
+        JsonNode questionsPayload
+) {
+}

--- a/src/main/java/server/MATE/domain/testdraft/dto/response/MyTestDraftItem.java
+++ b/src/main/java/server/MATE/domain/testdraft/dto/response/MyTestDraftItem.java
@@ -1,0 +1,26 @@
+package server.MATE.domain.testdraft.dto.response;
+
+import server.MATE.domain.testdraft.entity.TestDraft;
+import server.MATE.domain.testdraft.entity.TestDraftStatus;
+
+import java.time.LocalDateTime;
+
+public record MyTestDraftItem(
+        Long draftId,
+        String title,
+        TestDraftStatus status,
+        Integer goalPpl,
+        Integer reward,
+        LocalDateTime updatedAt
+) {
+    public static MyTestDraftItem from(TestDraft draft) {
+        return new MyTestDraftItem(
+                draft.getId(),
+                draft.getTitle(),
+                draft.getStatus(),
+                draft.getGoalPpl(),
+                draft.getReward(),
+                draft.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/testdraft/dto/response/MyTestDraftResponse.java
+++ b/src/main/java/server/MATE/domain/testdraft/dto/response/MyTestDraftResponse.java
@@ -1,0 +1,12 @@
+package server.MATE.domain.testdraft.dto.response;
+
+import java.util.List;
+
+public record MyTestDraftResponse(
+        int draftCount,
+        List<MyTestDraftItem> drafts
+) {
+    public static MyTestDraftResponse from(List<MyTestDraftItem> drafts) {
+        return new MyTestDraftResponse(drafts.size(), drafts);
+    }
+}

--- a/src/main/java/server/MATE/domain/testdraft/dto/response/TestDraftResponse.java
+++ b/src/main/java/server/MATE/domain/testdraft/dto/response/TestDraftResponse.java
@@ -1,0 +1,52 @@
+package server.MATE.domain.testdraft.dto.response;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import server.MATE.domain.testdraft.entity.TestDraft;
+import server.MATE.domain.testdraft.entity.TestDraftStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TestDraftResponse(
+        Long draftId,
+        Long makerId,
+        String title,
+        String description,
+        String serviceName,
+        String serviceDescription,
+        List<String> imageKeys,
+        List<String> categories,
+        Integer goalPpl,
+        Integer reward,
+        JsonNode questionsPayload,
+        TestDraftStatus status,
+        Long publishedTestId,
+        String orderNo,
+        Integer expectedAmount,
+        String payToken,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static TestDraftResponse from(TestDraft draft, JsonNode questionsPayload) {
+        return new TestDraftResponse(
+                draft.getId(),
+                draft.getMakerId(),
+                draft.getTitle(),
+                draft.getDescription(),
+                draft.getServiceName(),
+                draft.getServiceDescription(),
+                draft.getImageKeys(),
+                draft.getCategories(),
+                draft.getGoalPpl(),
+                draft.getReward(),
+                questionsPayload,
+                draft.getStatus(),
+                draft.getPublishedTestId(),
+                draft.getOrderNo(),
+                draft.getExpectedAmount(),
+                draft.getPayToken(),
+                draft.getCreatedAt(),
+                draft.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/testdraft/entity/TestDraft.java
+++ b/src/main/java/server/MATE/domain/testdraft/entity/TestDraft.java
@@ -15,6 +15,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
 import server.MATE.global.common.entity.BaseEntity;
 
 import java.util.ArrayList;
@@ -144,8 +146,6 @@ public class TestDraft extends BaseEntity {
         }
         if (categories != null) {
             this.categories = new ArrayList<>(categories);
-        } else {
-            this.categories = new ArrayList<>();
         }
         this.goalPpl = goalPpl;
         this.reward = reward;

--- a/src/main/java/server/MATE/domain/testdraft/entity/TestDraft.java
+++ b/src/main/java/server/MATE/domain/testdraft/entity/TestDraft.java
@@ -17,7 +17,6 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import server.MATE.global.common.entity.BaseEntity;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -53,11 +52,11 @@ public class TestDraft extends BaseEntity {
     private String serviceDescription;
 
     @JdbcTypeCode(SqlTypes.JSON)
-    @Column(columnDefinition = "json")
+    @Column(columnDefinition = "jsonb")
     private List<String> imageKeys = new ArrayList<>();
 
     @JdbcTypeCode(SqlTypes.JSON)
-    @Column(columnDefinition = "json")
+    @Column(nullable = false, columnDefinition = "jsonb")
     private List<String> categories = new ArrayList<>();
 
     private Integer goalPpl;
@@ -81,9 +80,43 @@ public class TestDraft extends BaseEntity {
 
     private String payToken;
 
-    private LocalDateTime expiresAt;
-
-    private LocalDateTime deletedAt;
+    public void update(String title,
+                       String description,
+                       String serviceName,
+                       String serviceDescription,
+                       List<String> imageKeys,
+                       List<String> categories,
+                       Integer goalPpl,
+                       Integer reward,
+                       Map<String, Object> questionsPayload) {
+        if (title != null) {
+            this.title = title;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+        if (serviceName != null) {
+            this.serviceName = serviceName;
+        }
+        if (serviceDescription != null) {
+            this.serviceDescription = serviceDescription;
+        }
+        if (imageKeys != null) {
+            this.imageKeys = new ArrayList<>(imageKeys);
+        }
+        if (categories != null) {
+            this.categories = new ArrayList<>(categories);
+        }
+        if (goalPpl != null) {
+            this.goalPpl = goalPpl;
+        }
+        if (reward != null) {
+            this.reward = reward;
+        }
+        if (questionsPayload != null) {
+            this.questionsPayload = questionsPayload;
+        }
+    }
 
     @Builder
     public TestDraft(Long makerId,
@@ -100,9 +133,7 @@ public class TestDraft extends BaseEntity {
                      Long publishedTestId,
                      String orderNo,
                      Integer expectedAmount,
-                     String payToken,
-                     LocalDateTime expiresAt,
-                     LocalDateTime deletedAt) {
+                     String payToken) {
         this.makerId = makerId;
         this.title = title;
         this.description = description;
@@ -113,6 +144,8 @@ public class TestDraft extends BaseEntity {
         }
         if (categories != null) {
             this.categories = new ArrayList<>(categories);
+        } else {
+            this.categories = new ArrayList<>();
         }
         this.goalPpl = goalPpl;
         this.reward = reward;
@@ -122,7 +155,5 @@ public class TestDraft extends BaseEntity {
         this.orderNo = orderNo;
         this.expectedAmount = expectedAmount;
         this.payToken = payToken;
-        this.expiresAt = expiresAt;
-        this.deletedAt = deletedAt;
     }
 }

--- a/src/main/java/server/MATE/domain/testdraft/repository/TestDraftRepository.java
+++ b/src/main/java/server/MATE/domain/testdraft/repository/TestDraftRepository.java
@@ -9,11 +9,11 @@ import java.util.Optional;
 
 public interface TestDraftRepository extends JpaRepository<TestDraft, Long> {
 
-    Optional<TestDraft> findByIdAndDeletedAtIsNull(Long id);
+    Optional<TestDraft> findById(Long id);
 
-    List<TestDraft> findAllByMakerIdAndDeletedAtIsNullOrderByUpdatedAtDesc(Long makerId);
+    List<TestDraft> findAllByMakerIdOrderByUpdatedAtDesc(Long makerId);
 
-    List<TestDraft> findAllByStatusAndDeletedAtIsNull(TestDraftStatus status);
+    List<TestDraft> findAllByStatus(TestDraftStatus status);
 
-    Optional<TestDraft> findByOrderNoAndDeletedAtIsNull(String orderNo);
+    Optional<TestDraft> findByOrderNo(String orderNo);
 }

--- a/src/main/java/server/MATE/domain/testdraft/service/TestDraftService.java
+++ b/src/main/java/server/MATE/domain/testdraft/service/TestDraftService.java
@@ -1,0 +1,90 @@
+package server.MATE.domain.testdraft.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.testdraft.dto.request.TestDraftUpdateRequest;
+import server.MATE.domain.testdraft.dto.response.MyTestDraftItem;
+import server.MATE.domain.testdraft.dto.response.MyTestDraftResponse;
+import server.MATE.domain.testdraft.dto.response.TestDraftResponse;
+import server.MATE.domain.testdraft.entity.TestDraft;
+import server.MATE.domain.testdraft.repository.TestDraftRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TestDraftService {
+
+    private final TestDraftRepository testDraftRepository;
+    private final ObjectMapper objectMapper;
+
+    public TestDraftResponse createDraft(Long makerId) {
+        TestDraft draft = testDraftRepository.save(TestDraft.builder()
+                .makerId(makerId)
+                .build());
+        return TestDraftResponse.from(draft, null);
+    }
+
+    @Transactional(readOnly = true)
+    public TestDraftResponse getDraft(Long draftId, Long makerId) {
+        TestDraft draft = getOwnedDraft(draftId, makerId);
+        return TestDraftResponse.from(draft, toJsonNode(draft.getQuestionsPayload()));
+    }
+
+    @Transactional(readOnly = true)
+    public MyTestDraftResponse listMyDrafts(Long makerId) {
+        List<MyTestDraftItem> items = testDraftRepository.findAllByMakerIdOrderByUpdatedAtDesc(makerId)
+                .stream()
+                .map(MyTestDraftItem::from)
+                .toList();
+        return MyTestDraftResponse.from(items);
+    }
+
+    public TestDraftResponse updateDraft(Long draftId, Long makerId, TestDraftUpdateRequest request) {
+        TestDraft draft = getOwnedDraft(draftId, makerId);
+        draft.update(
+                request.title(),
+                request.description(),
+                request.serviceName(),
+                request.serviceDescription(),
+                request.imageKeys(),
+                request.categories() == null ? null : request.categories().stream().map(Enum::name).toList(),
+                request.goalPpl(),
+                request.reward(),
+                toMap(request.questionsPayload())
+        );
+        return TestDraftResponse.from(draft, toJsonNode(draft.getQuestionsPayload()));
+    }
+
+    public void deleteDraft(Long draftId, Long makerId) {
+        TestDraft draft = getOwnedDraft(draftId, makerId);
+        testDraftRepository.delete(draft);
+    }
+
+    private TestDraft getOwnedDraft(Long draftId, Long makerId) {
+        TestDraft draft = testDraftRepository.findById(draftId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.DRAFT_001));
+        if (!draft.getMakerId().equals(makerId)) {
+            throw new BaseException(BaseErrorCode.DRAFT_002);
+        }
+        return draft;
+    }
+
+    private JsonNode toJsonNode(Map<String, Object> payload) {
+        return payload == null ? null : objectMapper.valueToTree(payload);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> toMap(JsonNode payload) {
+        return payload == null || payload.isNull()
+                ? null
+                : objectMapper.convertValue(payload, Map.class);
+    }
+}

--- a/src/main/java/server/MATE/domain/testdraft/service/TestDraftService.java
+++ b/src/main/java/server/MATE/domain/testdraft/service/TestDraftService.java
@@ -83,7 +83,7 @@ public class TestDraftService {
 
     @SuppressWarnings("unchecked")
     private Map<String, Object> toMap(JsonNode payload) {
-        return payload == null || payload.isNull()
+        return payload == null || !payload.isObject()
                 ? null
                 : objectMapper.convertValue(payload, Map.class);
     }

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -43,6 +43,10 @@ public enum BaseErrorCode implements ErrorCode {
     TEST_005(HttpStatus.FORBIDDEN, "TEST_005", "테스트 메이커만 조회할 수 있습니다."),
     TEST_006(HttpStatus.BAD_REQUEST, "TEST_006", "테스트가 종료된 후에 조회할 수 있습니다."),
 
+    // Test Draft
+    DRAFT_001(HttpStatus.NOT_FOUND, "DRAFT_001", "테스트 초안을 찾을 수 없습니다."),
+    DRAFT_002(HttpStatus.FORBIDDEN, "DRAFT_002", "테스트 초안에 접근할 권한이 없습니다."),
+
     // Question
     QUESTION_001(HttpStatus.BAD_REQUEST, "QUESTION_001", "최소 선택 개수는 1 이상이어야 합니다."),
     QUESTION_002(HttpStatus.BAD_REQUEST, "QUESTION_002", "최대 선택 개수는 최소 선택 개수 이상이어야 합니다."),

--- a/src/test/java/server/MATE/domain/testdraft/controller/TestDraftControllerTest.java
+++ b/src/test/java/server/MATE/domain/testdraft/controller/TestDraftControllerTest.java
@@ -79,7 +79,7 @@ class TestDraftControllerTest {
 
         mockMvc.perform(post("/api/v1/test-drafts").with(authenticationPrincipal()))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.message").value("테스트 초안을 생성했습니다."))
+                .andExpect(jsonPath("$.message").value("테스트 초안을 등록했습니다."))
                 .andExpect(jsonPath("$.data.draftId").value(10L))
                 .andExpect(jsonPath("$.data.status").value("DRAFT"));
     }
@@ -114,7 +114,7 @@ class TestDraftControllerTest {
     @Test
     @DisplayName("테스트 초안 수정 요청을 정상 처리한다")
     void updatesDraftSuccessfully() throws Exception {
-        given(testDraftService.updateDraft(eq(10L), eq(1L), any())).willReturn(sampleDraftResponse());
+        given(testDraftService.updateDraft(eq(10L), eq(1L), any())).willReturn(sampleDraftResponse("수정된 테스트"));
 
         String request = """
                 {
@@ -139,7 +139,7 @@ class TestDraftControllerTest {
                         .content(request))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("테스트 초안을 수정했습니다."))
-                .andExpect(jsonPath("$.data.title").value("초안 제목"));
+                .andExpect(jsonPath("$.data.title").value("수정된 테스트"));
     }
 
     @Test
@@ -153,6 +153,10 @@ class TestDraftControllerTest {
     }
 
     private TestDraftResponse sampleDraftResponse() {
+        return sampleDraftResponse("초안 제목");
+    }
+
+    private TestDraftResponse sampleDraftResponse(String title) {
         JsonNode payload = objectMapper.valueToTree(
                 java.util.Map.of(
                         "questions", List.of(
@@ -163,7 +167,7 @@ class TestDraftControllerTest {
         return new TestDraftResponse(
                 10L,
                 1L,
-                "초안 제목",
+                title,
                 "초안 설명",
                 "서비스",
                 "서비스 설명",

--- a/src/test/java/server/MATE/domain/testdraft/controller/TestDraftControllerTest.java
+++ b/src/test/java/server/MATE/domain/testdraft/controller/TestDraftControllerTest.java
@@ -1,0 +1,200 @@
+package server.MATE.domain.testdraft.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import server.MATE.domain.auth.jwt.TokenType;
+import server.MATE.domain.testdraft.dto.response.MyTestDraftItem;
+import server.MATE.domain.testdraft.dto.response.MyTestDraftResponse;
+import server.MATE.domain.testdraft.dto.response.TestDraftResponse;
+import server.MATE.domain.testdraft.entity.TestDraftStatus;
+import server.MATE.domain.testdraft.service.TestDraftService;
+import server.MATE.domain.users.entity.Role;
+import server.MATE.global.common.exception.GlobalExceptionHandler;
+import server.MATE.global.discord.DiscordWebhookNotifier;
+import server.MATE.global.security.principal.AuthenticatedUser;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class TestDraftControllerTest {
+
+    @Mock
+    private TestDraftService testDraftService;
+
+    @Mock
+    private DiscordWebhookNotifier discordWebhookNotifier;
+
+    @InjectMocks
+    private TestDraftController testDraftController;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(testDraftController)
+                .setControllerAdvice(new GlobalExceptionHandler(discordWebhookNotifier))
+                .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("테스트 초안 생성 요청을 정상 처리한다")
+    void createsDraftSuccessfully() throws Exception {
+        given(testDraftService.createDraft(1L)).willReturn(sampleDraftResponse());
+
+        mockMvc.perform(post("/api/v1/test-drafts").with(authenticationPrincipal()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.message").value("테스트 초안을 생성했습니다."))
+                .andExpect(jsonPath("$.data.draftId").value(10L))
+                .andExpect(jsonPath("$.data.status").value("DRAFT"));
+    }
+
+    @Test
+    @DisplayName("테스트 초안 상세 조회 요청을 정상 처리한다")
+    void getsDraftSuccessfully() throws Exception {
+        given(testDraftService.getDraft(10L, 1L)).willReturn(sampleDraftResponse());
+
+        mockMvc.perform(get("/api/v1/test-drafts/10").with(authenticationPrincipal()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("테스트 초안을 조회했습니다."))
+                .andExpect(jsonPath("$.data.draftId").value(10L))
+                .andExpect(jsonPath("$.data.questionsPayload.questions[0].type").value("OBJECTIVE"));
+    }
+
+    @Test
+    @DisplayName("내 테스트 초안 목록 조회 요청을 정상 처리한다")
+    void listsDraftsSuccessfully() throws Exception {
+        given(testDraftService.listMyDrafts(1L)).willReturn(new MyTestDraftResponse(
+                1,
+                List.of(new MyTestDraftItem(10L, "초안 제목", TestDraftStatus.DRAFT, 100, 300, LocalDateTime.parse("2026-05-25T12:00:00")))
+        ));
+
+        mockMvc.perform(get("/api/v1/test-drafts/me").with(authenticationPrincipal()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.draftCount").value(1))
+                .andExpect(jsonPath("$.data.drafts[0].draftId").value(10L))
+                .andExpect(jsonPath("$.data.drafts[0].status").value("DRAFT"));
+    }
+
+    @Test
+    @DisplayName("테스트 초안 수정 요청을 정상 처리한다")
+    void updatesDraftSuccessfully() throws Exception {
+        given(testDraftService.updateDraft(eq(10L), eq(1L), any())).willReturn(sampleDraftResponse());
+
+        String request = """
+                {
+                  "title": "수정된 테스트",
+                  "description": "수정 설명",
+                  "goalPpl": 100,
+                  "reward": 300,
+                  "questionsPayload": {
+                    "questions": [
+                      {
+                        "type": "OBJECTIVE",
+                        "title": "질문"
+                      }
+                    ]
+                  }
+                }
+                """;
+
+        mockMvc.perform(patch("/api/v1/test-drafts/10")
+                        .with(authenticationPrincipal())
+                        .contentType(APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("테스트 초안을 수정했습니다."))
+                .andExpect(jsonPath("$.data.title").value("초안 제목"));
+    }
+
+    @Test
+    @DisplayName("테스트 초안 삭제 요청을 정상 처리한다")
+    void deletesDraftSuccessfully() throws Exception {
+        mockMvc.perform(delete("/api/v1/test-drafts/10").with(authenticationPrincipal()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("테스트 초안을 삭제했습니다."));
+
+        verify(testDraftService).deleteDraft(10L, 1L);
+    }
+
+    private TestDraftResponse sampleDraftResponse() {
+        JsonNode payload = objectMapper.valueToTree(
+                java.util.Map.of(
+                        "questions", List.of(
+                                java.util.Map.of("type", "OBJECTIVE", "title", "질문 1")
+                        )
+                )
+        );
+        return new TestDraftResponse(
+                10L,
+                1L,
+                "초안 제목",
+                "초안 설명",
+                "서비스",
+                "서비스 설명",
+                List.of("img-1"),
+                List.of("FOOD"),
+                100,
+                300,
+                payload,
+                TestDraftStatus.DRAFT,
+                null,
+                null,
+                null,
+                null,
+                LocalDateTime.parse("2026-05-25T11:00:00"),
+                LocalDateTime.parse("2026-05-25T12:00:00")
+        );
+    }
+
+    private RequestPostProcessor authenticationPrincipal() {
+        return request -> {
+            AuthenticatedUser principal = new AuthenticatedUser(
+                    1L,
+                    Role.USER,
+                    TokenType.ACCESS
+            );
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(authentication);
+            SecurityContextHolder.setContext(context);
+            return request;
+        };
+    }
+}


### PR DESCRIPTION
## 📍 요약
- 테스트 draft CRUD API를 구현함

## 🔗 관련 이슈
- Closes #148 

## 📌 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- 다음의 api를 구현함
   - 테스트 초안 생성
   - 테스트 초안 상세 조회
   - 테스트 초안 삭제
   - 테스트 초안 수정
   - 내 테스트 초안 목록 조회

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew compileJava test --tests server.MATE.domain.testdraft.controller.TestDraftControllerTest
