### PR TITLE
fix: 찜한 테스트 조회 시 id, 개수 필드 추가

### DIFF
--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -70,11 +70,13 @@ public class TestController {
     }
 
     @Operation(
-            summary = "내가 찜한 테스트 목록 조회",
+            summary = "찜한 테스트 목록 조회",
             description = """
-                    현재 로그인한 사용자가 찜한 테스트 목록을 찜한 시각 최신순으로 조회합니다.
+                    현재 로그인한 사용자가 찜한 테스트 목록을 찜한 시각 최신순으로 조회합니다. 관심 탭 HM_01 19 화면에 해당하는 api 입니다.<br>
                     삭제되지 않았고 관리자 승인(`ACCEPTED`)이 완료된 테스트만 반환합니다.
 
+                    - **testCount**: 테스트 개수
+                    - **id**: 테스트 ID
                     - **thumbnailUrl**: 썸네일 Public URL (만료 없음, 이미지 없으면 null)
                     - **title**: 테스트명
                     - **description**: 테스트 한 줄 소개
@@ -82,10 +84,10 @@ public class TestController {
                     """
     )
     @GetMapping("/likes")
-    public ResponseEntity<ApiResponse<List<LikedTestSummaryResponse>>> listLikedTests(
+    public ResponseEntity<ApiResponse<LikedTestSummaryResponse>> listLikedTests(
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser
     ) {
-        List<LikedTestSummaryResponse> data = testService.listLikedTests(authenticatedUser.getId());
+        LikedTestSummaryResponse data = testService.listLikedTests(authenticatedUser.getId());
         return ResponseEntity.ok(ApiResponse.ok("내가 찜한 테스트 목록을 조회했습니다.", data));
     }
 

--- a/src/main/java/server/MATE/domain/test/dto/response/LikedTestSummaryItem.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/LikedTestSummaryItem.java
@@ -1,0 +1,28 @@
+package server.MATE.domain.test.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import server.MATE.domain.test.entity.Test;
+
+@Schema(description = "내가 찜한 테스트 목록 노출용 요약 항목")
+public record LikedTestSummaryItem(
+        @Schema(description = "테스트 ID", example = "1")
+        Long id,
+        @Schema(description = "썸네일 Public URL (만료 없음, 이미지 없으면 null)")
+        String thumbnailUrl,
+        @Schema(description = "테스트명", example = "남이만든테스트1")
+        String title,
+        @Schema(description = "테스트 한 줄 소개")
+        String description,
+        @Schema(description = "보상 금액(머니)", example = "600")
+        Integer reward
+) {
+    public static LikedTestSummaryItem from(Test test, String thumbnailUrl) {
+        return new LikedTestSummaryItem(
+                test.getId(),
+                thumbnailUrl,
+                test.getTitle(),
+                test.getDescription(),
+                test.getReward()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/test/dto/response/LikedTestSummaryResponse.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/LikedTestSummaryResponse.java
@@ -1,26 +1,17 @@
 package server.MATE.domain.test.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import server.MATE.domain.test.entity.Test;
 
+import java.util.List;
 
-@Schema(description = "내가 찜한 테스트 목록 노출용 요약")
+@Schema(description = "내가 찜한 테스트 목록 조회 응답")
 public record LikedTestSummaryResponse(
-        @Schema(description = "썸네일 Public URL (만료 없음, 이미지 없으면 null)")
-        String thumbnailUrl,
-        @Schema(description = "테스트명", example = "남이만든테스트1")
-        String title,
-        @Schema(description = "테스트 한 줄 소개")
-        String description,
-        @Schema(description = "보상 금액(머니)", example = "600")
-        Integer reward
+        @Schema(description = "테스트 개수", example = "3")
+        int testCount,
+        @Schema(description = "테스트 목록")
+        List<LikedTestSummaryItem> tests
 ) {
-    public static LikedTestSummaryResponse from(Test test, String thumbnailUrl) {
-        return new LikedTestSummaryResponse(
-                thumbnailUrl,
-                test.getTitle(),
-                test.getDescription(),
-                test.getReward()
-        );
+    public static LikedTestSummaryResponse from(List<LikedTestSummaryItem> tests) {
+        return new LikedTestSummaryResponse(tests.size(), tests);
     }
 }

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.MATE.domain.test.dto.request.TestUpdateRequest;
 import server.MATE.domain.test.dto.response.ImageInfo;
+import server.MATE.domain.test.dto.response.LikedTestSummaryItem;
 import server.MATE.domain.test.dto.response.TestDetailResponse;
 import server.MATE.domain.test.dto.response.TestLikeResponse;
 import server.MATE.domain.test.dto.response.LikedTestSummaryResponse;
@@ -57,11 +58,12 @@ public class TestService {
     }
 
     @Transactional(readOnly = true)
-    public List<LikedTestSummaryResponse> listLikedTests(Long userId) {
+    public LikedTestSummaryResponse listLikedTests(Long userId) {
         List<Test> tests = testRepository.findLikedTestsByUserId(userId, ApprovalStatus.ACCEPTED);
-        return tests.stream()
-                .map(test -> LikedTestSummaryResponse.from(test, toThumbnailUrl(test.getImageKeys())))
+        List<LikedTestSummaryItem> items = tests.stream()
+                .map(test -> LikedTestSummaryItem.from(test, toThumbnailUrl(test.getImageKeys())))
                 .toList();
+        return LikedTestSummaryResponse.from(items);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Clock;
 import server.MATE.domain.test.dto.request.TestUpdateRequest;
+import server.MATE.domain.test.dto.response.LikedTestSummaryItem;
 import server.MATE.domain.test.dto.response.TestLikeResponse;
 import server.MATE.domain.test.dto.response.LikedTestSummaryResponse;
 import server.MATE.domain.test.dto.response.MyTestSummaryResponse;
@@ -141,13 +142,17 @@ class TestServiceTest {
         given(testRepository.findLikedTestsByUserId(MAKER_ID, ApprovalStatus.ACCEPTED))
                 .willReturn(List.of(test));
 
-        List<LikedTestSummaryResponse> responses = testService.listLikedTests(MAKER_ID);
+        LikedTestSummaryResponse response = testService.listLikedTests(MAKER_ID);
 
-        assertThat(responses).hasSize(1);
-        assertThat(responses.getFirst().title()).isEqualTo("기존 제목");
-        assertThat(responses.getFirst().description()).isEqualTo("기존 소개");
-        assertThat(responses.getFirst().reward()).isEqualTo(300);
-        assertThat(responses.getFirst().thumbnailUrl()).isEqualTo("https://example.com/url");
+        assertThat(response.testCount()).isEqualTo(1);
+        assertThat(response.tests()).hasSize(1);
+
+        LikedTestSummaryItem item = response.tests().getFirst();
+        assertThat(item.id()).isEqualTo(TEST_ID);
+        assertThat(item.title()).isEqualTo("기존 제목");
+        assertThat(item.description()).isEqualTo("기존 소개");
+        assertThat(item.reward()).isEqualTo(300);
+        assertThat(item.thumbnailUrl()).isEqualTo("https://example.com/url");
     }
 
     @Test


### PR DESCRIPTION
## 📍 요약
- 찜한 테스트 조회시 테스트 id, 개수를 포함하도록 DTO 구조를 수정함

## 🔗 관련 이슈
- Closes #138 

## 📌 변경 사항
- [] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- 기존 LikedTestSummaryResponse를 LikedTestSummaryItem으로 수정
-- LikedTestSummaryResponse를 목록 래퍼 응답으로 변경하고 testCount, tests 필드 추가

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew test --tests server.MATE.domain.test.service.TestServiceTest
