### PR TITLE
feat: PromotionGateway 추상화 및 리워드 지급 로직 구현

### DIFF
--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -11,6 +11,7 @@ import server.MATE.domain.answer.repository.AnswerRepository;
 import server.MATE.domain.answer.service.handler.AnswerCreateHandler;
 import server.MATE.domain.participation.entity.Participation;
 import server.MATE.domain.participation.repository.ParticipationRepository;
+import server.MATE.domain.promotion.event.PromotionRewardRequestEvent;
 import server.MATE.domain.question.dto.response.AnswerQuestionTypeView;
 import server.MATE.domain.question.entity.CardSorting;
 import server.MATE.domain.question.entity.FiveSecond;
@@ -135,8 +136,15 @@ public class AnswerService {
             answers.add(handlerMap.get(item.type()).build(participation.getId(), item, context));
         }
 
-        // 응답 저장 후 참여자 수를 갱신하고, 목표 인원 도달 시 테스트 완료 및 리포트 집계 이벤트 발행
+        // 응답 저장 후 참여자 수를 갱신하고, 리워드 지급 이벤트 발행
+        // 목표 인원을 만족한다면, 리포트 집계 이벤트 발행
         answerRepository.saveAll(answers);
+        eventPublisher.publishEvent(new PromotionRewardRequestEvent(
+                participation.getId(),
+                testId,
+                testerId,
+                test.getReward()
+        ));
         test.incrementPplCount();
         if (test.getPplCount() >= test.getGoalPpl()) {
             test.complete();

--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -26,7 +26,7 @@ import server.MATE.domain.question.repository.QuestionRepository;
 import server.MATE.domain.question.repository.ScaleRepository;
 import server.MATE.domain.question.repository.TreeTestRepository;
 import server.MATE.domain.test.entity.Test;
-import server.MATE.domain.test.event.TestCompletedEvent;
+import server.MATE.domain.test.event.TestCompleteEvent;
 import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
@@ -149,7 +149,7 @@ public class AnswerService {
         if (test.getPplCount() >= test.getGoalPpl()) {
             test.complete();
             test.startReportAggregation();
-            eventPublisher.publishEvent(new TestCompletedEvent(testId));
+            eventPublisher.publishEvent(new TestCompleteEvent(testId));
         }
         return AnswerBatchCreateResponse.from(participation);
     }

--- a/src/main/java/server/MATE/domain/promotion/entity/PromotionReward.java
+++ b/src/main/java/server/MATE/domain/promotion/entity/PromotionReward.java
@@ -1,0 +1,141 @@
+package server.MATE.domain.promotion.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import server.MATE.global.common.entity.BaseEntity;
+
+@Getter
+@Entity
+@Table(
+        name = "promotion_reward",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = "participation_id")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PromotionReward extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "participation_id", nullable = false, unique = true)
+    private Long participationId;
+
+    @Column(nullable = false)
+    private Long testId;
+
+    @Column(nullable = false)
+    private Long testerId;
+
+    private Long tossUserKey;
+
+    @Column(nullable = false)
+    private Integer rewardAmount;
+
+    @Column(length = 100)
+    private String promotionCode;
+
+    @Column(length = 500)
+    private String rewardKey;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private PromotionRewardStatus status;
+
+    @Column(length = 50)
+    private String lastErrorCode;
+
+    @Column(length = 500)
+    private String lastErrorReason;
+
+    private LocalDateTime executedAt;
+
+    private LocalDateTime resolvedAt;
+
+    @Builder
+    public PromotionReward(
+            Long participationId,
+            Long testId,
+            Long testerId,
+            Long tossUserKey,
+            Integer rewardAmount,
+            String promotionCode,
+            String rewardKey,
+            PromotionRewardStatus status,
+            String lastErrorCode,
+            String lastErrorReason,
+            LocalDateTime executedAt,
+            LocalDateTime resolvedAt
+    ) {
+        this.participationId = participationId;
+        this.testId = testId;
+        this.testerId = testerId;
+        this.tossUserKey = tossUserKey;
+        this.rewardAmount = rewardAmount;
+        this.promotionCode = promotionCode;
+        this.rewardKey = rewardKey;
+        this.status = status == null ? PromotionRewardStatus.READY : status;
+        this.lastErrorCode = lastErrorCode;
+        this.lastErrorReason = lastErrorReason;
+        this.executedAt = executedAt;
+        this.resolvedAt = resolvedAt;
+    }
+
+    public boolean isInFlightOrCompleted() {
+        return status == PromotionRewardStatus.KEY_ISSUED
+                || status == PromotionRewardStatus.EXECUTED
+                || status == PromotionRewardStatus.PENDING
+                || status == PromotionRewardStatus.SUCCEEDED;
+    }
+
+    public void assignTossUserKey(Long tossUserKey) {
+        this.tossUserKey = tossUserKey;
+    }
+
+    public void issueKey(String promotionCode, String rewardKey) {
+        this.promotionCode = promotionCode;
+        this.rewardKey = rewardKey;
+        this.status = PromotionRewardStatus.KEY_ISSUED;
+        this.lastErrorCode = null;
+        this.lastErrorReason = null;
+        this.resolvedAt = null;
+    }
+
+    public void markExecuted(LocalDateTime executedAt) {
+        this.status = PromotionRewardStatus.EXECUTED;
+        this.executedAt = executedAt;
+    }
+
+    public void markPending() {
+        this.status = PromotionRewardStatus.PENDING;
+        this.resolvedAt = null;
+    }
+
+    public void markSucceeded(LocalDateTime resolvedAt) {
+        this.status = PromotionRewardStatus.SUCCEEDED;
+        this.resolvedAt = resolvedAt;
+        this.lastErrorCode = null;
+        this.lastErrorReason = null;
+    }
+
+    public void markFailed(String errorCode, String errorReason, LocalDateTime resolvedAt) {
+        this.status = PromotionRewardStatus.FAILED;
+        this.lastErrorCode = errorCode;
+        this.lastErrorReason = errorReason;
+        this.resolvedAt = resolvedAt;
+    }
+}

--- a/src/main/java/server/MATE/domain/promotion/entity/PromotionRewardStatus.java
+++ b/src/main/java/server/MATE/domain/promotion/entity/PromotionRewardStatus.java
@@ -1,0 +1,10 @@
+package server.MATE.domain.promotion.entity;
+
+public enum PromotionRewardStatus {
+    READY,
+    KEY_ISSUED,
+    EXECUTED,
+    PENDING,
+    SUCCEEDED,
+    FAILED
+}

--- a/src/main/java/server/MATE/domain/promotion/event/PromotionRewardEventListener.java
+++ b/src/main/java/server/MATE/domain/promotion/event/PromotionRewardEventListener.java
@@ -1,0 +1,26 @@
+package server.MATE.domain.promotion.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import server.MATE.domain.promotion.service.MockPromotionService;
+
+@Component
+@RequiredArgsConstructor
+public class PromotionRewardEventListener {
+
+    private final MockPromotionService mockPromotionService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onPromotionRewardRequested(PromotionRewardRequestEvent event) {
+        mockPromotionService.grant(
+                event.participationId(),
+                event.testId(),
+                event.testerId(),
+                event.rewardAmount()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/promotion/event/PromotionRewardRequestEvent.java
+++ b/src/main/java/server/MATE/domain/promotion/event/PromotionRewardRequestEvent.java
@@ -1,0 +1,9 @@
+package server.MATE.domain.promotion.event;
+
+public record PromotionRewardRequestEvent(
+        Long participationId,
+        Long testId,
+        Long testerId,
+        Integer rewardAmount
+) {
+}

--- a/src/main/java/server/MATE/domain/promotion/mock/MockPromotionGateway.java
+++ b/src/main/java/server/MATE/domain/promotion/mock/MockPromotionGateway.java
@@ -1,0 +1,39 @@
+package server.MATE.domain.promotion.mock;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.springframework.stereotype.Component;
+import server.MATE.toss.dto.request.TossPromotionExecuteRequest;
+import server.MATE.toss.dto.request.TossPromotionGetKeyRequest;
+import server.MATE.toss.dto.request.TossPromotionResultRequest;
+import server.MATE.toss.dto.response.TossPromotionExecuteResponse;
+import server.MATE.toss.dto.response.TossPromotionExecutionStatus;
+import server.MATE.toss.dto.response.TossPromotionKeyResponse;
+import server.MATE.toss.dto.response.TossPromotionResultResponse;
+import server.MATE.toss.gateway.TossPromotionGateway;
+
+@Component
+public class MockPromotionGateway implements TossPromotionGateway {
+
+    @Override
+    public TossPromotionKeyResponse getKey(TossPromotionGetKeyRequest request) {
+        return new TossPromotionKeyResponse(encode("promotion:" + request.tossUserKey()));
+    }
+
+    @Override
+    public TossPromotionExecuteResponse executePromotion(TossPromotionExecuteRequest request) {
+        return new TossPromotionExecuteResponse(request.key());
+    }
+
+    @Override
+    public TossPromotionResultResponse getExecutionResult(TossPromotionResultRequest request) {
+        return new TossPromotionResultResponse(TossPromotionExecutionStatus.SUCCESS);
+    }
+
+    private String encode(String value) {
+        return Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/server/MATE/domain/promotion/repository/PromotionRewardRepository.java
+++ b/src/main/java/server/MATE/domain/promotion/repository/PromotionRewardRepository.java
@@ -1,0 +1,11 @@
+package server.MATE.domain.promotion.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import server.MATE.domain.promotion.entity.PromotionReward;
+
+public interface PromotionRewardRepository extends JpaRepository<PromotionReward, Long> {
+
+    Optional<PromotionReward> findByParticipationId(Long participationId);
+}

--- a/src/main/java/server/MATE/domain/promotion/service/MockPromotionService.java
+++ b/src/main/java/server/MATE/domain/promotion/service/MockPromotionService.java
@@ -3,7 +3,6 @@ package server.MATE.domain.promotion.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import server.MATE.toss.dto.request.TossPromotionExecuteRequest;
 import server.MATE.toss.dto.request.TossPromotionGetKeyRequest;
 import server.MATE.toss.dto.request.TossPromotionResultRequest;
@@ -26,7 +25,6 @@ public class MockPromotionService {
     private final PromotionFailureStateService promotionFailureStateService;
     private final TossPromotionGateway tossPromotionGateway;
 
-    @Transactional
     public void grant(Long participationId, Long testId, Long testerId, Integer rewardAmount) {
         PromotionPrepareService.PromotionPreparation preparation =
                 promotionPrepareService.prepare(participationId, testId, testerId, rewardAmount);

--- a/src/main/java/server/MATE/domain/promotion/service/MockPromotionService.java
+++ b/src/main/java/server/MATE/domain/promotion/service/MockPromotionService.java
@@ -1,0 +1,117 @@
+package server.MATE.domain.promotion.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.toss.dto.request.TossPromotionExecuteRequest;
+import server.MATE.toss.dto.request.TossPromotionGetKeyRequest;
+import server.MATE.toss.dto.request.TossPromotionResultRequest;
+import server.MATE.toss.dto.response.TossPromotionExecutionStatus;
+import server.MATE.toss.exception.TossApiException;
+import server.MATE.toss.gateway.TossPromotionGateway;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MockPromotionService {
+
+    private static final String MOCK_PROMOTION_ERROR_CODE_GATEWAY = "MOCK_PROMOTION_GATEWAY_ERROR";
+    private static final String MOCK_PROMOTION_ERROR_CODE_EXECUTION_FAILED = "MOCK_PROMOTION_EXECUTION_FAILED";
+    private static final String MOCK_PROMOTION_ERROR_REASON_EXECUTION_FAILED = "Mock promotion execution result is FAILED.";
+
+    private final PromotionPrepareService promotionPrepareService;
+    private final PromotionIssueStateService promotionIssueStateService;
+    private final PromotionExecuteStateService promotionExecuteStateService;
+    private final PromotionFailureStateService promotionFailureStateService;
+    private final TossPromotionGateway tossPromotionGateway;
+
+    @Transactional
+    public void grant(Long participationId, Long testId, Long testerId, Integer rewardAmount) {
+        PromotionPrepareService.PromotionPreparation preparation =
+                promotionPrepareService.prepare(participationId, testId, testerId, rewardAmount);
+
+        if (preparation.skipped()) {
+            log.debug("MOCK_PROMOTION skipped. participationId={}, testId={}, testerId={}",
+                    participationId, testId, testerId);
+            return;
+        }
+        if (preparation.shouldFail()) {
+            promotionFailureStateService.markFailed(
+                    preparation.rewardId(),
+                    preparation.errorCode(),
+                    preparation.errorReason()
+            );
+            log.warn("MOCK_PROMOTION preparation failed. participationId={}, testId={}, testerId={}, code={}",
+                    participationId, testId, testerId, preparation.errorCode());
+            return;
+        }
+
+        try {
+            var keyResponse = tossPromotionGateway.getKey(
+                    new TossPromotionGetKeyRequest(preparation.tossUserKey())
+            );
+            promotionIssueStateService.markKeyIssued(
+                    preparation.rewardId(),
+                    preparation.promotionCode(),
+                    keyResponse.key()
+            );
+            log.info("MOCK_PROMOTION key issued. participationId={}, rewardId={}",
+                    participationId, preparation.rewardId());
+
+            tossPromotionGateway.executePromotion(new TossPromotionExecuteRequest(
+                    preparation.tossUserKey(),
+                    preparation.promotionCode(),
+                    keyResponse.key(),
+                    preparation.rewardAmount()
+            ));
+            promotionExecuteStateService.markExecuted(preparation.rewardId());
+            log.info("MOCK_PROMOTION execute requested. participationId={}, rewardId={}",
+                    participationId, preparation.rewardId());
+
+            var result = tossPromotionGateway.getExecutionResult(new TossPromotionResultRequest(
+                    preparation.tossUserKey(),
+                    preparation.promotionCode(),
+                    keyResponse.key()
+            ));
+
+            if (result.status() == TossPromotionExecutionStatus.SUCCESS) {
+                promotionExecuteStateService.markSucceeded(preparation.rewardId());
+                log.info("MOCK_PROMOTION succeeded. participationId={}, rewardId={}",
+                        participationId, preparation.rewardId());
+                return;
+            }
+            if (result.status() == TossPromotionExecutionStatus.PENDING) {
+                promotionExecuteStateService.markPending(preparation.rewardId());
+                log.info("MOCK_PROMOTION pending. participationId={}, rewardId={}",
+                        participationId, preparation.rewardId());
+                return;
+            }
+
+            promotionFailureStateService.markFailed(
+                    preparation.rewardId(),
+                    MOCK_PROMOTION_ERROR_CODE_EXECUTION_FAILED,
+                    MOCK_PROMOTION_ERROR_REASON_EXECUTION_FAILED
+            );
+            log.warn("MOCK_PROMOTION failed by result. participationId={}, rewardId={}",
+                    participationId, preparation.rewardId());
+        } catch (TossApiException e) {
+            promotionFailureStateService.markFailed(
+                    preparation.rewardId(),
+                    "MOCK_" + e.getErrorCode().getCode(),
+                    e.getMessage()
+            );
+            log.warn("MOCK_PROMOTION gateway failed with toss exception. participationId={}, code={}",
+                    participationId, e.getErrorCode().getCode(), e);
+            throw e;
+        } catch (RuntimeException e) {
+            promotionFailureStateService.markFailed(
+                    preparation.rewardId(),
+                    MOCK_PROMOTION_ERROR_CODE_GATEWAY,
+                    e.getMessage()
+            );
+            log.warn("MOCK_PROMOTION gateway failed. participationId={}", participationId, e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/server/MATE/domain/promotion/service/PromotionExecuteStateService.java
+++ b/src/main/java/server/MATE/domain/promotion/service/PromotionExecuteStateService.java
@@ -1,0 +1,51 @@
+package server.MATE.domain.promotion.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.promotion.entity.PromotionReward;
+import server.MATE.domain.promotion.repository.PromotionRewardRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class PromotionExecuteStateService {
+
+    private final PromotionRewardRepository promotionRewardRepository;
+    private final Clock clock;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public PromotionReward markExecuted(Long rewardId) {
+        PromotionReward reward = findReward(rewardId);
+        reward.markExecuted(now());
+        return reward;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public PromotionReward markPending(Long rewardId) {
+        PromotionReward reward = findReward(rewardId);
+        reward.markPending();
+        return reward;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public PromotionReward markSucceeded(Long rewardId) {
+        PromotionReward reward = findReward(rewardId);
+        reward.markSucceeded(now());
+        return reward;
+    }
+
+    private PromotionReward findReward(Long rewardId) {
+        return promotionRewardRepository.findById(rewardId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.COMMON_999));
+    }
+
+    private LocalDateTime now() {
+        return LocalDateTime.now(clock);
+    }
+}

--- a/src/main/java/server/MATE/domain/promotion/service/PromotionFailureStateService.java
+++ b/src/main/java/server/MATE/domain/promotion/service/PromotionFailureStateService.java
@@ -1,0 +1,29 @@
+package server.MATE.domain.promotion.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.promotion.entity.PromotionReward;
+import server.MATE.domain.promotion.repository.PromotionRewardRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class PromotionFailureStateService {
+
+    private final PromotionRewardRepository promotionRewardRepository;
+    private final Clock clock;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public PromotionReward markFailed(Long rewardId, String errorCode, String errorReason) {
+        PromotionReward reward = promotionRewardRepository.findById(rewardId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.COMMON_999));
+        reward.markFailed(errorCode, errorReason, LocalDateTime.now(clock));
+        return reward;
+    }
+}

--- a/src/main/java/server/MATE/domain/promotion/service/PromotionIssueStateService.java
+++ b/src/main/java/server/MATE/domain/promotion/service/PromotionIssueStateService.java
@@ -1,0 +1,25 @@
+package server.MATE.domain.promotion.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.promotion.entity.PromotionReward;
+import server.MATE.domain.promotion.repository.PromotionRewardRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+@Service
+@RequiredArgsConstructor
+public class PromotionIssueStateService {
+
+    private final PromotionRewardRepository promotionRewardRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public PromotionReward markKeyIssued(Long rewardId, String promotionCode, String rewardKey) {
+        PromotionReward reward = promotionRewardRepository.findById(rewardId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.COMMON_999));
+        reward.issueKey(promotionCode, rewardKey);
+        return reward;
+    }
+}

--- a/src/main/java/server/MATE/domain/promotion/service/PromotionPrepareService.java
+++ b/src/main/java/server/MATE/domain/promotion/service/PromotionPrepareService.java
@@ -1,7 +1,5 @@
 package server.MATE.domain.promotion.service;
 
-import java.util.Optional;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -50,9 +48,10 @@ public class PromotionPrepareService {
             );
         }
 
-        Optional<TossAccount> tossAccount = tossAccountRepository.findByUserId(testerId)
-                .filter(TossAccount::isLinked);
-        if (tossAccount.isEmpty()) {
+        TossAccount tossAccount = tossAccountRepository.findByUserId(testerId)
+                .filter(TossAccount::isLinked)
+                .orElse(null);
+        if (tossAccount == null) {
             return PromotionPreparation.failure(
                     reward.getId(),
                     LOCAL_ERROR_CODE_NOT_LINKED,
@@ -60,8 +59,8 @@ public class PromotionPrepareService {
             );
         }
 
-        reward.assignTossUserKey(tossAccount.get().getTossUserKey());
-        return PromotionPreparation.ready(reward.getId(), tossAccount.get().getTossUserKey(), promotionCode, rewardAmount);
+        reward.assignTossUserKey(tossAccount.getTossUserKey());
+        return PromotionPreparation.ready(reward.getId(), tossAccount.getTossUserKey(), promotionCode, rewardAmount);
     }
 
     public record PromotionPreparation(

--- a/src/main/java/server/MATE/domain/promotion/service/PromotionPrepareService.java
+++ b/src/main/java/server/MATE/domain/promotion/service/PromotionPrepareService.java
@@ -1,0 +1,93 @@
+package server.MATE.domain.promotion.service;
+
+import java.util.Optional;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.promotion.entity.PromotionReward;
+import server.MATE.domain.promotion.repository.PromotionRewardRepository;
+import server.MATE.domain.users.entity.TossAccount;
+import server.MATE.domain.users.repository.TossAccountRepository;
+import server.MATE.toss.config.TossPromotionProperties;
+
+@Service
+@RequiredArgsConstructor
+public class PromotionPrepareService {
+
+    static final String LOCAL_ERROR_CODE_NOT_LINKED = "TOSS_ACCOUNT_NOT_LINKED";
+    static final String LOCAL_ERROR_CODE_MISSING_PROMOTION = "PROMOTION_CODE_MISSING";
+
+    private final PromotionRewardRepository promotionRewardRepository;
+    private final TossAccountRepository tossAccountRepository;
+    private final TossPromotionProperties tossPromotionProperties;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public PromotionPreparation prepare(Long participationId, Long testId, Long testerId, Integer rewardAmount) {
+        if (!tossPromotionProperties.answer().enabled() || rewardAmount == null || rewardAmount <= 0) {
+            return PromotionPreparation.skip();
+        }
+
+        PromotionReward reward = promotionRewardRepository.findByParticipationId(participationId)
+                .orElseGet(() -> promotionRewardRepository.save(PromotionReward.builder()
+                        .participationId(participationId)
+                        .testId(testId)
+                        .testerId(testerId)
+                        .rewardAmount(rewardAmount)
+                        .build()));
+
+        if (reward.isInFlightOrCompleted()) {
+            return PromotionPreparation.skip();
+        }
+
+        String promotionCode = tossPromotionProperties.answer().promotionCode();
+        if (promotionCode == null || promotionCode.isBlank()) {
+            return PromotionPreparation.failure(
+                    reward.getId(),
+                    LOCAL_ERROR_CODE_MISSING_PROMOTION,
+                    "프로모션 코드가 설정되지 않았습니다."
+            );
+        }
+
+        Optional<TossAccount> tossAccount = tossAccountRepository.findByUserId(testerId)
+                .filter(TossAccount::isLinked);
+        if (tossAccount.isEmpty()) {
+            return PromotionPreparation.failure(
+                    reward.getId(),
+                    LOCAL_ERROR_CODE_NOT_LINKED,
+                    "연결된 토스 계정을 찾을 수 없습니다."
+            );
+        }
+
+        reward.assignTossUserKey(tossAccount.get().getTossUserKey());
+        return PromotionPreparation.ready(reward.getId(), tossAccount.get().getTossUserKey(), promotionCode, rewardAmount);
+    }
+
+    public record PromotionPreparation(
+            Long rewardId,
+            Long tossUserKey,
+            String promotionCode,
+            Integer rewardAmount,
+            String errorCode,
+            String errorReason,
+            boolean skipped,
+            boolean ready
+    ) {
+        static PromotionPreparation skip() {
+            return new PromotionPreparation(null, null, null, null, null, null, true, false);
+        }
+
+        static PromotionPreparation ready(Long rewardId, Long tossUserKey, String promotionCode, Integer rewardAmount) {
+            return new PromotionPreparation(rewardId, tossUserKey, promotionCode, rewardAmount, null, null, false, true);
+        }
+
+        static PromotionPreparation failure(Long rewardId, String errorCode, String errorReason) {
+            return new PromotionPreparation(rewardId, null, null, null, errorCode, errorReason, false, false);
+        }
+
+        public boolean shouldFail() {
+            return !skipped && !ready;
+        }
+    }
+}

--- a/src/main/java/server/MATE/domain/report/event/ReportAggregateEventListener.java
+++ b/src/main/java/server/MATE/domain/report/event/ReportAggregateEventListener.java
@@ -1,23 +1,23 @@
-package server.MATE.domain.report.service;
+package server.MATE.domain.report.event;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
-import server.MATE.domain.test.event.TestCompletedEvent;
+import server.MATE.domain.test.event.TestCompleteEvent;
 
 @Component
 @RequiredArgsConstructor
-public class ReportAggregationEventListener {
+public class ReportAggregateEventListener {
 
-    private final ReportAggregationService reportAggregationService;
+    private final ReportAggregateService reportAggregateService;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void onTestCompleted(TestCompletedEvent event) {
+    public void onTestCompleted(TestCompleteEvent event) {
         // answer 저장 -> testStatus, reportStatus 변경 보장
         // event 발행하면 report 집계를 시작
-        reportAggregationService.aggregate(event.testId());
+        reportAggregateService.aggregate(event.testId());
     }
 }

--- a/src/main/java/server/MATE/domain/report/event/ReportAggregateService.java
+++ b/src/main/java/server/MATE/domain/report/event/ReportAggregateService.java
@@ -1,4 +1,4 @@
-package server.MATE.domain.report.service;
+package server.MATE.domain.report.event;
 
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
@@ -23,6 +23,7 @@ import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.repository.QuestionRepository;
 import server.MATE.domain.report.entity.Report;
 import server.MATE.domain.report.repository.ReportRepository;
+import server.MATE.domain.report.service.ReportHandler;
 import server.MATE.domain.test.entity.Test;
 import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
@@ -30,7 +31,7 @@ import server.MATE.global.common.exception.BaseException;
 
 @Slf4j
 @Service
-public class ReportAggregationService {
+public class ReportAggregateService {
 
     private final QuestionRepository questionRepository;
     private final AnswerRepository answerRepository;
@@ -38,11 +39,11 @@ public class ReportAggregationService {
     private final TestRepository testRepository;
     private final Map<QuestionType, ReportHandler> handlerMap;
 
-    public ReportAggregationService(QuestionRepository questionRepository,
-                                    AnswerRepository answerRepository,
-                                    ReportRepository reportRepository,
-                                    TestRepository testRepository,
-                                    List<ReportHandler> handlers) {
+    public ReportAggregateService(QuestionRepository questionRepository,
+                                  AnswerRepository answerRepository,
+                                  ReportRepository reportRepository,
+                                  TestRepository testRepository,
+                                  List<ReportHandler> handlers) {
         this.questionRepository = questionRepository;
         this.answerRepository = answerRepository;
         this.reportRepository = reportRepository;

--- a/src/main/java/server/MATE/domain/test/event/TestCompleteEvent.java
+++ b/src/main/java/server/MATE/domain/test/event/TestCompleteEvent.java
@@ -1,0 +1,4 @@
+package server.MATE.domain.test.event;
+
+public record TestCompleteEvent(Long testId) {
+}

--- a/src/main/java/server/MATE/domain/test/event/TestCompletedEvent.java
+++ b/src/main/java/server/MATE/domain/test/event/TestCompletedEvent.java
@@ -1,4 +1,0 @@
-package server.MATE.domain.test.event;
-
-public record TestCompletedEvent(Long testId) {
-}

--- a/src/main/java/server/MATE/toss/config/TossClientConfig.java
+++ b/src/main/java/server/MATE/toss/config/TossClientConfig.java
@@ -20,6 +20,7 @@ import server.MATE.toss.crypto.TossCryptoProperties;
 @Configuration
 @EnableConfigurationProperties({
         TossProperties.class,
+        TossPromotionProperties.class,
         TossCryptoProperties.class,
         TokenEncryptionProperties.class
 })

--- a/src/main/java/server/MATE/toss/config/TossPromotionProperties.java
+++ b/src/main/java/server/MATE/toss/config/TossPromotionProperties.java
@@ -1,0 +1,21 @@
+package server.MATE.toss.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "toss.promotion")
+public record TossPromotionProperties(
+        Answer answer
+) {
+
+    public TossPromotionProperties {
+        if (answer == null) {
+            answer = new Answer(false, null);
+        }
+    }
+
+    public record Answer(
+            boolean enabled,
+            String promotionCode
+    ) {
+    }
+}

--- a/src/main/java/server/MATE/toss/dto/request/TossPromotionExecuteRequest.java
+++ b/src/main/java/server/MATE/toss/dto/request/TossPromotionExecuteRequest.java
@@ -1,0 +1,12 @@
+package server.MATE.toss.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record TossPromotionExecuteRequest(
+        Long tossUserKey,
+        String promotionCode,
+        String key,
+        Integer amount
+) {
+}

--- a/src/main/java/server/MATE/toss/dto/request/TossPromotionGetKeyRequest.java
+++ b/src/main/java/server/MATE/toss/dto/request/TossPromotionGetKeyRequest.java
@@ -1,0 +1,6 @@
+package server.MATE.toss.dto.request;
+
+public record TossPromotionGetKeyRequest(
+        Long tossUserKey
+) {
+}

--- a/src/main/java/server/MATE/toss/dto/request/TossPromotionResultRequest.java
+++ b/src/main/java/server/MATE/toss/dto/request/TossPromotionResultRequest.java
@@ -1,0 +1,8 @@
+package server.MATE.toss.dto.request;
+
+public record TossPromotionResultRequest(
+        Long tossUserKey,
+        String promotionCode,
+        String key
+) {
+}

--- a/src/main/java/server/MATE/toss/dto/response/TossPromotionExecuteResponse.java
+++ b/src/main/java/server/MATE/toss/dto/response/TossPromotionExecuteResponse.java
@@ -1,0 +1,6 @@
+package server.MATE.toss.dto.response;
+
+public record TossPromotionExecuteResponse(
+        String key
+) {
+}

--- a/src/main/java/server/MATE/toss/dto/response/TossPromotionExecutionStatus.java
+++ b/src/main/java/server/MATE/toss/dto/response/TossPromotionExecutionStatus.java
@@ -1,0 +1,7 @@
+package server.MATE.toss.dto.response;
+
+public enum TossPromotionExecutionStatus {
+    PENDING,
+    SUCCESS,
+    FAILED
+}

--- a/src/main/java/server/MATE/toss/dto/response/TossPromotionKeyResponse.java
+++ b/src/main/java/server/MATE/toss/dto/response/TossPromotionKeyResponse.java
@@ -1,0 +1,6 @@
+package server.MATE.toss.dto.response;
+
+public record TossPromotionKeyResponse(
+        String key
+) {
+}

--- a/src/main/java/server/MATE/toss/dto/response/TossPromotionResultResponse.java
+++ b/src/main/java/server/MATE/toss/dto/response/TossPromotionResultResponse.java
@@ -1,0 +1,6 @@
+package server.MATE.toss.dto.response;
+
+public record TossPromotionResultResponse(
+        TossPromotionExecutionStatus status
+) {
+}

--- a/src/main/java/server/MATE/toss/exception/TossErrorCode.java
+++ b/src/main/java/server/MATE/toss/exception/TossErrorCode.java
@@ -17,7 +17,15 @@ public enum TossErrorCode implements ErrorCode {
     TOSS_006(HttpStatus.BAD_GATEWAY, "TOSS_006", "토스 내부 서버 오류가 발생했습니다."),
     TOSS_007(HttpStatus.NOT_FOUND, "TOSS_007", "토스 userKey를 찾을 수 없습니다."),
     TOSS_008(HttpStatus.NOT_FOUND, "TOSS_008", "토스 사용자 정보를 찾을 수 없습니다."),
-    TOSS_009(HttpStatus.TOO_MANY_REQUESTS, "TOSS_009", "토스 인증서 조회 가능 횟수를 초과했습니다.");
+    TOSS_009(HttpStatus.TOO_MANY_REQUESTS, "TOSS_009", "토스 인증서 조회 가능 횟수를 초과했습니다."),
+    TOSS_010(HttpStatus.BAD_GATEWAY, "TOSS_010", "토스 프로모션 정보를 찾을 수 없습니다."),
+    TOSS_011(HttpStatus.BAD_GATEWAY, "TOSS_011", "토스 프로모션이 실행 중이 아닙니다."),
+    TOSS_012(HttpStatus.BAD_GATEWAY, "TOSS_012", "토스 프로모션 실행에 실패했습니다."),
+    TOSS_013(HttpStatus.BAD_GATEWAY, "TOSS_013", "토스 프로모션 지급 내역을 찾을 수 없습니다."),
+    TOSS_014(HttpStatus.BAD_GATEWAY, "TOSS_014", "토스 프로모션 예산이 부족합니다."),
+    TOSS_015(HttpStatus.CONFLICT, "TOSS_015", "토스 프로모션 실행 키가 이미 사용되었습니다."),
+    TOSS_016(HttpStatus.BAD_GATEWAY, "TOSS_016", "토스 프로모션 1회 지급 금액 한도를 초과했습니다."),
+    TOSS_017(HttpStatus.BAD_GATEWAY, "TOSS_017", "토스 프로모션 총 예산 한도를 초과했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;
@@ -36,6 +44,14 @@ public enum TossErrorCode implements ErrorCode {
             case "USER_KEY_NOT_FOUND" -> TOSS_007;
             case "USER_NOT_FOUND" -> TOSS_008;
             case "BAD_REQUEST_RETRIEVE_CERT_RESULT_EXCEEDED_LIMIT" -> TOSS_009;
+            case "4100" -> TOSS_010;
+            case "4104", "4105", "4108", "4109" -> TOSS_011;
+            case "4110" -> TOSS_012;
+            case "4111" -> TOSS_013;
+            case "4112" -> TOSS_014;
+            case "4113" -> TOSS_015;
+            case "4114" -> TOSS_016;
+            case "4116" -> TOSS_017;
             default -> TOSS_001;
         };
     }

--- a/src/main/java/server/MATE/toss/gateway/TossPromotionGateway.java
+++ b/src/main/java/server/MATE/toss/gateway/TossPromotionGateway.java
@@ -1,0 +1,17 @@
+package server.MATE.toss.gateway;
+
+import server.MATE.toss.dto.request.TossPromotionExecuteRequest;
+import server.MATE.toss.dto.request.TossPromotionGetKeyRequest;
+import server.MATE.toss.dto.request.TossPromotionResultRequest;
+import server.MATE.toss.dto.response.TossPromotionExecuteResponse;
+import server.MATE.toss.dto.response.TossPromotionKeyResponse;
+import server.MATE.toss.dto.response.TossPromotionResultResponse;
+
+public interface TossPromotionGateway {
+
+    TossPromotionKeyResponse getKey(TossPromotionGetKeyRequest request);
+
+    TossPromotionExecuteResponse executePromotion(TossPromotionExecuteRequest request);
+
+    TossPromotionResultResponse getExecutionResult(TossPromotionResultRequest request);
+}

--- a/src/main/java/server/MATE/toss/response/TossResultType.java
+++ b/src/main/java/server/MATE/toss/response/TossResultType.java
@@ -2,5 +2,10 @@ package server.MATE.toss.response;
 
 public enum TossResultType {
     SUCCESS,
-    FAIL
+    FAIL,
+    HTTP_TIMEOUT,
+    NETWORK_ERROR,
+    EXECUTION_FAIL,
+    INTERRUPTED,
+    INTERNAL_ERROR
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -33,6 +33,10 @@ toss:
     ssl:
       enabled: ${TOSS_API_SSL_ENABLED:true}
       bundle: toss
+  promotion:
+    answer:
+      enabled: ${TOSS_PROMOTION_ANSWER_ENABLED:false}
+      promotion-code: ${TOSS_PROMOTION_ANSWER_CODE:}
   callback:
     basic-auth-header: ${TOSS_CALLBACK_BASIC_AUTH_HEADER:}
   crypto:

--- a/src/test/java/server/MATE/domain/promotion/service/MockPromotionServiceTest.java
+++ b/src/test/java/server/MATE/domain/promotion/service/MockPromotionServiceTest.java
@@ -1,0 +1,118 @@
+package server.MATE.domain.promotion.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import server.MATE.toss.dto.request.TossPromotionExecuteRequest;
+import server.MATE.toss.dto.request.TossPromotionGetKeyRequest;
+import server.MATE.toss.dto.request.TossPromotionResultRequest;
+import server.MATE.toss.dto.response.TossPromotionExecuteResponse;
+import server.MATE.toss.dto.response.TossPromotionExecutionStatus;
+import server.MATE.toss.dto.response.TossPromotionKeyResponse;
+import server.MATE.toss.dto.response.TossPromotionResultResponse;
+import server.MATE.toss.gateway.TossPromotionGateway;
+
+@ExtendWith(MockitoExtension.class)
+class MockPromotionServiceTest {
+
+    @Mock
+    private PromotionPrepareService promotionPrepareService;
+
+    @Mock
+    private PromotionIssueStateService promotionIssueStateService;
+
+    @Mock
+    private PromotionExecuteStateService promotionExecuteStateService;
+
+    @Mock
+    private PromotionFailureStateService promotionFailureStateService;
+
+    @Mock
+    private TossPromotionGateway tossPromotionGateway;
+
+    private MockPromotionService mockPromotionService;
+
+    @BeforeEach
+    void setUp() {
+        mockPromotionService = new MockPromotionService(
+                promotionPrepareService,
+                promotionIssueStateService,
+                promotionExecuteStateService,
+                promotionFailureStateService,
+                tossPromotionGateway
+        );
+    }
+
+    @Test
+    @DisplayName("준비 결과가 ready면 key 발급, execute, result 조회 순서로 상태를 반영한다")
+    void grantsRewardSuccessfully() {
+        given(promotionPrepareService.prepare(10L, 20L, 30L, 300))
+                .willReturn(PromotionPrepareService.PromotionPreparation.ready(1L, 777L, "promo-answer", 300));
+        given(tossPromotionGateway.getKey(any(TossPromotionGetKeyRequest.class)))
+                .willReturn(new TossPromotionKeyResponse("reward-key"));
+        given(tossPromotionGateway.executePromotion(any(TossPromotionExecuteRequest.class)))
+                .willReturn(new TossPromotionExecuteResponse("reward-key"));
+        given(tossPromotionGateway.getExecutionResult(any(TossPromotionResultRequest.class)))
+                .willReturn(new TossPromotionResultResponse(TossPromotionExecutionStatus.SUCCESS));
+
+        mockPromotionService.grant(10L, 20L, 30L, 300);
+
+        verify(promotionIssueStateService).markKeyIssued(1L, "promo-answer", "reward-key");
+        verify(promotionExecuteStateService).markExecuted(1L);
+        verify(promotionExecuteStateService).markSucceeded(1L);
+    }
+
+    @Test
+    @DisplayName("준비 결과가 skip이면 외부 provider를 호출하지 않는다")
+    void skipsWhenPreparationReturnsSkip() {
+        given(promotionPrepareService.prepare(10L, 20L, 30L, 300))
+                .willReturn(PromotionPrepareService.PromotionPreparation.skip());
+
+        mockPromotionService.grant(10L, 20L, 30L, 300);
+
+        verify(promotionPrepareService).prepare(10L, 20L, 30L, 300);
+    }
+
+    @Test
+    @DisplayName("준비 결과가 fail이면 실패 상태만 반영한다")
+    void marksFailedWhenPreparationFails() {
+        given(promotionPrepareService.prepare(10L, 20L, 30L, 300))
+                .willReturn(PromotionPrepareService.PromotionPreparation.failure(
+                        1L,
+                        PromotionPrepareService.LOCAL_ERROR_CODE_NOT_LINKED,
+                        "연결된 토스 계정을 찾을 수 없습니다."
+                ));
+
+        mockPromotionService.grant(10L, 20L, 30L, 300);
+
+        verify(promotionFailureStateService).markFailed(
+                1L,
+                PromotionPrepareService.LOCAL_ERROR_CODE_NOT_LINKED,
+                "연결된 토스 계정을 찾을 수 없습니다."
+        );
+    }
+
+    @Test
+    @DisplayName("result가 pending이면 pending 상태를 반영한다")
+    void marksPendingWhenResultIsPending() {
+        given(promotionPrepareService.prepare(10L, 20L, 30L, 300))
+                .willReturn(PromotionPrepareService.PromotionPreparation.ready(1L, 777L, "promo-answer", 300));
+        given(tossPromotionGateway.getKey(any(TossPromotionGetKeyRequest.class)))
+                .willReturn(new TossPromotionKeyResponse("reward-key"));
+        given(tossPromotionGateway.executePromotion(any(TossPromotionExecuteRequest.class)))
+                .willReturn(new TossPromotionExecuteResponse("reward-key"));
+        given(tossPromotionGateway.getExecutionResult(any(TossPromotionResultRequest.class)))
+                .willReturn(new TossPromotionResultResponse(TossPromotionExecutionStatus.PENDING));
+
+        mockPromotionService.grant(10L, 20L, 30L, 300);
+
+        verify(promotionExecuteStateService).markPending(1L);
+    }
+}

--- a/src/test/java/server/MATE/domain/promotion/service/PromotionPrepareServiceTest.java
+++ b/src/test/java/server/MATE/domain/promotion/service/PromotionPrepareServiceTest.java
@@ -1,0 +1,126 @@
+package server.MATE.domain.promotion.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import server.MATE.domain.promotion.entity.PromotionReward;
+import server.MATE.domain.promotion.entity.PromotionRewardStatus;
+import server.MATE.domain.promotion.repository.PromotionRewardRepository;
+import server.MATE.domain.users.entity.TossAccount;
+import server.MATE.domain.users.entity.Users;
+import server.MATE.domain.users.repository.TossAccountRepository;
+import server.MATE.toss.config.TossPromotionProperties;
+
+@ExtendWith(MockitoExtension.class)
+class PromotionPrepareServiceTest {
+
+    @Mock
+    private PromotionRewardRepository promotionRewardRepository;
+
+    @Mock
+    private TossAccountRepository tossAccountRepository;
+
+    private PromotionPrepareService promotionPrepareService;
+
+    @BeforeEach
+    void setUp() {
+        promotionPrepareService = new PromotionPrepareService(
+                promotionRewardRepository,
+                tossAccountRepository,
+                new TossPromotionProperties(new TossPromotionProperties.Answer(true, "promo-answer"))
+        );
+    }
+
+    @Test
+    @DisplayName("enabled가 false면 skip한다")
+    void skipsWhenDisabled() {
+        PromotionPrepareService service = new PromotionPrepareService(
+                promotionRewardRepository,
+                tossAccountRepository,
+                new TossPromotionProperties(new TossPromotionProperties.Answer(false, "promo-answer"))
+        );
+
+        var result = service.prepare(10L, 20L, 30L, 300);
+
+        assertThat(result.skipped()).isTrue();
+    }
+
+    @Test
+    @DisplayName("진행 중이거나 완료된 지급 건이면 skip한다")
+    void skipsWhenRewardAlreadyInFlightOrCompleted() {
+        PromotionReward reward = PromotionReward.builder()
+                .participationId(10L)
+                .testId(20L)
+                .testerId(30L)
+                .rewardAmount(300)
+                .status(PromotionRewardStatus.SUCCEEDED)
+                .build();
+
+        given(promotionRewardRepository.findByParticipationId(10L)).willReturn(Optional.of(reward));
+
+        var result = promotionPrepareService.prepare(10L, 20L, 30L, 300);
+
+        assertThat(result.skipped()).isTrue();
+    }
+
+    @Test
+    @DisplayName("linked toss account가 없으면 failure를 반환한다")
+    void failsWhenTossAccountIsMissing() {
+        PromotionReward reward = PromotionReward.builder()
+                .participationId(10L)
+                .testId(20L)
+                .testerId(30L)
+                .rewardAmount(300)
+                .build();
+        ReflectionTestUtils.setField(reward, "id", 1L);
+
+        given(promotionRewardRepository.findByParticipationId(10L)).willReturn(Optional.empty());
+        given(promotionRewardRepository.save(any(PromotionReward.class))).willReturn(reward);
+        given(tossAccountRepository.findByUserId(30L)).willReturn(Optional.empty());
+
+        var result = promotionPrepareService.prepare(10L, 20L, 30L, 300);
+
+        assertThat(result.shouldFail()).isTrue();
+        assertThat(result.errorCode()).isEqualTo(PromotionPrepareService.LOCAL_ERROR_CODE_NOT_LINKED);
+    }
+
+    @Test
+    @DisplayName("준비가 완료되면 rewardId, tossUserKey, promotionCode를 반환한다")
+    void returnsReadyPreparation() {
+        PromotionReward reward = PromotionReward.builder()
+                .participationId(10L)
+                .testId(20L)
+                .testerId(30L)
+                .rewardAmount(300)
+                .build();
+        ReflectionTestUtils.setField(reward, "id", 1L);
+
+        TossAccount tossAccount = TossAccount.builder()
+                .user(Users.builder().ci("ci").name("tester").build())
+                .tossUserKey(777L)
+                .isLinked(true)
+                .build();
+
+        given(promotionRewardRepository.findByParticipationId(10L)).willReturn(Optional.empty());
+        given(promotionRewardRepository.save(any(PromotionReward.class))).willReturn(reward);
+        given(tossAccountRepository.findByUserId(30L)).willReturn(Optional.of(tossAccount));
+
+        var result = promotionPrepareService.prepare(10L, 20L, 30L, 300);
+
+        assertThat(result.ready()).isTrue();
+        assertThat(result.rewardId()).isEqualTo(1L);
+        assertThat(result.tossUserKey()).isEqualTo(777L);
+        assertThat(result.promotionCode()).isEqualTo("promo-answer");
+        assertThat(reward.getTossUserKey()).isEqualTo(777L);
+    }
+}

--- a/src/test/java/server/MATE/domain/report/service/ReportAggregateServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/ReportAggregateServiceTest.java
@@ -12,6 +12,7 @@ import server.MATE.domain.answer.repository.AnswerRepository;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.repository.QuestionRepository;
 import server.MATE.domain.report.entity.Report;
+import server.MATE.domain.report.event.ReportAggregateService;
 import server.MATE.domain.report.repository.ReportRepository;
 import server.MATE.domain.test.entity.ReportStatus;
 import server.MATE.domain.test.repository.TestRepository;
@@ -24,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
-class ReportAggregationServiceTest {
+class ReportAggregateServiceTest {
 
     @Mock
     private QuestionRepository questionRepository;
@@ -38,14 +39,14 @@ class ReportAggregationServiceTest {
     @Mock
     private TestRepository testRepository;
 
-    private ReportAggregationService reportAggregationService;
+    private ReportAggregateService reportAggregateService;
 
     private server.MATE.domain.test.entity.Test test;
     private final Long TEST_ID = 10L;
 
     @BeforeEach
     void setUp() {
-        reportAggregationService = new ReportAggregationService(
+        reportAggregateService = new ReportAggregateService(
                 questionRepository,
                 answerRepository,
                 reportRepository,
@@ -75,7 +76,7 @@ class ReportAggregationServiceTest {
         given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
         given(reportRepository.findAllByTestId(TEST_ID)).willReturn(List.of(report1, report2));
 
-        List<Report> recovered = reportAggregationService.recover(
+        List<Report> recovered = reportAggregateService.recover(
                 new DataIntegrityViolationException("duplicate key"), TEST_ID);
 
         assertThat(recovered).containsExactly(report1, report2);
@@ -93,7 +94,7 @@ class ReportAggregationServiceTest {
         given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
         given(reportRepository.findAllByTestId(TEST_ID)).willReturn(List.of(report1, report2));
 
-        List<Report> recovered = reportAggregationService.recover(
+        List<Report> recovered = reportAggregateService.recover(
                 new RuntimeException("aggregate failed"), TEST_ID);
 
         assertThat(recovered).containsExactly(report1, report2);
@@ -107,7 +108,7 @@ class ReportAggregationServiceTest {
         given(reportRepository.countByTestId(TEST_ID)).willReturn(1L);
         given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
 
-        List<Report> recovered = reportAggregationService.recover(
+        List<Report> recovered = reportAggregateService.recover(
                 new DataIntegrityViolationException("duplicate key"), TEST_ID);
 
         assertThat(recovered).isEmpty();
@@ -121,7 +122,7 @@ class ReportAggregationServiceTest {
         given(reportRepository.countByTestId(TEST_ID)).willReturn(0L);
         given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
 
-        List<Report> recovered = reportAggregationService.recover(
+        List<Report> recovered = reportAggregateService.recover(
                 new RuntimeException("aggregate failed"), TEST_ID);
 
         assertThat(recovered).isEmpty();

--- a/src/test/java/server/MATE/integration/BaseQuestionAnswerEndToEndTest.java
+++ b/src/test/java/server/MATE/integration/BaseQuestionAnswerEndToEndTest.java
@@ -14,6 +14,7 @@ import server.MATE.domain.answer.repository.AnswerRepository;
 import server.MATE.domain.auth.jwt.JwtProvider;
 import server.MATE.domain.auth.jwt.TokenType;
 import server.MATE.domain.participation.repository.ParticipationRepository;
+import server.MATE.domain.promotion.repository.PromotionRewardRepository;
 import server.MATE.domain.question.dto.request.QuestionCreateRequest;
 import server.MATE.domain.question.dto.response.QuestionCreateResponse;
 import server.MATE.domain.question.repository.AbTestRepository;
@@ -27,7 +28,9 @@ import server.MATE.domain.question.repository.TreeTestRepository;
 import server.MATE.domain.question.service.QuestionService;
 import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.domain.users.entity.TossAccount;
 import server.MATE.domain.users.entity.Users;
+import server.MATE.domain.users.repository.TossAccountRepository;
 import server.MATE.domain.users.repository.UsersRepository;
 import server.MATE.global.storage.FileStorageService;
 
@@ -89,6 +92,12 @@ abstract class BaseQuestionAnswerEndToEndTest {
     @Autowired
     protected AnswerRepository answerRepository;
 
+    @Autowired
+    protected PromotionRewardRepository promotionRewardRepository;
+
+    @Autowired
+    protected TossAccountRepository tossAccountRepository;
+
     @PersistenceContext
     protected EntityManager entityManager;
 
@@ -97,6 +106,8 @@ abstract class BaseQuestionAnswerEndToEndTest {
 
     @AfterEach
     void tearDownBase() {
+        promotionRewardRepository.deleteAll();
+        tossAccountRepository.deleteAll();
         answerRepository.deleteAll();
         participationRepository.deleteAll();
         treeTestRepository.deleteAll();
@@ -140,6 +151,16 @@ abstract class BaseQuestionAnswerEndToEndTest {
 
     protected String bearerToken(Users user) {
         return "Bearer " + jwtProvider.generateToken(user.getId(), user.getRole().name(), TokenType.ACCESS);
+    }
+
+    protected TossAccount linkTossAccount(Users user, Long tossUserKey) {
+        return tossAccountRepository.save(TossAccount.builder()
+                .user(user)
+                .tossUserKey(tossUserKey)
+                .isLinked(true)
+                .lastLoginAt(java.time.LocalDateTime.now())
+                .lastTokenRefreshedAt(java.time.LocalDateTime.now())
+                .build());
     }
 
     protected JsonNode seedQuestion(Long testId, String token, String payload) throws Exception {

--- a/src/test/java/server/MATE/integration/QuestionAnswerPromotionIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/QuestionAnswerPromotionIntegrationTest.java
@@ -1,0 +1,58 @@
+package server.MATE.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import server.MATE.domain.promotion.entity.PromotionRewardStatus;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+        "toss.promotion.answer.enabled=true",
+        "toss.promotion.answer.promotion-code=test-answer-promotion"
+})
+class QuestionAnswerPromotionIntegrationTest extends BaseQuestionAnswerEndToEndTest {
+
+    @Test
+    @DisplayName("응답 등록 후 linked toss account가 있으면 mock promotion 지급 row가 성공 상태로 저장된다")
+    void submitsAnswerAndCreatesSucceededPromotionReward() throws Exception {
+        TestActors actors = createActors();
+        linkTossAccount(usersRepository.findById(actors.testerId()).orElseThrow(), 777L);
+        createSingleSubjectiveQuestion(actors.testId(), actors.makerToken());
+        long questionId = getSingleQuestion(actors.testId(), actors.makerToken()).path("questionId").asLong();
+
+        var response = submitAnswerExpectSuccess(actors.testId(), actors.testerToken(), """
+                {
+                  "answers": [
+                    {
+                      "type": "SUBJECTIVE",
+                      "questionId": %d,
+                      "text": "프로모션 지급 검증 응답"
+                    }
+                  ]
+                }
+                """.formatted(questionId));
+
+        long participationId = response.path("data").path("participationId").asLong();
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    var reward = promotionRewardRepository.findByParticipationId(participationId).orElseThrow();
+                    assertThat(reward.getTesterId()).isEqualTo(actors.testerId());
+                    assertThat(reward.getTossUserKey()).isEqualTo(777L);
+                    assertThat(reward.getPromotionCode()).isEqualTo("test-answer-promotion");
+                    assertThat(reward.getStatus()).isEqualTo(PromotionRewardStatus.SUCCEEDED);
+                    assertThat(reward.getRewardKey()).isNotBlank();
+                });
+    }
+}

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -14,9 +14,8 @@ import org.springframework.test.context.ActiveProfiles;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.report.entity.Report;
 import server.MATE.domain.report.repository.ReportRepository;
-import server.MATE.domain.report.service.ReportAggregationService;
+import server.MATE.domain.report.event.ReportAggregateService;
 import server.MATE.domain.test.entity.ReportStatus;
-import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.support.time.MutableClock;
 
 import java.time.Duration;
@@ -39,7 +38,7 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
     private static final Instant DEFAULT_TEST_INSTANT = Instant.parse("2026-01-01T00:00:00Z");
 
     @Autowired
-    private ReportAggregationService reportAggregationService;
+    private ReportAggregateService reportAggregateService;
 
     @Autowired
     private ReportRepository reportRepository;
@@ -1121,7 +1120,7 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         List<Report> existingReports = reportRepository.findAllByTestId(actors.testId());
         JsonNode before = reportData(actors.testId(), actors.makerToken());
 
-        List<Report> reusedReports = reportAggregationService.aggregate(actors.testId());
+        List<Report> reusedReports = reportAggregateService.aggregate(actors.testId());
 
         server.MATE.domain.test.entity.Test updated = testRepository.findById(actors.testId()).orElseThrow();
         JsonNode after = reportData(actors.testId(), actors.makerToken());
@@ -1261,7 +1260,7 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
                 .build());
 
         completeTestStatusOnly(actors.testId());
-        reportAggregationService.aggregate(actors.testId());
+        reportAggregateService.aggregate(actors.testId());
 
         server.MATE.domain.test.entity.Test updated = testRepository.findById(actors.testId()).orElseThrow();
         assertThat(updated.getReportStatus()).isEqualTo(ReportStatus.FAILED);
@@ -1324,7 +1323,7 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         server.MATE.domain.test.entity.Test test = testRepository.findById(testId).orElseThrow();
         test.complete();
         testRepository.save(test);
-        reportAggregationService.aggregate(testId);
+        reportAggregateService.aggregate(testId);
     }
 
     private void completeTestStatusOnly(Long testId) {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -24,6 +24,10 @@ jwt:
 toss:
   api:
     enabled: false
+  promotion:
+    answer:
+      enabled: false
+      promotion-code: test-answer-promotion
   crypto:
     decryption-key: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
     aad: test-aad


### PR DESCRIPTION
## 📍 요약
- 테스트 응답 등록 후 mock 프로모션 리워드 지급 플로우를 추가하고, promotion 구조를 payment와 같은 방식으로 설계함

## 🔗 관련 이슈
- Closes #163 

## 📌 변경 사항
- [x] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [x] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- 응답 등록 후 PromotionRewardRequestEvent를 발행하고 mock 프로모션 리워드 지급 로직을 연결함
- promotion 구조를 payment와 유사하게 prepare / state service / orchestration으로 분리
- 응답 등록 → 리워드 지급 성공까지 확인하는 단위/통합 테스트를 추가

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew test --tests server.MATE.domain.promotion.service.MockPromotionServiceTest --tests server.MATE.domain.promotion.service.PromotionPrepareServiceTest --tests server.MATE.integration.QuestionAnswerPromotionIntegrationTest
  - ./gradlew test --tests server.MATE.integration.QuestionAnswerEndToEndIntegrationTest
  - 로컬에서 응답 등록 API 호출 후 promotion_reward 엔티티 조회
