### PR TITLE
refactor: 주관식 응답 집계 구조를 clusters/texts로 분리

### DIFF
--- a/src/main/java/server/MATE/domain/report/controller/ReportController.java
+++ b/src/main/java/server/MATE/domain/report/controller/ReportController.java
@@ -67,7 +67,7 @@ public class ReportController {
                             ),
                             @ExampleObject(
                                     name = "COMPLETED - SUBJECTIVE",
-                                    summary = "주관식 (SUBJECTIVE) — aiSummary: AI 3줄 요약, topAnswers: 많이 언급된 답변 최대 6개, texts: 전체 응답 텍스트 목록",
+                                    summary = "주관식 (SUBJECTIVE) — aiSummary: AI 요약, clusters: 그룹핑된 응답 목록, texts: 앱 미리보기용 최대 15개 샘플",
                                     value = """
                                             {
                                               "success": true,
@@ -89,7 +89,10 @@ public class ReportController {
                                                     "type": "SUBJECTIVE",
                                                     "result": {
                                                       "aiSummary": "AI 요약 준비 중입니다.",
-                                                      "topAnswers": ["로딩이 느립니다.", "버튼이 너무 작아요."],
+                                                      "clusters": [
+                                                        { "representative": "버튼이 너무 작아요.", "count": 2, "responses": ["버튼이 너무 작아요.", "버튼이 너무 작아요."] },
+                                                        { "representative": "로딩이 느립니다.", "count": 1, "responses": ["로딩이 느립니다."] }
+                                                      ],
                                                       "texts": [
                                                         "로딩이 느립니다.",
                                                         "버튼이 너무 작아요.",
@@ -104,7 +107,7 @@ public class ReportController {
                             ),
                             @ExampleObject(
                                     name = "COMPLETED - OBJECTIVE",
-                                    summary = "객관식 (OBJECTIVE) — options: 선택지별 count/ratio, isOther=true 시 aiSummary/topAnswers/otherTexts 포함",
+                                    summary = "객관식 (OBJECTIVE) — options: 선택지별 count/ratio, isOther=true 시 aiSummary/clusters/texts 포함",
                                     value = """
                                             {
                                               "success": true,
@@ -131,8 +134,10 @@ public class ReportController {
                                                         { "optionId": 103, "content": "기타", "count": 1, "ratio": 0.1 }
                                                       ],
                                                       "aiSummary": "AI 요약 준비 중입니다.",
-                                                      "topAnswers": ["알림 기능을 자주 씁니다."],
-                                                      "otherTexts": ["알림 기능을 자주 씁니다."]
+                                                      "clusters": [
+                                                        { "representative": "알림 기능을 자주 씁니다.", "count": 1, "responses": ["알림 기능을 자주 씁니다."] }
+                                                      ],
+                                                      "texts": ["알림 기능을 자주 씁니다."]
                                                     }
                                                   }
                                                 ]
@@ -142,7 +147,7 @@ public class ReportController {
                             ),
                             @ExampleObject(
                                     name = "COMPLETED - FIVE_SECOND (주관식)",
-                                    summary = "5초 테스트 주관식 (FIVE_SECOND, isObjective=false) — aiSummary/topAnswers/texts 포함",
+                                    summary = "5초 테스트 주관식 (FIVE_SECOND, isObjective=false) — aiSummary/clusters/texts 포함",
                                     value = """
                                             {
                                               "success": true,
@@ -164,7 +169,10 @@ public class ReportController {
                                                     "type": "FIVE_SECOND",
                                                     "result": {
                                                       "aiSummary": "AI 요약 준비 중입니다.",
-                                                      "topAnswers": ["상단 배너가 눈에 들어왔어요."],
+                                                      "clusters": [
+                                                        { "representative": "상단 배너가 눈에 들어왔어요.", "count": 1, "responses": ["상단 배너가 눈에 들어왔어요."] },
+                                                        { "representative": "검색창이 먼저 보였습니다.", "count": 1, "responses": ["검색창이 먼저 보였습니다."] }
+                                                      ],
                                                       "texts": [
                                                         "상단 배너가 눈에 들어왔어요.",
                                                         "검색창이 먼저 보였습니다."
@@ -178,7 +186,7 @@ public class ReportController {
                             ),
                             @ExampleObject(
                                     name = "COMPLETED - FIVE_SECOND (객관식)",
-                                    summary = "5초 테스트 객관식 (FIVE_SECOND, isObjective=true) — options: 선택지별 count/ratio, isOther=true 시 aiSummary/topAnswers/otherTexts 포함",
+                                    summary = "5초 테스트 객관식 (FIVE_SECOND, isObjective=true) — options: 선택지별 count/ratio, isOther=true 시 aiSummary/clusters/texts 포함",
                                     value = """
                                             {
                                               "success": true,
@@ -204,8 +212,10 @@ public class ReportController {
                                                         { "optionId": 202, "content": "배너", "count": 2, "ratio": 0.333 }
                                                       ],
                                                       "aiSummary": "AI 요약 준비 중입니다.",
-                                                      "topAnswers": ["하단 버튼이요"],
-                                                      "otherTexts": ["하단 버튼이요"]
+                                                      "clusters": [
+                                                        { "representative": "하단 버튼이요", "count": 1, "responses": ["하단 버튼이요"] }
+                                                      ],
+                                                      "texts": ["하단 버튼이요"]
                                                     }
                                                   }
                                                 ]

--- a/src/main/java/server/MATE/domain/report/controller/ReportController.java
+++ b/src/main/java/server/MATE/domain/report/controller/ReportController.java
@@ -107,7 +107,7 @@ public class ReportController {
                             ),
                             @ExampleObject(
                                     name = "COMPLETED - OBJECTIVE",
-                                    summary = "객관식 (OBJECTIVE) — options: 선택지별 count/ratio, isOther=true 시 aiSummary/clusters/texts 포함",
+                                    summary = "객관식 (OBJECTIVE) — options: 선택지별 count/ratio, isOther=true 시 aiSummary/clusters/otherTexts 포함",
                                     value = """
                                             {
                                               "success": true,
@@ -137,7 +137,7 @@ public class ReportController {
                                                       "clusters": [
                                                         { "representative": "알림 기능을 자주 씁니다.", "count": 1, "responses": ["알림 기능을 자주 씁니다."] }
                                                       ],
-                                                      "texts": ["알림 기능을 자주 씁니다."]
+                                                      "otherTexts": ["알림 기능을 자주 씁니다."]
                                                     }
                                                   }
                                                 ]
@@ -186,7 +186,7 @@ public class ReportController {
                             ),
                             @ExampleObject(
                                     name = "COMPLETED - FIVE_SECOND (객관식)",
-                                    summary = "5초 테스트 객관식 (FIVE_SECOND, isObjective=true) — options: 선택지별 count/ratio, isOther=true 시 aiSummary/clusters/texts 포함",
+                                    summary = "5초 테스트 객관식 (FIVE_SECOND, isObjective=true) — options: 선택지별 count/ratio, isOther=true 시 aiSummary/clusters/otherTexts 포함",
                                     value = """
                                             {
                                               "success": true,
@@ -215,7 +215,7 @@ public class ReportController {
                                                       "clusters": [
                                                         { "representative": "하단 버튼이요", "count": 1, "responses": ["하단 버튼이요"] }
                                                       ],
-                                                      "texts": ["하단 버튼이요"]
+                                                      "otherTexts": ["하단 버튼이요"]
                                                     }
                                                   }
                                                 ]

--- a/src/main/java/server/MATE/domain/report/service/handler/FiveSecondReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/FiveSecondReportHandler.java
@@ -79,7 +79,7 @@ public class FiveSecondReportHandler implements ReportHandler {
         if (Boolean.TRUE.equals(fiveSecond.getIsOther())) {
             result.put("aiSummary", "AI 요약 준비 중입니다.");
             result.put("clusters", ReportHandlerUtils.buildClusters(otherTexts));
-            result.put("texts", ReportHandlerUtils.sampleTexts(otherTexts));
+            result.put("otherTexts", ReportHandlerUtils.sampleTexts(otherTexts));
         }
         return result;
     }

--- a/src/main/java/server/MATE/domain/report/service/handler/FiveSecondReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/FiveSecondReportHandler.java
@@ -78,21 +78,21 @@ public class FiveSecondReportHandler implements ReportHandler {
         result.put("options", options);
         if (Boolean.TRUE.equals(fiveSecond.getIsOther())) {
             result.put("aiSummary", "AI 요약 준비 중입니다.");
-            result.put("topAnswers", ReportHandlerUtils.topAnswers(otherTexts));
-            result.put("otherTexts", otherTexts);
+            result.put("clusters", ReportHandlerUtils.buildClusters(otherTexts));
+            result.put("texts", ReportHandlerUtils.sampleTexts(otherTexts));
         }
         return result;
     }
 
     private Map<String, Object> computeSubjective(List<Answer> answers) {
-        List<String> texts = answers.stream()
+        List<String> allTexts = answers.stream()
                 .sorted(Comparator.comparing(Answer::getCreatedAt))
                 .map(a -> (String) a.getAnswer().get("text"))
                 .toList();
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("aiSummary", "AI 요약 준비 중입니다.");
-        result.put("topAnswers", ReportHandlerUtils.topAnswers(texts));
-        result.put("texts", texts);
+        result.put("clusters", ReportHandlerUtils.buildClusters(allTexts));
+        result.put("texts", ReportHandlerUtils.sampleTexts(allTexts));
         return result;
     }
 }

--- a/src/main/java/server/MATE/domain/report/service/handler/ObjectiveReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/ObjectiveReportHandler.java
@@ -77,7 +77,7 @@ public class ObjectiveReportHandler implements ReportHandler {
         if (objective.isOther()) {
             result.put("aiSummary", "AI 요약 준비 중입니다.");
             result.put("clusters", ReportHandlerUtils.buildClusters(otherTexts));
-            result.put("texts", ReportHandlerUtils.sampleTexts(otherTexts));
+            result.put("otherTexts", ReportHandlerUtils.sampleTexts(otherTexts));
         }
         return result;
     }

--- a/src/main/java/server/MATE/domain/report/service/handler/ObjectiveReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/ObjectiveReportHandler.java
@@ -76,8 +76,8 @@ public class ObjectiveReportHandler implements ReportHandler {
         result.put("options", options);
         if (objective.isOther()) {
             result.put("aiSummary", "AI 요약 준비 중입니다.");
-            result.put("topAnswers", ReportHandlerUtils.topAnswers(otherTexts));
-            result.put("otherTexts", otherTexts);
+            result.put("clusters", ReportHandlerUtils.buildClusters(otherTexts));
+            result.put("texts", ReportHandlerUtils.sampleTexts(otherTexts));
         }
         return result;
     }

--- a/src/main/java/server/MATE/domain/report/service/handler/ReportHandlerUtils.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/ReportHandlerUtils.java
@@ -1,11 +1,16 @@
 package server.MATE.domain.report.service.handler;
 
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 final class ReportHandlerUtils {
+
+    private static final int TEXT_SAMPLE_SIZE = 15;
 
     private ReportHandlerUtils() {
     }
@@ -16,15 +21,27 @@ final class ReportHandlerUtils {
     }
 
     // TODO: AI 연동 후 의미론적 유사도 기반 그룹핑으로 교체
-    static List<String> topAnswers(List<String> texts) {
+    static List<Map<String, Object>> buildClusters(List<String> texts) {
         return texts.stream()
                 .filter(t -> t != null && !t.isBlank())
-                .collect(Collectors.groupingBy(String::trim, Collectors.counting()))
+                .map(String::trim)
+                .collect(Collectors.groupingBy(Function.identity()))
                 .entrySet().stream()
-                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
-                .limit(6)
-                .map(Map.Entry::getKey)
+                .sorted(Map.Entry.<String, List<String>>comparingByValue(
+                        Comparator.comparingInt(List::size)).reversed())
+                .map(e -> {
+                    Map<String, Object> cluster = new LinkedHashMap<>();
+                    cluster.put("representative", e.getKey());
+                    cluster.put("count", e.getValue().size());
+                    cluster.put("responses", List.copyOf(e.getValue()));
+                    return cluster;
+                })
                 .toList();
+    }
+
+    static List<String> sampleTexts(List<String> texts) {
+        if (texts.size() <= TEXT_SAMPLE_SIZE) return texts;
+        return List.copyOf(texts.subList(0, TEXT_SAMPLE_SIZE));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/server/MATE/domain/report/service/handler/ReportHandlerUtils.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/ReportHandlerUtils.java
@@ -40,8 +40,10 @@ final class ReportHandlerUtils {
     }
 
     static List<String> sampleTexts(List<String> texts) {
-        if (texts.size() <= TEXT_SAMPLE_SIZE) return texts;
-        return List.copyOf(texts.subList(0, TEXT_SAMPLE_SIZE));
+        return texts.stream()
+                .filter(t -> t != null && !t.isBlank())
+                .limit(TEXT_SAMPLE_SIZE)
+                .toList();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/server/MATE/domain/report/service/handler/SubjectiveReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/SubjectiveReportHandler.java
@@ -30,14 +30,14 @@ public class SubjectiveReportHandler implements ReportHandler {
     }
 
     private Map<String, Object> computeForSubjective(List<Answer> answers) {
-        List<String> texts = answers.stream()
+        List<String> allTexts = answers.stream()
                 .sorted(Comparator.comparing(Answer::getCreatedAt))
                 .map(a -> (String) a.getAnswer().get("text"))
                 .toList();
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("aiSummary", "AI 요약 준비 중입니다.");
-        result.put("topAnswers", ReportHandlerUtils.topAnswers(texts));
-        result.put("texts", texts);
+        result.put("clusters", ReportHandlerUtils.buildClusters(allTexts));
+        result.put("texts", ReportHandlerUtils.sampleTexts(allTexts));
         return result;
     }
 }

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -106,7 +106,7 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         assertThat(result.path("type").asText()).isEqualTo("SUBJECTIVE");
         JsonNode resultData = result.path("result");
         assertThat(resultData.path("aiSummary").asText()).isEqualTo("AI 요약 준비 중입니다.");
-        assertThat(resultData.path("topAnswers").isArray()).isTrue();
+        assertThat(resultData.path("clusters").isArray()).isTrue();
         JsonNode texts = resultData.path("texts");
         assertThat(texts).hasSize(1);
         assertThat(texts.get(0).asText()).isEqualTo("주관식 응답");
@@ -189,7 +189,7 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         assertThat(result.path("type").asText()).isEqualTo("FIVE_SECOND");
         JsonNode resultData = result.path("result");
         assertThat(resultData.path("aiSummary").asText()).isEqualTo("AI 요약 준비 중입니다.");
-        assertThat(resultData.path("topAnswers").isArray()).isTrue();
+        assertThat(resultData.path("clusters").isArray()).isTrue();
         JsonNode texts = resultData.path("texts");
         assertThat(texts).hasSize(1);
         assertThat(texts.get(0).asText()).isEqualTo("5초 주관 응답");
@@ -798,8 +798,8 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
     }
 
     @Test
-    @DisplayName("OBJECTIVE isOther=true 응답 시 리포트에 otherTexts가 포함된다")
-    void getReport_withObjectiveOtherText_returnsOtherTexts() throws Exception {
+    @DisplayName("OBJECTIVE isOther=true 응답 시 리포트에 clusters와 texts가 포함된다")
+    void getReport_withObjectiveOtherText_returnsClustersAndTexts() throws Exception {
         TestActors actors = createActors();
         createObjectiveQuestion(actors.testId(), actors.makerToken(), false, null, null, true);
         JsonNode questionNode = getSingleQuestion(actors.testId(), actors.makerToken());
@@ -817,10 +817,10 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
 
         JsonNode result = reportData(actors.testId(), actors.makerToken()).path("reports").get(0).path("result");
         assertThat(result.path("aiSummary").asText()).isEqualTo("AI 요약 준비 중입니다.");
-        assertThat(result.path("topAnswers").isArray()).isTrue();
-        JsonNode otherTexts = result.path("otherTexts");
-        assertThat(otherTexts).hasSize(1);
-        assertThat(otherTexts.get(0).asText()).isEqualTo("직접 입력 응답");
+        assertThat(result.path("clusters").isArray()).isTrue();
+        JsonNode texts = result.path("texts");
+        assertThat(texts).hasSize(1);
+        assertThat(texts.get(0).asText()).isEqualTo("직접 입력 응답");
     }
 
     @Test
@@ -994,8 +994,8 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
     }
 
     @Test
-    @DisplayName("SUBJECTIVE와 FIVE_SECOND 주관식 리포트의 texts는 createdAt 오름차순으로 정렬된다")
-    void getReport_withSubjectiveTexts_returnsCreatedAtAscendingOrder() throws Exception {
+    @DisplayName("SUBJECTIVE와 FIVE_SECOND 주관식 리포트의 texts는 미리보기 샘플을 포함한다")
+    void getReport_withSubjectiveTexts_returnsPreviewSample() throws Exception {
         mutableClock.setInstant(DEFAULT_TEST_INSTANT);
 
         TestActors actors = createActors();
@@ -1049,12 +1049,12 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         JsonNode fiveSecondTexts = reports.get(1).path("result").path("texts");
 
         assertThat(subjectiveTexts).hasSize(2);
-        assertThat(subjectiveTexts.get(0).asText()).isEqualTo("빠른 주관식 응답");
-        assertThat(subjectiveTexts.get(1).asText()).isEqualTo("늦은 주관식 응답");
+        assertThat(subjectiveTexts).extracting(JsonNode::asText)
+                .containsExactlyInAnyOrder("빠른 주관식 응답", "늦은 주관식 응답");
 
         assertThat(fiveSecondTexts).hasSize(2);
-        assertThat(fiveSecondTexts.get(0).asText()).isEqualTo("빠른 5초 응답");
-        assertThat(fiveSecondTexts.get(1).asText()).isEqualTo("늦은 5초 응답");
+        assertThat(fiveSecondTexts).extracting(JsonNode::asText)
+                .containsExactlyInAnyOrder("빠른 5초 응답", "늦은 5초 응답");
     }
 
     @TestConfiguration(proxyBeanMethods = false)
@@ -1167,8 +1167,8 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
     }
 
     @Test
-    @DisplayName("FIVE_SECOND isOther=true 응답 시 리포트에 otherTexts가 포함된다")
-    void getReport_withFiveSecondOtherText_returnsOtherTexts() throws Exception {
+    @DisplayName("FIVE_SECOND isOther=true 응답 시 리포트에 clusters와 texts가 포함된다")
+    void getReport_withFiveSecondOtherText_returnsClustersAndTexts() throws Exception {
         TestActors actors = createActors();
         createFiveSecondObjectiveQuestion(actors.testId(), actors.makerToken(), false, null, null, true);
         JsonNode questionNode = getSingleQuestion(actors.testId(), actors.makerToken());
@@ -1193,10 +1193,10 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
 
         JsonNode result = reportData(actors.testId(), actors.makerToken()).path("reports").get(0).path("result");
         assertThat(result.path("aiSummary").asText()).isEqualTo("AI 요약 준비 중입니다.");
-        assertThat(result.path("topAnswers").isArray()).isTrue();
-        JsonNode otherTexts = result.path("otherTexts");
-        assertThat(otherTexts).hasSize(1);
-        assertThat(otherTexts.get(0).asText()).isEqualTo("5초 기타 응답");
+        assertThat(result.path("clusters").isArray()).isTrue();
+        JsonNode texts = result.path("texts");
+        assertThat(texts).hasSize(1);
+        assertThat(texts.get(0).asText()).isEqualTo("5초 기타 응답");
     }
 
     @Test

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -1050,11 +1050,11 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
 
         assertThat(subjectiveTexts).hasSize(2);
         assertThat(subjectiveTexts).extracting(JsonNode::asText)
-                .containsExactlyInAnyOrder("빠른 주관식 응답", "늦은 주관식 응답");
+                .containsExactly("빠른 주관식 응답", "늦은 주관식 응답");
 
         assertThat(fiveSecondTexts).hasSize(2);
         assertThat(fiveSecondTexts).extracting(JsonNode::asText)
-                .containsExactlyInAnyOrder("빠른 5초 응답", "늦은 5초 응답");
+                .containsExactly("빠른 5초 응답", "늦은 5초 응답");
     }
 
     @TestConfiguration(proxyBeanMethods = false)

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -818,9 +818,9 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         JsonNode result = reportData(actors.testId(), actors.makerToken()).path("reports").get(0).path("result");
         assertThat(result.path("aiSummary").asText()).isEqualTo("AI 요약 준비 중입니다.");
         assertThat(result.path("clusters").isArray()).isTrue();
-        JsonNode texts = result.path("texts");
-        assertThat(texts).hasSize(1);
-        assertThat(texts.get(0).asText()).isEqualTo("직접 입력 응답");
+        JsonNode otherTexts = result.path("otherTexts");
+        assertThat(otherTexts).hasSize(1);
+        assertThat(otherTexts.get(0).asText()).isEqualTo("직접 입력 응답");
     }
 
     @Test
@@ -1194,9 +1194,9 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         JsonNode result = reportData(actors.testId(), actors.makerToken()).path("reports").get(0).path("result");
         assertThat(result.path("aiSummary").asText()).isEqualTo("AI 요약 준비 중입니다.");
         assertThat(result.path("clusters").isArray()).isTrue();
-        JsonNode texts = result.path("texts");
-        assertThat(texts).hasSize(1);
-        assertThat(texts.get(0).asText()).isEqualTo("5초 기타 응답");
+        JsonNode otherTexts = result.path("otherTexts");
+        assertThat(otherTexts).hasSize(1);
+        assertThat(otherTexts.get(0).asText()).isEqualTo("5초 기타 응답");
     }
 
     @Test


### PR DESCRIPTION
This reverts commit 0f2b104b8aee070f455a610769421e23f067cf69.

  ## 📍 요약
  - AI 연동 전 주관식 응답 집계를 clusters(그룹핑) + texts(미리보기 샘플) 구조로 분리
  
  ## 🔗 관련 이슈
  - Closes #157
  
  ## 📌 변경 사항
  - [ ] 기능
  - [ ] 버그 수정
  - [x] 리팩토링
  - [ ] 문서
  - [ ] 테스트
  - [ ] 기타
  
  ## ✅ 작업 내용
  - `clusters`: exact-match 그룹핑, representative / count / responses 구조 (AI 연동 후 의미론적 유사도
  기반으로 교체 예정)
  - `texts`: createdAt 오름차순 기준 최대 15개 미리보기 샘플
  - `ReportHandlerUtils`에 공통 로직 추출, SUBJECTIVE / FIVE_SECOND / OBJECTIVE(isOther) 핸들러 일괄 적용
  
  ## 테스트
  - [x] 로컬 테스트 완료
  - 테스트 방법:
    - `./gradlew test --tests "server.MATE.integration.ReportEndToEndIntegrationTest"`
