### PR TITLE
fix: 질문 목록 조회시 필터링 수정 및 필드 누락 해결

### DIFF
--- a/src/main/java/server/MATE/domain/question/controller/QuestionController.java
+++ b/src/main/java/server/MATE/domain/question/controller/QuestionController.java
@@ -528,12 +528,11 @@ public class QuestionController {
         return ResponseEntity.ok(ApiResponse.ok("질문 상세 조회했습니다.", questionDetailResponse));
     }
 
-    @Operation(summary = "⚠️ 질문 목록 조회", description = """
+    @Operation(summary = "✔️ 질문 목록 조회", description = """
             testId에 해당하는 테스트의 질문 목록 정보를 조회합니다. 통계의 질문 탭 MKST_01 화면에 해당하는 api입니다.
             - 테스트 메이커만 조회할 수 있습니다.
-            - 테스트가 종료된 경우에만 조회할 수 있습니다.
-            - 질문 개수, 테스트 참여자 수, 질문 목록을 반환합니다.
-            - 버그 사항: testStatus 필드 추가, 테스트 종료 시점 관계없이 조회 가능하도록 수정
+            - 테스트 종료 여부와 관계없이 조회할 수 있습니다.
+            - 테스트 상태, 질문 개수, 테스트 참여자 수, 질문 목록을 반환합니다.
             """)
     @GetMapping("/summary")
     public ResponseEntity<ApiResponse<QuestionSummaryResponse>> getQuestionSummary(

--- a/src/main/java/server/MATE/domain/question/dto/response/QuestionSummaryResponse.java
+++ b/src/main/java/server/MATE/domain/question/dto/response/QuestionSummaryResponse.java
@@ -1,11 +1,15 @@
 package server.MATE.domain.question.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import server.MATE.domain.test.entity.TestStatus;
 
 import java.util.List;
 
 @Schema(description = "질문 목록 조회 응답")
 public record QuestionSummaryResponse(
+        @Schema(description = "테스트 상태 (WAITING / IN_PROGRESS / COMPLETED / REJECTED)", example = "IN_PROGRESS")
+        TestStatus testStatus,
+
         @Schema(description = "질문 개수", example = "7")
         int questionCount,
 

--- a/src/main/java/server/MATE/domain/question/service/QuestionService.java
+++ b/src/main/java/server/MATE/domain/question/service/QuestionService.java
@@ -153,10 +153,10 @@ public class QuestionService {
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
         if (!test.getMakerId().equals(makerId)) throw new BaseException(BaseErrorCode.TEST_005);
-        if (test.getTestStatus() != TestStatus.COMPLETED) throw new BaseException(BaseErrorCode.TEST_006);
 
         List<QuestionSummaryItem> questions = questionRepository.findQuestionSummariesByTestId(testId);
         return new QuestionSummaryResponse(
+                test.getTestStatus(),
                 questions.size(),
                 test.getPplCount(),
                 questions

--- a/src/main/java/server/MATE/domain/report/controller/ReportController.java
+++ b/src/main/java/server/MATE/domain/report/controller/ReportController.java
@@ -17,7 +17,7 @@ import server.MATE.domain.report.service.ReportService;
 import server.MATE.global.common.response.ApiResponse;
 import server.MATE.global.security.principal.AuthenticatedUser;
 
-@Tag(name = "[REPORT] 통계 API", description = "테스트 결과 통계 관련 API")
+@Tag(name = "[REPORT] 리포트 API", description = "테스트 리포트 관련 API")
 @RestController
 @RequestMapping("/api/v1/tests/{testId}/report")
 @SecurityRequirement(name = "JWT")
@@ -27,15 +27,14 @@ public class ReportController {
     private final ReportService reportService;
 
     @Operation(
-            summary = "⚠️ 리포트 전체 조회",
+            summary = "✔️ 리포트 전체 조회",
             description = """
-                    메이커가 자신의 테스트에 대한 질문 목록 및 질문 유형별 응답 리포트를 조회합니다. MKST_02 화면에 해당하는 api 입니다.
+                    메이커가 자신의 테스트에 대한 질문 유형별 응답 리포트를 조회합니다. MKST_02 화면에 해당하는 api 입니다.
                     - 테스트 소유자(메이커)만 조회할 수 있습니다.
                     - `testStatus`가 `COMPLETED`가 아니면 `reports`는 빈 리스트를 반환합니다.
                     - `testStatus`가 `COMPLETED`이고 `reportStatus`가 `IN_PROGRESS`이면 집계 중으로 `reports`는 빈 리스트입니다.
                     - `reportStatus`가 `COMPLETED`이면 `reports`를 반환합니다.
                     - `reports[].result` 구조는 질문 유형(`type`)마다 다릅니다. 아래 예시 응답을 참고해주세요.
-                    - 버그 사항: questions 필드 삭제
                     """
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -56,10 +55,6 @@ public class ReportController {
                                                 "reportStatus": "PENDING",
                                                 "questionCount": 2,
                                                 "participantCount": 3,
-                                                "questions": [
-                                                  { "questionId": 1, "sequence": 1, "title": "첫 번째 질문", "type": "SUBJECTIVE" },
-                                                  { "questionId": 2, "sequence": 2, "title": "두 번째 질문", "type": "SCALE" }
-                                                ],
                                                 "reports": []
                                               }
                                             }
@@ -78,9 +73,6 @@ public class ReportController {
                                                 "reportStatus": "COMPLETED",
                                                 "questionCount": 1,
                                                 "participantCount": 5,
-                                                "questions": [
-                                                  { "questionId": 1, "sequence": 1, "title": "서비스에서 불편한 점은?", "type": "SUBJECTIVE" }
-                                                ],
                                                 "reports": [
                                                   {
                                                     "questionId": 1,
@@ -118,9 +110,6 @@ public class ReportController {
                                                 "reportStatus": "COMPLETED",
                                                 "questionCount": 1,
                                                 "participantCount": 10,
-                                                "questions": [
-                                                  { "questionId": 2, "sequence": 1, "title": "자주 사용하는 기능은?", "type": "OBJECTIVE" }
-                                                ],
                                                 "reports": [
                                                   {
                                                     "questionId": 2,
@@ -158,9 +147,6 @@ public class ReportController {
                                                 "reportStatus": "COMPLETED",
                                                 "questionCount": 1,
                                                 "participantCount": 4,
-                                                "questions": [
-                                                  { "questionId": 3, "sequence": 1, "title": "화면에서 가장 먼저 눈에 띈 것은?", "type": "FIVE_SECOND" }
-                                                ],
                                                 "reports": [
                                                   {
                                                     "questionId": 3,
@@ -197,9 +183,6 @@ public class ReportController {
                                                 "reportStatus": "COMPLETED",
                                                 "questionCount": 1,
                                                 "participantCount": 6,
-                                                "questions": [
-                                                  { "questionId": 4, "sequence": 1, "title": "어떤 요소가 먼저 보였나요?", "type": "FIVE_SECOND" }
-                                                ],
                                                 "reports": [
                                                   {
                                                     "questionId": 4,
@@ -236,9 +219,6 @@ public class ReportController {
                                                 "reportStatus": "COMPLETED",
                                                 "questionCount": 1,
                                                 "participantCount": 5,
-                                                "questions": [
-                                                  { "questionId": 5, "sequence": 1, "title": "전반적인 만족도는?", "type": "SCALE" }
-                                                ],
                                                 "reports": [
                                                   {
                                                     "questionId": 5,
@@ -279,9 +259,6 @@ public class ReportController {
                                                 "reportStatus": "COMPLETED",
                                                 "questionCount": 1,
                                                 "participantCount": 8,
-                                                "questions": [
-                                                  { "questionId": 6, "sequence": 1, "title": "어떤 디자인이 더 마음에 드시나요?", "type": "AB_TEST" }
-                                                ],
                                                 "reports": [
                                                   {
                                                     "questionId": 6,
@@ -311,9 +288,6 @@ public class ReportController {
                                                 "reportStatus": "COMPLETED",
                                                 "questionCount": 1,
                                                 "participantCount": 4,
-                                                "questions": [
-                                                  { "questionId": 7, "sequence": 1, "title": "카드를 분류해 주세요.", "type": "CARD_SORTING" }
-                                                ],
                                                 "reports": [
                                                   {
                                                     "questionId": 7,
@@ -361,9 +335,6 @@ public class ReportController {
                                                 "reportStatus": "COMPLETED",
                                                 "questionCount": 1,
                                                 "participantCount": 6,
-                                                "questions": [
-                                                  { "questionId": 8, "sequence": 1, "title": "고객센터를 찾아보세요.", "type": "TREE_TEST" }
-                                                ],
                                                 "reports": [
                                                   {
                                                     "questionId": 8,

--- a/src/main/java/server/MATE/domain/report/dto/response/ReportResponse.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/ReportResponse.java
@@ -1,7 +1,6 @@
 package server.MATE.domain.report.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import server.MATE.domain.question.dto.response.QuestionSummaryItem;
 import server.MATE.domain.test.entity.ReportStatus;
 import server.MATE.domain.test.entity.TestStatus;
 
@@ -20,9 +19,6 @@ public record ReportResponse(
 
         @Schema(description = "총 참여자 수", example = "12")
         Long participantCount,
-
-        @Schema(description = "질문 목록 (순서 오름차순)")
-        List<QuestionSummaryItem> questions,
 
         @Schema(description = "질문별 집계 결과 (reportStatus가 COMPLETED일 때만 포함)")
         List<ReportItem> reports

--- a/src/main/java/server/MATE/domain/report/service/ReportService.java
+++ b/src/main/java/server/MATE/domain/report/service/ReportService.java
@@ -66,10 +66,19 @@ public class ReportService {
 
         // 테스트가 종료됐고 리포트 집계가 끝났다면 리포트를 반환함
         List<Report> aggregations = reportRepository.findAllByTestId(testId);
+        List<QuestionSummaryItem> questionSummaries = questionRepository.findQuestionSummariesByTestId(testId);
 
-        if (aggregations.size() != questionCount) {
-            log.error("테스트 {} 리포트 조회 중 완전성 불일치 감지: questionCount={}, reportCount={}",
-                    testId, questionCount, aggregations.size());
+        Map<Long, Map<String, Object>> resultByQuestionId = aggregations.stream()
+                .collect(Collectors.toMap(Report::getQuestionId, Report::getResult));
+
+        List<Long> missingQuestionIds = questionSummaries.stream()
+                .map(QuestionSummaryItem::questionId)
+                .filter(questionId -> !resultByQuestionId.containsKey(questionId))
+                .toList();
+
+        if (!missingQuestionIds.isEmpty()) {
+            log.error("테스트 {} 리포트 조회 중 활성 질문 리포트 누락 감지: questionCount={}, reportCount={}, missingQuestionIds={}",
+                    testId, questionCount, aggregations.size(), missingQuestionIds);
             return new ReportResponse(
                     test.getTestStatus(),
                     ReportStatus.FAILED,
@@ -78,11 +87,6 @@ public class ReportService {
                     List.of()
             );
         }
-
-        Map<Long, Map<String, Object>> resultByQuestionId = aggregations.stream()
-                .collect(Collectors.toMap(Report::getQuestionId, Report::getResult));
-
-        List<QuestionSummaryItem> questionSummaries = questionRepository.findQuestionSummariesByTestId(testId);
 
         // 질문 요약 projection을 reports 조립에 재사용
         List<ReportItem> reports = questionSummaries.stream()

--- a/src/main/java/server/MATE/domain/report/service/ReportService.java
+++ b/src/main/java/server/MATE/domain/report/service/ReportService.java
@@ -48,7 +48,6 @@ public class ReportService {
                         reportStatus,
                         questionCount,
                         test.getPplCount(),
-                        questionSummaries,
                         List.of()
                 );
             }
@@ -60,7 +59,6 @@ public class ReportService {
                             reportStatus,
                             questionCount,
                             test.getPplCount(),
-                            questionSummaries,
                             List.of()
                     );
                 }
@@ -78,7 +76,6 @@ public class ReportService {
                     ReportStatus.FAILED,
                     questionCount,
                     test.getPplCount(),
-                    questionSummaries,
                     List.of()
             );
         }
@@ -102,7 +99,6 @@ public class ReportService {
                 ReportStatus.COMPLETED,
                 questionCount,
                 test.getPplCount(),
-                questionSummaries,
                 reports
         );
     }

--- a/src/main/java/server/MATE/domain/report/service/ReportService.java
+++ b/src/main/java/server/MATE/domain/report/service/ReportService.java
@@ -36,8 +36,7 @@ public class ReportService {
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
         if (!test.getMakerId().equals(makerId)) throw new BaseException(BaseErrorCode.TEST_005);
 
-        List<QuestionSummaryItem> questionSummaries = questionRepository.findQuestionSummariesByTestId(testId);
-        int questionCount = questionSummaries.size();
+        int questionCount = Math.toIntExact(questionRepository.countByTestIdAndDeletedAtIsNull(testId));
         ReportStatus reportStatus = test.getReportStatus() != null ? test.getReportStatus() : ReportStatus.PENDING;
 
         switch (test.getTestStatus()) {
@@ -83,7 +82,9 @@ public class ReportService {
         Map<Long, Map<String, Object>> resultByQuestionId = aggregations.stream()
                 .collect(Collectors.toMap(Report::getQuestionId, Report::getResult));
 
-        // questions에서 사용한 projection을 reports에서 재사용
+        List<QuestionSummaryItem> questionSummaries = questionRepository.findQuestionSummariesByTestId(testId);
+
+        // 질문 요약 projection을 reports 조립에 재사용
         List<ReportItem> reports = questionSummaries.stream()
                 .map(question -> new ReportItem(
                         question.questionId(),

--- a/src/test/java/server/MATE/domain/question/controller/QuestionControllerTest.java
+++ b/src/test/java/server/MATE/domain/question/controller/QuestionControllerTest.java
@@ -35,6 +35,7 @@ import server.MATE.domain.question.dto.response.TreeTestNodeDetailResponse;
 import server.MATE.domain.question.entity.ImageRatio;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.service.QuestionService;
+import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.domain.users.entity.Role;
 import server.MATE.global.common.exception.GlobalExceptionHandler;
 import server.MATE.global.discord.DiscordWebhookNotifier;
@@ -167,6 +168,7 @@ class QuestionControllerTest {
     @DisplayName("질문 목록 조회 요청을 정상 처리한다")
     void handlesQuestionSummaryRequestSuccessfully() throws Exception {
         QuestionSummaryResponse response = new QuestionSummaryResponse(
+                TestStatus.IN_PROGRESS,
                 2,
                 17L,
                 List.of(
@@ -182,6 +184,7 @@ class QuestionControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.code").value("200"))
                 .andExpect(jsonPath("$.message").value("질문 목록을 조회했습니다."))
+                .andExpect(jsonPath("$.data.testStatus").value("IN_PROGRESS"))
                 .andExpect(jsonPath("$.data.questionCount").value(2))
                 .andExpect(jsonPath("$.data.participantCount").value(17))
                 .andExpect(jsonPath("$.data.questions.length()").value(2))

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
@@ -241,6 +241,7 @@ class QuestionServiceTest {
 
         QuestionSummaryResponse response = questionService.getQuestionSummary(TEST_ID, MAKER_ID);
 
+        assertThat(response.testStatus()).isEqualTo(TestStatus.COMPLETED);
         assertThat(response.questionCount()).isEqualTo(2);
         assertThat(response.participantCount()).isEqualTo(12L);
         assertThat(response.questions()).extracting(QuestionSummaryItem::questionId)
@@ -250,16 +251,22 @@ class QuestionServiceTest {
     }
 
     @Test
-    @DisplayName("테스트가 진행 중이면 질문 요약 조회 시 TEST_006 예외가 발생한다")
-    void getQuestionSummaryThrowsTest006WhenTestIsInProgress() {
+    @DisplayName("질문 목록 조회는 테스트가 진행 중이어도 현재 testStatus와 함께 반환한다")
+    void getQuestionSummaryReturnsWhenTestIsInProgress() {
+        setTestStatus(test, TestStatus.IN_PROGRESS);
+        setTestPplCount(test, 3L);
         given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(questionRepository.findQuestionSummariesByTestId(TEST_ID)).willReturn(List.of(
+                new QuestionSummaryItem(301L, 1L, "진행 중 질문", QuestionType.SUBJECTIVE)
+        ));
 
-        assertThatThrownBy(() -> questionService.getQuestionSummary(TEST_ID, MAKER_ID))
-                .isInstanceOf(BaseException.class)
-                .extracting(ex -> ((BaseException) ex).getErrorCode())
-                .isEqualTo(BaseErrorCode.TEST_006);
+        QuestionSummaryResponse response = questionService.getQuestionSummary(TEST_ID, MAKER_ID);
 
-        verify(questionRepository, never()).findQuestionSummariesByTestId(TEST_ID);
+        assertThat(response.testStatus()).isEqualTo(TestStatus.IN_PROGRESS);
+        assertThat(response.questionCount()).isEqualTo(1);
+        assertThat(response.participantCount()).isEqualTo(3L);
+        assertThat(response.questions()).extracting(QuestionSummaryItem::questionId)
+                .containsExactly(301L);
     }
 
     @Test

--- a/src/test/java/server/MATE/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/ReportServiceTest.java
@@ -9,17 +9,22 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import server.MATE.domain.question.repository.QuestionRepository;
+import server.MATE.domain.question.dto.response.QuestionSummaryItem;
 import server.MATE.domain.report.dto.response.ReportResponse;
+import server.MATE.domain.report.entity.Report;
 import server.MATE.domain.report.repository.ReportRepository;
 import server.MATE.domain.test.entity.ReportStatus;
 import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.domain.test.repository.TestRepository;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ReportServiceTest {
@@ -59,13 +64,14 @@ class ReportServiceTest {
         ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.FAILED);
 
         given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
-        given(questionRepository.findQuestionSummariesByTestId(10L)).willReturn(List.of());
+        given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(0L);
 
         ReportResponse response = reportService.getReport(10L, 1L);
 
         assertThat(response.testStatus()).isEqualTo(TestStatus.IN_PROGRESS);
         assertThat(response.reportStatus()).isEqualTo(ReportStatus.FAILED);
         assertThat(response.reports()).isEmpty();
+        verify(questionRepository, never()).findQuestionSummariesByTestId(10L);
     }
 
     @Test
@@ -75,12 +81,57 @@ class ReportServiceTest {
         ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.FAILED);
 
         given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
-        given(questionRepository.findQuestionSummariesByTestId(10L)).willReturn(List.of());
+        given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(0L);
 
         ReportResponse response = reportService.getReport(10L, 1L);
 
         assertThat(response.testStatus()).isEqualTo(TestStatus.REJECTED);
         assertThat(response.reportStatus()).isEqualTo(ReportStatus.FAILED);
         assertThat(response.reports()).isEmpty();
+        verify(questionRepository, never()).findQuestionSummariesByTestId(10L);
+    }
+
+    @Test
+    @DisplayName("리포트 집계가 완료되지 않은 COMPLETED 테스트는 질문 요약을 조회하지 않고 빈 결과를 반환한다")
+    void getReport_returnsEarlyWithoutQuestionSummariesWhenReportStatusIsNotCompleted() {
+        ReflectionTestUtils.setField(test, "testStatus", TestStatus.COMPLETED);
+        ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.IN_PROGRESS);
+
+        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+        given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(2L);
+
+        ReportResponse response = reportService.getReport(10L, 1L);
+
+        assertThat(response.testStatus()).isEqualTo(TestStatus.COMPLETED);
+        assertThat(response.reportStatus()).isEqualTo(ReportStatus.IN_PROGRESS);
+        assertThat(response.questionCount()).isEqualTo(2);
+        assertThat(response.reports()).isEmpty();
+        verify(questionRepository, never()).findQuestionSummariesByTestId(10L);
+    }
+
+    @Test
+    @DisplayName("리포트 집계가 완료된 테스트는 질문 요약을 조회해 reports를 조립한다")
+    void getReport_fetchesQuestionSummariesWhenReportStatusIsCompleted() {
+        ReflectionTestUtils.setField(test, "testStatus", TestStatus.COMPLETED);
+        ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.COMPLETED);
+
+        Report report = Report.builder()
+                .testId(10L)
+                .questionId(101L)
+                .result(Map.of("count", 3))
+                .build();
+
+        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+        given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(1L);
+        given(reportRepository.findAllByTestId(10L)).willReturn(List.of(report));
+        given(questionRepository.findQuestionSummariesByTestId(10L)).willReturn(List.of(
+                new QuestionSummaryItem(101L, 1L, "질문", server.MATE.domain.question.entity.QuestionType.SUBJECTIVE)
+        ));
+
+        ReportResponse response = reportService.getReport(10L, 1L);
+
+        assertThat(response.reportStatus()).isEqualTo(ReportStatus.COMPLETED);
+        assertThat(response.reports()).hasSize(1);
+        verify(questionRepository).findQuestionSummariesByTestId(10L);
     }
 }

--- a/src/test/java/server/MATE/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/ReportServiceTest.java
@@ -134,4 +134,61 @@ class ReportServiceTest {
         assertThat(response.reports()).hasSize(1);
         verify(questionRepository).findQuestionSummariesByTestId(10L);
     }
+
+    @Test
+    @DisplayName("활성 질문의 리포트가 하나라도 누락되면 FAILED를 반환한다")
+    void getReport_returnsFailedWhenActiveQuestionReportIsMissing() {
+        ReflectionTestUtils.setField(test, "testStatus", TestStatus.COMPLETED);
+        ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.COMPLETED);
+
+        Report report = Report.builder()
+                .testId(10L)
+                .questionId(101L)
+                .result(Map.of("count", 3))
+                .build();
+
+        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+        given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(2L);
+        given(reportRepository.findAllByTestId(10L)).willReturn(List.of(report));
+        given(questionRepository.findQuestionSummariesByTestId(10L)).willReturn(List.of(
+                new QuestionSummaryItem(101L, 1L, "질문1", server.MATE.domain.question.entity.QuestionType.SUBJECTIVE),
+                new QuestionSummaryItem(102L, 2L, "질문2", server.MATE.domain.question.entity.QuestionType.SUBJECTIVE)
+        ));
+
+        ReportResponse response = reportService.getReport(10L, 1L);
+
+        assertThat(response.reportStatus()).isEqualTo(ReportStatus.FAILED);
+        assertThat(response.reports()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("고립된 리포트가 추가로 있어도 활성 질문 리포트가 모두 있으면 정상 반환한다")
+    void getReport_ignoresOrphanReportsWhenActiveQuestionReportsExist() {
+        ReflectionTestUtils.setField(test, "testStatus", TestStatus.COMPLETED);
+        ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.COMPLETED);
+
+        Report activeReport = Report.builder()
+                .testId(10L)
+                .questionId(101L)
+                .result(Map.of("count", 3))
+                .build();
+        Report orphanReport = Report.builder()
+                .testId(10L)
+                .questionId(999L)
+                .result(Map.of("count", 1))
+                .build();
+
+        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+        given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(1L);
+        given(reportRepository.findAllByTestId(10L)).willReturn(List.of(activeReport, orphanReport));
+        given(questionRepository.findQuestionSummariesByTestId(10L)).willReturn(List.of(
+                new QuestionSummaryItem(101L, 1L, "질문", server.MATE.domain.question.entity.QuestionType.SUBJECTIVE)
+        ));
+
+        ReportResponse response = reportService.getReport(10L, 1L);
+
+        assertThat(response.reportStatus()).isEqualTo(ReportStatus.COMPLETED);
+        assertThat(response.reports()).hasSize(1);
+        assertThat(response.reports().getFirst().questionId()).isEqualTo(101L);
+    }
 }

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -328,7 +328,7 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
     }
 
     @Test
-    @DisplayName("COMPLETED 테스트에 질문이 없으면 questions와 reports가 모두 빈 리스트다")
+    @DisplayName("COMPLETED 테스트에 질문이 없으면 reports가 빈 리스트다")
     void getReport_whenCompletedWithNoQuestions_returnsEmptyLists() throws Exception {
         TestActors actors = createActors();
         completeTest(actors.testId());
@@ -337,7 +337,6 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
 
         assertThat(data.path("testStatus").asText()).isEqualTo("COMPLETED");
         assertThat(data.path("questionCount").asInt()).isEqualTo(0);
-        assertThat(data.path("questions")).isEmpty();
         assertThat(data.path("reports")).isEmpty();
     }
 
@@ -482,16 +481,16 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
     }
 
     @Test
-    @DisplayName("리포트의 questions 필드는 sequence 오름차순으로 질문 목록을 반환한다")
-    void getReport_questions_returnedInSequenceOrder() throws Exception {
+    @DisplayName("리포트의 reports 필드는 sequence 오름차순으로 질문별 결과를 반환한다")
+    void getReport_reports_returnedInSequenceOrder() throws Exception {
         TestActors actors = createActors();
         createTwoSubjectiveQuestions(actors.testId(), actors.makerToken());
         completeTest(actors.testId());
 
-        JsonNode questions = reportData(actors.testId(), actors.makerToken()).path("questions");
-        assertThat(questions).hasSize(2);
-        assertThat(questions.get(0).path("sequence").asLong()).isEqualTo(1L);
-        assertThat(questions.get(1).path("sequence").asLong()).isEqualTo(2L);
+        JsonNode reports = reportData(actors.testId(), actors.makerToken()).path("reports");
+        assertThat(reports).hasSize(2);
+        assertThat(reports.get(0).path("sequence").asLong()).isEqualTo(1L);
+        assertThat(reports.get(1).path("sequence").asLong()).isEqualTo(2L);
     }
 
     @Test


### PR DESCRIPTION
## 📍 요약
- 질문 목록 조회 API에 testStatus 필드를 추가하고, 테스트 종료 여부와 관계없이 메이커가 조회할 수 있도록 수정함

## 🔗 관련 이슈
- Closes #165 

## 📌 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- QuestionSummaryResponse에 testStatus 필드를 추가했습니다.
- QuestionService.getQuestionSummary에서 테스트 종료 상태 제한을 제거해 메이커가 WAITING, IN_PROGRESS, COMPLETED, REJECTED 상태 모두 조회할 수 있도록 수정함

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew test --tests server.MATE.domain.question.service.QuestionServiceTest --tests server.MATE.domain.question.controller.QuestionControllerTest
