### PR TITLE
fix: 테스트의 testStatus와 approvalStatus 통합

### DIFF
--- a/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
+++ b/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
@@ -28,7 +28,7 @@ public class AnswerController {
 
     @Operation(summary = "응답 전체 등록", description = """
             참여자가 테스트의 모든 문항에 대한 응답을 한 번에 제출합니다.
-            - 테스트가 진행 중(`IN_PROGRESS`)이고 승인(`ACCEPTED`) 상태여야 합니다.
+            - 테스트가 진행 중(`IN_PROGRESS`) 상태여야 합니다.
             - 목표 인원 수(`goalPpl`)이 초과된 경우 참여 불가합니다.
             - 이미 참여한 테스트에 중복 제출 불가합니다.
             - 응답(`answers`) 배열의 각 항목은 질문 유형(`type`) 필드로 구분합니다.

--- a/src/main/java/server/MATE/domain/report/controller/ReportController.java
+++ b/src/main/java/server/MATE/domain/report/controller/ReportController.java
@@ -31,9 +31,9 @@ public class ReportController {
             description = """
                     메이커가 자신의 테스트에 대한 질문 목록 및 질문 유형별 응답 리포트를 조회합니다. MKST_02 화면에 해당하는 api 입니다.
                     - 테스트 소유자(메이커)만 조회할 수 있습니다.
-                    - `testStatus`가 `IN_PROGRESS`이면 `reports`는 빈 리스트를 반환합니다.
+                    - `testStatus`가 `COMPLETED`가 아니면 `reports`는 빈 리스트를 반환합니다.
                     - `testStatus`가 `COMPLETED`이고 `reportStatus`가 `IN_PROGRESS`이면 집계 중으로 `reports`는 빈 리스트입니다.
-                    - `reportStatus`가 `COMPLETED`이면 질문 유형별 리포트가 포함됩니다.
+                    - `reportStatus`가 `COMPLETED`이면 `reports`를 반환합니다.
                     - `reports[].result` 구조는 질문 유형(`type`)마다 다릅니다. 아래 예시 응답을 참고해주세요.
                     - 버그 사항: questions 필드 삭제
                     """

--- a/src/main/java/server/MATE/domain/report/service/ReportService.java
+++ b/src/main/java/server/MATE/domain/report/service/ReportService.java
@@ -38,40 +38,43 @@ public class ReportService {
 
         List<QuestionSummaryItem> questionSummaries = questionRepository.findQuestionSummariesByTestId(testId);
         int questionCount = questionSummaries.size();
-
-        // 테스트가 진행 중이고, 리포트 집계가 시작되지 않은 상태. reports를 빈 리스트로 반환
-        if (test.getTestStatus() == TestStatus.IN_PROGRESS) {
-            return new ReportResponse(
-                    TestStatus.IN_PROGRESS,
-                    ReportStatus.PENDING,
-                    questionCount,
-                    test.getPplCount(),
-                    questionSummaries,
-                    List.of()
-            );
-        }
-
-        // 테스트가 완료이지만, 리포트 집계가 끝나지 않음. reportStatus를 업데이트하고 reports를 빈 리스트로 반환
         ReportStatus reportStatus = test.getReportStatus() != null ? test.getReportStatus() : ReportStatus.PENDING;
-        if (reportStatus != ReportStatus.COMPLETED) {
-            return new ReportResponse(
-                    TestStatus.COMPLETED,
-                    reportStatus,
-                    questionCount,
-                    test.getPplCount(),
-                    questionSummaries,
-                    List.of()
-            );
+
+        switch (test.getTestStatus()) {
+            case WAITING, IN_PROGRESS, REJECTED -> {
+                // 완료 전 상태이므로 집계 결과 없이 현재 리포트 상태만 반환함
+                return new ReportResponse(
+                        test.getTestStatus(),
+                        reportStatus,
+                        questionCount,
+                        test.getPplCount(),
+                        questionSummaries,
+                        List.of()
+                );
+            }
+            case COMPLETED -> {
+                // 테스트는 종료됐지만 집계가 끝나지 않았으면 빈 결과를 반환함
+                if (reportStatus != ReportStatus.COMPLETED) {
+                    return new ReportResponse(
+                            TestStatus.COMPLETED,
+                            reportStatus,
+                            questionCount,
+                            test.getPplCount(),
+                            questionSummaries,
+                            List.of()
+                    );
+                }
+            }
         }
 
-        // 테스트가 완료이고, 리포트 집계가 끝난 상태. 질문별 집계 결과를 반환
+        // 테스트가 종료됐고 리포트 집계가 끝났다면 리포트를 반환함
         List<Report> aggregations = reportRepository.findAllByTestId(testId);
 
         if (aggregations.size() != questionCount) {
             log.error("테스트 {} 리포트 조회 중 완전성 불일치 감지: questionCount={}, reportCount={}",
                     testId, questionCount, aggregations.size());
             return new ReportResponse(
-                    TestStatus.COMPLETED,
+                    test.getTestStatus(),
                     ReportStatus.FAILED,
                     questionCount,
                     test.getPplCount(),

--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -31,7 +31,7 @@ public class TestController {
             summary = "⚠️ 테스트 목록 조회",
             description = """
                     전체 테스트 요약 목록을 최신순으로 조회합니다. 발견 탭 HM_01 57 화면에 해당하는 api 입니다.
-                    테스트 등록 후 관리자 승인(`approvalStatus`)이 완료(`ACCEPTED`)되어야 조회됩니다.<br>
+                    `IN_PROGRESS`(진행 중) 이거나, `WAITING`(검수 중) 인 테스트를 반환합니다.
                     추후 페이지네이션 적용하여 무한 스크롤 지원하도록 리팩토링이 필요합니다.
 
                     - **thumbnailUrl**: 업로드된 이미지 중 첫 번째의 Public URL, 없으면 null을 반환
@@ -56,7 +56,7 @@ public class TestController {
                     승인 상태와 관계없이 삭제되지 않은 테스트를 모두 반환합니다.
                     
                     - **testCount**: 테스트 개수
-                    - **testStatus**: `IN_PROGRESS`(진행 중), `COMPLETED`(완료)
+                    - **testStatus**: `WAITING`(검수 중), `IN_PROGRESS`(진행 중), `COMPLETED`(종료), `REJECTED`(반려)
                     - **title**: 테스트 제목
                     - **pplCount**: 현재 참여 인원
                     - 버그 사항: 관리자 승인 상태별 조회 필터링
@@ -74,7 +74,7 @@ public class TestController {
             summary = "⚠️ 찜한 테스트 목록 조회",
             description = """
                     현재 로그인한 사용자가 찜한 테스트 목록을 찜한 시각 최신순으로 조회합니다. 관심 탭 HM_01 19 화면에 해당하는 api 입니다.<br>
-                    삭제되지 않았고 관리자 승인(`ACCEPTED`)이 완료된 테스트만 반환합니다.<br>
+                    삭제되지 않았고 진행 중(`IN_PROGRESS`)인 테스트만 반환합니다.<br>
                     추후 페이지네이션 적용하여 무한 스크롤 지원하도록 리팩토링이 필요합니다.
                     
                     - **testCount**: 테스트 개수

--- a/src/main/java/server/MATE/domain/test/entity/ApprovalStatus.java
+++ b/src/main/java/server/MATE/domain/test/entity/ApprovalStatus.java
@@ -1,7 +1,0 @@
-package server.MATE.domain.test.entity;
-
-public enum ApprovalStatus {
-    WAITING,
-    ACCEPTED,
-    REJECTED
-}

--- a/src/main/java/server/MATE/domain/test/entity/Test.java
+++ b/src/main/java/server/MATE/domain/test/entity/Test.java
@@ -52,10 +52,6 @@ public class Test extends BaseEntity {
     @Column(nullable = false, length = 20)
     private ReportStatus reportStatus = ReportStatus.PENDING;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private ApprovalStatus approvalStatus;
-
     @Column(nullable = false)
     private Integer goalPpl;
 
@@ -101,7 +97,7 @@ public class Test extends BaseEntity {
     }
 
     public void validateCanParticipate() {
-        if (this.approvalStatus != ApprovalStatus.ACCEPTED || this.testStatus != TestStatus.IN_PROGRESS) {
+        if (this.testStatus != TestStatus.IN_PROGRESS) {
             throw new BaseException(BaseErrorCode.PARTICIPATION_002);
         }
         if (this.pplCount >= this.goalPpl.longValue()) {
@@ -127,6 +123,14 @@ public class Test extends BaseEntity {
         this.testStatus = TestStatus.COMPLETED;
     }
 
+    public void start() {
+        this.testStatus = TestStatus.IN_PROGRESS;
+    }
+
+    public void reject() {
+        this.testStatus = TestStatus.REJECTED;
+    }
+
     public void startReportAggregation() {
         this.reportStatus = ReportStatus.IN_PROGRESS;
     }
@@ -146,15 +150,14 @@ public class Test extends BaseEntity {
     @Builder
     public Test(Long makerId, String title, String description, String serviceName,
                 String serviceDescription, List<String> imageKeys, Integer goalPpl, Integer reward,
-                TestStatus testStatus, ApprovalStatus approvalStatus) {
+                TestStatus testStatus) {
         this.makerId = makerId;
         this.title = title;
         this.description = description;
         this.serviceName = serviceName;
         this.serviceDescription = serviceDescription;
         if (imageKeys != null) this.imageKeys.addAll(imageKeys);
-        this.testStatus = testStatus == null ? TestStatus.IN_PROGRESS : testStatus;
-        this.approvalStatus = approvalStatus == null ? ApprovalStatus.ACCEPTED : approvalStatus; // Todo. 관리자 api 개발 후 WAITING으로 수정
+        this.testStatus = testStatus == null ? TestStatus.WAITING : testStatus;
         this.goalPpl = goalPpl == null ? 100 : goalPpl;
         this.reward = reward == null ? 300 : reward;
         this.pplCount = 0L;

--- a/src/main/java/server/MATE/domain/test/entity/TestStatus.java
+++ b/src/main/java/server/MATE/domain/test/entity/TestStatus.java
@@ -1,6 +1,8 @@
 package server.MATE.domain.test.entity;
 
 public enum TestStatus {
+    WAITING,
     IN_PROGRESS,
-    COMPLETED
+    COMPLETED,
+    REJECTED
 }

--- a/src/main/java/server/MATE/domain/test/repository/TestRepository.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestRepository.java
@@ -6,8 +6,8 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import server.MATE.domain.test.entity.ApprovalStatus;
 import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.entity.TestStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,7 +15,7 @@ import java.util.Optional;
 public interface TestRepository extends JpaRepository<Test, Long> {
 
     @EntityGraph(attributePaths = {"categories"})
-    List<Test> findAllByApprovalStatusAndDeletedAtIsNullOrderByCreatedAtDesc(ApprovalStatus approvalStatus);
+    List<Test> findAllByTestStatusAndDeletedAtIsNullOrderByCreatedAtDesc(TestStatus testStatus);
 
     List<Test> findAllByMakerIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long makerId);
 
@@ -25,17 +25,17 @@ public interface TestRepository extends JpaRepository<Test, Long> {
             join TestLike tl on tl.testId = t.id
             where tl.userId = :userId
               and t.deletedAt is null
-              and t.approvalStatus = :approvalStatus
+              and t.testStatus = :testStatus
             order by tl.createdAt desc
             """)
     List<Test> findLikedTestsByUserId(
             @Param("userId") Long userId,
-            @Param("approvalStatus") ApprovalStatus approvalStatus
+            @Param("testStatus") TestStatus testStatus
     );
 
     Optional<Test> findByIdAndDeletedAtIsNull(Long id);
 
-    Optional<Test> findByIdAndApprovalStatusAndDeletedAtIsNull(Long id, ApprovalStatus approvalStatus);
+    Optional<Test> findByIdAndTestStatusAndDeletedAtIsNull(Long id, TestStatus testStatus);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""

--- a/src/main/java/server/MATE/domain/test/service/TestPublishService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestPublishService.java
@@ -12,7 +12,6 @@ import server.MATE.domain.payment.entity.Payment;
 import server.MATE.domain.payment.repository.PaymentRepository;
 import server.MATE.domain.question.dto.request.QuestionCreateRequest;
 import server.MATE.domain.question.service.QuestionService;
-import server.MATE.domain.test.entity.ApprovalStatus;
 import server.MATE.domain.test.entity.Category;
 import server.MATE.domain.test.entity.Test;
 import server.MATE.domain.test.entity.TestStatus;
@@ -66,8 +65,7 @@ public class TestPublishService {
                 .imageKeys(draft.getImageKeys())
                 .goalPpl(payment.getGoalPpl())
                 .reward(payment.getReward())
-                .testStatus(TestStatus.IN_PROGRESS)
-                .approvalStatus(ApprovalStatus.ACCEPTED)
+                .testStatus(TestStatus.WAITING)
                 .build());
 
         if (draft.getCategories() != null && !draft.getCategories().isEmpty()) {

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -10,9 +10,9 @@ import server.MATE.domain.test.dto.response.LikedTestSummaryResponse;
 import server.MATE.domain.test.dto.response.MyTestSummaryItem;
 import server.MATE.domain.test.dto.response.MyTestSummaryResponse;
 import server.MATE.domain.test.dto.response.TestSummaryResponse;
-import server.MATE.domain.test.entity.ApprovalStatus;
 import server.MATE.domain.test.entity.Test;
 import server.MATE.domain.test.entity.TestLike;
+import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.domain.test.repository.TestLikeRepository;
 import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
@@ -34,7 +34,7 @@ public class TestService {
 
     @Transactional(readOnly = true)
     public List<TestSummaryResponse> listTests(Long userId) {
-        List<Test> tests = testRepository.findAllByApprovalStatusAndDeletedAtIsNullOrderByCreatedAtDesc(ApprovalStatus.ACCEPTED);
+        List<Test> tests = testRepository.findAllByTestStatusAndDeletedAtIsNullOrderByCreatedAtDesc(TestStatus.IN_PROGRESS);
         return toSummaryResponses(userId, tests);
     }
 
@@ -49,7 +49,7 @@ public class TestService {
 
     @Transactional(readOnly = true)
     public LikedTestSummaryResponse listLikedTests(Long userId) {
-        List<Test> tests = testRepository.findLikedTestsByUserId(userId, ApprovalStatus.ACCEPTED);
+        List<Test> tests = testRepository.findLikedTestsByUserId(userId, TestStatus.IN_PROGRESS);
         List<LikedTestSummaryItem> items = tests.stream()
                 .map(test -> LikedTestSummaryItem.from(test, toThumbnailUrl(test.getImageKeys())))
                 .toList();
@@ -58,7 +58,7 @@ public class TestService {
 
     @Transactional(readOnly = true)
     public TestDetailResponse getTest(Long testId) {
-        Test test = testRepository.findByIdAndApprovalStatusAndDeletedAtIsNull(testId, ApprovalStatus.ACCEPTED)
+        Test test = testRepository.findByIdAndTestStatusAndDeletedAtIsNull(testId, TestStatus.IN_PROGRESS)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
         return TestDetailResponse.from(test, toImageUrls(test.getImageKeys()));
     }

--- a/src/test/java/server/MATE/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/ReportServiceTest.java
@@ -1,0 +1,86 @@
+package server.MATE.domain.report.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import server.MATE.domain.question.repository.QuestionRepository;
+import server.MATE.domain.report.dto.response.ReportResponse;
+import server.MATE.domain.report.repository.ReportRepository;
+import server.MATE.domain.test.entity.ReportStatus;
+import server.MATE.domain.test.entity.TestStatus;
+import server.MATE.domain.test.repository.TestRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceTest {
+
+    @Mock
+    private TestRepository testRepository;
+
+    @Mock
+    private QuestionRepository questionRepository;
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @InjectMocks
+    private ReportService reportService;
+
+    private server.MATE.domain.test.entity.Test test;
+
+    @BeforeEach
+    void setUp() {
+        test = server.MATE.domain.test.entity.Test.builder()
+                .makerId(1L)
+                .title("테스트")
+                .description("설명")
+                .serviceName("서비스")
+                .serviceDescription("서비스 설명")
+                .imageKeys(List.of())
+                .testStatus(TestStatus.WAITING)
+                .build();
+        ReflectionTestUtils.setField(test, "id", 10L);
+    }
+
+    @Test
+    @DisplayName("완료 전 테스트는 현재 reportStatus를 유지해서 반환한다")
+    void getReport_returnsCurrentReportStatusForNonCompletedTest() {
+        ReflectionTestUtils.setField(test, "testStatus", TestStatus.IN_PROGRESS);
+        ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.FAILED);
+
+        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+        given(questionRepository.findQuestionSummariesByTestId(10L)).willReturn(List.of());
+
+        ReportResponse response = reportService.getReport(10L, 1L);
+
+        assertThat(response.testStatus()).isEqualTo(TestStatus.IN_PROGRESS);
+        assertThat(response.reportStatus()).isEqualTo(ReportStatus.FAILED);
+        assertThat(response.reports()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("반려된 테스트도 reportStatus를 덮어쓰지 않고 반환한다")
+    void getReport_returnsCurrentReportStatusForRejectedTest() {
+        ReflectionTestUtils.setField(test, "testStatus", TestStatus.REJECTED);
+        ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.FAILED);
+
+        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+        given(questionRepository.findQuestionSummariesByTestId(10L)).willReturn(List.of());
+
+        ReportResponse response = reportService.getReport(10L, 1L);
+
+        assertThat(response.testStatus()).isEqualTo(TestStatus.REJECTED);
+        assertThat(response.reportStatus()).isEqualTo(ReportStatus.FAILED);
+        assertThat(response.reports()).isEmpty();
+    }
+}

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -12,7 +12,6 @@ import server.MATE.domain.test.dto.response.LikedTestSummaryItem;
 import server.MATE.domain.test.dto.response.TestLikeResponse;
 import server.MATE.domain.test.dto.response.LikedTestSummaryResponse;
 import server.MATE.domain.test.dto.response.MyTestSummaryResponse;
-import server.MATE.domain.test.entity.ApprovalStatus;
 import server.MATE.domain.test.entity.Category;
 import server.MATE.domain.test.entity.TestLike;
 import server.MATE.domain.test.entity.TestStatus;
@@ -85,13 +84,14 @@ class TestServiceTest {
         assertThat(response.tests()).hasSize(1);
         assertThat(response.tests().getFirst().id()).isEqualTo(TEST_ID);
         assertThat(response.tests().getFirst().title()).isEqualTo("내 테스트");
-        assertThat(response.tests().getFirst().testStatus()).isEqualTo(TestStatus.IN_PROGRESS);
+        assertThat(response.tests().getFirst().testStatus()).isEqualTo(TestStatus.WAITING);
         assertThat(response.tests().getFirst().pplCount()).isZero();
     }
 
     @Test
     void 내가_찜한_테스트_목록을_조회한다() {
-        given(testRepository.findLikedTestsByUserId(MAKER_ID, ApprovalStatus.ACCEPTED))
+        ReflectionTestUtils.setField(test, "testStatus", TestStatus.IN_PROGRESS);
+        given(testRepository.findLikedTestsByUserId(MAKER_ID, TestStatus.IN_PROGRESS))
                 .willReturn(List.of(test));
 
         LikedTestSummaryResponse response = testService.listLikedTests(MAKER_ID);

--- a/src/test/java/server/MATE/integration/BaseQuestionAnswerEndToEndTest.java
+++ b/src/test/java/server/MATE/integration/BaseQuestionAnswerEndToEndTest.java
@@ -25,6 +25,7 @@ import server.MATE.domain.question.repository.ScaleRepository;
 import server.MATE.domain.question.repository.SubjectiveRepository;
 import server.MATE.domain.question.repository.TreeTestRepository;
 import server.MATE.domain.question.service.QuestionService;
+import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.domain.users.entity.Users;
 import server.MATE.domain.users.repository.UsersRepository;
@@ -126,6 +127,7 @@ abstract class BaseQuestionAnswerEndToEndTest {
                 .serviceName("서비스")
                 .serviceDescription("서비스 설명")
                 .imageKeys(List.of())
+                .testStatus(TestStatus.IN_PROGRESS)
                 .build());
         return new TestActors(
                 maker.getId(),

--- a/src/test/java/server/MATE/integration/DraftPaymentPublishEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/DraftPaymentPublishEndToEndIntegrationTest.java
@@ -175,7 +175,7 @@ class DraftPaymentPublishEndToEndIntegrationTest {
         assertThat(savedTest.getTitle()).isEqualTo("신규 테스트");
         assertThat(savedTest.getGoalPpl()).isEqualTo(5);
         assertThat(savedTest.getReward()).isEqualTo(300);
-        assertThat(savedTest.getTestStatus()).isEqualTo(TestStatus.IN_PROGRESS);
+        assertThat(savedTest.getTestStatus()).isEqualTo(TestStatus.WAITING);
         assertThat(questionRepository.countByTestIdAndDeletedAtIsNull(testId)).isEqualTo(1);
 
         JsonNode questions = getQuestions(testId, makerToken);
@@ -377,6 +377,9 @@ class DraftPaymentPublishEndToEndIntegrationTest {
         updateDraft(draftId, makerToken, draftPayload());
         Long paymentId = createPayment(draftId, makerToken);
         long testId = executePayment(paymentId, makerToken).path("testId").asLong();
+        var publishedTest = testRepository.findById(testId).orElseThrow();
+        publishedTest.start();
+        testRepository.saveAndFlush(publishedTest);
 
         JsonNode listBody = parseBody(mockMvc.perform(get("/api/v1/tests")
                         .header("Authorization", testerToken))
@@ -421,8 +424,8 @@ class DraftPaymentPublishEndToEndIntegrationTest {
                 .andReturn());
 
         assertThat(answerBody.path("message").asText()).isEqualTo("응답이 등록되었습니다.");
-        var publishedTest = testRepository.findById(testId).orElseThrow();
-        assertThat(publishedTest.getPplCount()).isEqualTo(1L);
+        var answeredTest = testRepository.findById(testId).orElseThrow();
+        assertThat(answeredTest.getPplCount()).isEqualTo(1L);
         assertThat(participationRepository.count()).isEqualTo(1L);
         assertThat(answerRepository.count()).isEqualTo(1L);
     }

--- a/src/test/java/server/MATE/integration/QuestionAnswerEndToEndFailureIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/QuestionAnswerEndToEndFailureIntegrationTest.java
@@ -7,7 +7,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
-import server.MATE.domain.test.entity.ApprovalStatus;
+import server.MATE.domain.test.entity.TestStatus;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -675,7 +675,7 @@ class QuestionAnswerEndToEndFailureIntegrationTest extends BaseQuestionAnswerEnd
         long questionId = getSingleQuestion(actors.testId(), actors.makerToken()).path("questionId").asLong();
 
         server.MATE.domain.test.entity.Test test = testRepository.findById(actors.testId()).orElseThrow();
-        ReflectionTestUtils.setField(test, "approvalStatus", ApprovalStatus.WAITING);
+        ReflectionTestUtils.setField(test, "testStatus", TestStatus.WAITING);
         testRepository.saveAndFlush(test);
 
         submitAnswerExpectingError(actors.testId(), actors.testerToken(), """


### PR DESCRIPTION
## 📍 요약
- testStatus와 approvalStatus로 분리/관리했던 구조에서 testStatus로 통합함

## 🔗 관련 이슈
- Closes #162

## 📌 변경 사항
- [ ] 기능
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- testStatus를 기존 관리자 승인값까지 포함하여`WAITING`(검수 중), `IN_PROGRESS`(진행 중), `COMPLETED`(종료), `REJECTED`(반려)로 구성
- 연관 도메인에서 testStatus 초기값을 WAITING으로 수정
- 리포트 집계 시점에 대한 조건 분기를 수정하고 테스트 코드로 검증함

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew test
