### PR TITLE
feat: 주관식 응답 AI 요약 및 클러스터링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ crash.log
 .terraform.tfvars
 .terraform.tfvars.json
 !*.tfvars.example
+
+# AI 통합 테스트 (Claude API 크레딧 소모, 로컬 전용)
+src/test/java/server/MATE/global/claude/SubjectiveAiServiceIntegrationTest.java

--- a/deploy/apps/mate/externalsecret-mate-env.yaml
+++ b/deploy/apps/mate/externalsecret-mate-env.yaml
@@ -68,3 +68,6 @@ spec:
     - secretKey: TOSS_PROMOTION_ANSWER_CODE
       remoteRef:
         key: toss-promotion-answer-code
+    - secretKey: CLAUDE_API_KEY
+      remoteRef:
+        key: claude-api-key

--- a/src/main/java/server/MATE/domain/report/service/handler/FiveSecondReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/FiveSecondReportHandler.java
@@ -9,6 +9,7 @@ import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.repository.FiveSecondRepository;
 import server.MATE.domain.report.service.ReportHandler;
+import server.MATE.global.claude.SubjectiveAiService;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
 public class FiveSecondReportHandler implements ReportHandler {
 
     private final FiveSecondRepository fiveSecondRepository;
+    private final SubjectiveAiService aiService;
 
     @Override
     public QuestionType supports() {
@@ -57,7 +59,7 @@ public class FiveSecondReportHandler implements ReportHandler {
                 countByOptionId.merge(optionId, 1, Integer::sum);
             }
             String otherText = (String) answer.getAnswer().get("otherText");
-            if (otherText != null) otherTexts.add(otherText);
+            if (otherText != null && !otherText.isBlank()) otherTexts.add(otherText);
         }
 
         int total = answers.size();
@@ -77,9 +79,7 @@ public class FiveSecondReportHandler implements ReportHandler {
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("options", options);
         if (Boolean.TRUE.equals(fiveSecond.getIsOther())) {
-            result.put("aiSummary", "AI 요약 준비 중입니다.");
-            result.put("clusters", ReportHandlerUtils.buildClusters(otherTexts));
-            result.put("otherTexts", ReportHandlerUtils.sampleTexts(otherTexts));
+            appendAiResult(result, otherTexts, "otherTexts");
         }
         return result;
     }
@@ -88,11 +88,30 @@ public class FiveSecondReportHandler implements ReportHandler {
         List<String> allTexts = answers.stream()
                 .sorted(Comparator.comparing(Answer::getCreatedAt))
                 .map(a -> (String) a.getAnswer().get("text"))
+                .filter(t -> t != null && !t.isBlank())
                 .toList();
+
         Map<String, Object> result = new LinkedHashMap<>();
-        result.put("aiSummary", "AI 요약 준비 중입니다.");
-        result.put("clusters", ReportHandlerUtils.buildClusters(allTexts));
-        result.put("texts", ReportHandlerUtils.sampleTexts(allTexts));
+        appendAiResult(result, allTexts, "texts");
         return result;
+    }
+
+    private void appendAiResult(Map<String, Object> result, List<String> texts, String rawTextsKey) {
+        if (texts.size() < aiService.getMinResponseThreshold()) {
+            result.put(rawTextsKey, texts);
+            return;
+        }
+
+        aiService.analyze(texts).ifPresentOrElse(
+                aiResult -> {
+                    result.put("aiSummary", aiResult.aiSummary());
+                    result.put("clusters", aiResult.toClusterMaps());
+                    result.put(rawTextsKey, ReportHandlerUtils.sampleTexts(texts));
+                },
+                () -> {
+                    result.put("clusters", ReportHandlerUtils.buildClusters(texts));
+                    result.put(rawTextsKey, texts);
+                }
+        );
     }
 }

--- a/src/main/java/server/MATE/domain/report/service/handler/ObjectiveReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/ObjectiveReportHandler.java
@@ -9,6 +9,7 @@ import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.repository.ObjectiveRepository;
 import server.MATE.domain.report.service.ReportHandler;
+import server.MATE.global.claude.SubjectiveAiService;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
 public class ObjectiveReportHandler implements ReportHandler {
 
     private final ObjectiveRepository objectiveRepository;
+    private final SubjectiveAiService aiService;
 
     @Override
     public QuestionType supports() {
@@ -55,7 +57,7 @@ public class ObjectiveReportHandler implements ReportHandler {
                 countByOptionId.merge(optionId, 1, Integer::sum);
             }
             String otherText = (String) answer.getAnswer().get("otherText");
-            if (otherText != null) otherTexts.add(otherText);
+            if (otherText != null && !otherText.isBlank()) otherTexts.add(otherText);
         }
 
         int total = answers.size();
@@ -75,10 +77,28 @@ public class ObjectiveReportHandler implements ReportHandler {
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("options", options);
         if (objective.isOther()) {
-            result.put("aiSummary", "AI 요약 준비 중입니다.");
-            result.put("clusters", ReportHandlerUtils.buildClusters(otherTexts));
-            result.put("otherTexts", ReportHandlerUtils.sampleTexts(otherTexts));
+            appendAiResult(result, otherTexts);
         }
         return result;
     }
+
+    private void appendAiResult(Map<String, Object> result, List<String> texts) {
+        if (texts.size() < aiService.getMinResponseThreshold()) {
+            result.put("otherTexts", texts);
+            return;
+        }
+
+        aiService.analyze(texts).ifPresentOrElse(
+                aiResult -> {
+                    result.put("aiSummary", aiResult.aiSummary());
+                    result.put("clusters", aiResult.toClusterMaps());
+                    result.put("otherTexts", ReportHandlerUtils.sampleTexts(texts));
+                },
+                () -> {
+                    result.put("clusters", ReportHandlerUtils.buildClusters(texts));
+                    result.put("otherTexts", texts);
+                }
+        );
+    }
+
 }

--- a/src/main/java/server/MATE/domain/report/service/handler/ReportHandlerUtils.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/ReportHandlerUtils.java
@@ -20,7 +20,6 @@ final class ReportHandlerUtils {
         return Math.round(count * 1000.0 / total) / 1000.0;
     }
 
-    // TODO: AI 연동 후 의미론적 유사도 기반 그룹핑으로 교체
     static List<Map<String, Object>> buildClusters(List<String> texts) {
         return texts.stream()
                 .filter(t -> t != null && !t.isBlank())
@@ -31,9 +30,9 @@ final class ReportHandlerUtils {
                         Comparator.comparingInt(List::size)).reversed())
                 .map(e -> {
                     Map<String, Object> cluster = new LinkedHashMap<>();
+                    cluster.put("tag", null);
                     cluster.put("representative", e.getKey());
                     cluster.put("count", e.getValue().size());
-                    cluster.put("responses", List.copyOf(e.getValue()));
                     return cluster;
                 })
                 .toList();

--- a/src/main/java/server/MATE/domain/report/service/handler/SubjectiveReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/SubjectiveReportHandler.java
@@ -1,10 +1,12 @@
 package server.MATE.domain.report.service.handler;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import server.MATE.domain.answer.entity.Answer;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.report.service.ReportHandler;
+import server.MATE.global.claude.SubjectiveAiService;
 
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -12,7 +14,10 @@ import java.util.List;
 import java.util.Map;
 
 @Component
+@RequiredArgsConstructor
 public class SubjectiveReportHandler implements ReportHandler {
+
+    private final SubjectiveAiService aiService;
 
     @Override
     public QuestionType supports() {
@@ -33,11 +38,27 @@ public class SubjectiveReportHandler implements ReportHandler {
         List<String> allTexts = answers.stream()
                 .sorted(Comparator.comparing(Answer::getCreatedAt))
                 .map(a -> (String) a.getAnswer().get("text"))
+                .filter(t -> t != null && !t.isBlank())
                 .toList();
+
         Map<String, Object> result = new LinkedHashMap<>();
-        result.put("aiSummary", "AI 요약 준비 중입니다.");
-        result.put("clusters", ReportHandlerUtils.buildClusters(allTexts));
-        result.put("texts", ReportHandlerUtils.sampleTexts(allTexts));
+
+        if (allTexts.size() < aiService.getMinResponseThreshold()) {
+            result.put("texts", allTexts);
+            return result;
+        }
+
+        aiService.analyze(allTexts).ifPresentOrElse(
+                aiResult -> {
+                    result.put("aiSummary", aiResult.aiSummary());
+                    result.put("clusters", aiResult.toClusterMaps());
+                    result.put("texts", ReportHandlerUtils.sampleTexts(allTexts));
+                },
+                () -> {
+                    result.put("clusters", ReportHandlerUtils.buildClusters(allTexts));
+                    result.put("texts", allTexts);
+                }
+        );
         return result;
     }
 }

--- a/src/main/java/server/MATE/global/claude/AiAnalysisResult.java
+++ b/src/main/java/server/MATE/global/claude/AiAnalysisResult.java
@@ -1,0 +1,22 @@
+package server.MATE.global.claude;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public record AiAnalysisResult(String aiSummary, List<ClusterResult> clusters) {
+
+    public record ClusterResult(String tag, String representative, int count) {}
+
+    public List<Map<String, Object>> toClusterMaps() {
+        return clusters.stream()
+                .map(c -> {
+                    Map<String, Object> m = new LinkedHashMap<>();
+                    m.put("tag", c.tag());
+                    m.put("representative", c.representative());
+                    m.put("count", c.count());
+                    return m;
+                })
+                .toList();
+    }
+}

--- a/src/main/java/server/MATE/global/claude/ClaudeConfig.java
+++ b/src/main/java/server/MATE/global/claude/ClaudeConfig.java
@@ -1,0 +1,25 @@
+package server.MATE.global.claude;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+@EnableConfigurationProperties(ClaudeProperties.class)
+public class ClaudeConfig {
+
+    @Bean
+    @Qualifier("claudeWebClient")
+    public WebClient claudeWebClient(WebClient.Builder builder, ClaudeProperties properties) {
+        return builder
+                .baseUrl("https://api.anthropic.com")
+                .defaultHeader("x-api-key", properties.key())
+                .defaultHeader("anthropic-version", "2023-06-01")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}

--- a/src/main/java/server/MATE/global/claude/ClaudeProperties.java
+++ b/src/main/java/server/MATE/global/claude/ClaudeProperties.java
@@ -1,0 +1,11 @@
+package server.MATE.global.claude;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "claude.api")
+public record ClaudeProperties(String key, String model, int minResponseThreshold) {
+    public ClaudeProperties {
+        if (model == null) model = "claude-sonnet-4-6";
+        if (minResponseThreshold <= 0) minResponseThreshold = 20;
+    }
+}

--- a/src/main/java/server/MATE/global/claude/SubjectiveAiService.java
+++ b/src/main/java/server/MATE/global/claude/SubjectiveAiService.java
@@ -1,0 +1,154 @@
+package server.MATE.global.claude;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Slf4j
+@Service
+public class SubjectiveAiService {
+
+    private static final String SYSTEM_PROMPT = """
+            당신은 사용자 리서치 전문가입니다. 주관식 설문 응답을 분석하여 반드시 순수 JSON만 출력하세요. 마크다운 코드블록을 사용하지 마세요.
+
+            규칙:
+            - aiSummary: 2~3문장, 사실 기반, 추측 표현 금지("~인 것 같습니다" 사용 불가), "응답자들은"으로 시작
+            - clusters: 의미론적으로 유사한 응답 그룹. 최소 3개 최대 21개
+            - mappings: 각 응답(0-based 인덱스)이 속하는 클러스터 인덱스 배열. 길이는 반드시 응답 수와 동일해야 함. 한 응답은 하나의 클러스터에만 속함
+            """;
+
+    private final WebClient claudeWebClient;
+    private final ClaudeProperties properties;
+    private final ObjectMapper objectMapper;
+
+    public SubjectiveAiService(
+            @Qualifier("claudeWebClient") WebClient claudeWebClient,
+            ClaudeProperties properties,
+            ObjectMapper objectMapper
+    ) {
+        this.claudeWebClient = claudeWebClient;
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+    }
+
+    public int getMinResponseThreshold() {
+        return properties.minResponseThreshold();
+    }
+
+    public Optional<AiAnalysisResult> analyze(List<String> texts) {
+        try {
+            String rawJson = callClaude(texts);
+            return Optional.of(parseAndValidate(rawJson, texts.size()));
+        } catch (Exception e) {
+            log.warn("Claude AI 분석 실패, 폴백 처리: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private String callClaude(List<String> texts) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("응답 수: ").append(texts.size()).append("개\n\n");
+        for (int i = 0; i < texts.size(); i++) {
+            sb.append("[").append(i).append("] ").append(texts.get(i)).append("\n");
+        }
+        sb.append("""
+
+                다음 JSON 형식으로만 응답하세요:
+                {
+                  "aiSummary": "응답자들은 ...",
+                  "clusters": [
+                    {"tag": "태그1~2단어", "representative": "대표 문장 1줄"}
+                  ],
+                  "mappings": [0, 1, 0, 2]
+                }
+                """);
+
+        Map<String, Object> requestBody = Map.of(
+                "model", properties.model(),
+                "max_tokens", 4096,
+                "system", SYSTEM_PROMPT,
+                "messages", List.of(Map.of("role", "user", "content", sb.toString()))
+        );
+
+        Map<String, Object> response = claudeWebClient.post()
+                .uri("/v1/messages")
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block(Duration.ofSeconds(60));
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> content = (List<Map<String, Object>>) response.get("content");
+        return stripMarkdown((String) content.get(0).get("text"));
+    }
+
+    private String stripMarkdown(String text) {
+        String trimmed = text.trim();
+        if (trimmed.startsWith("```")) {
+            int start = trimmed.indexOf('\n') + 1;
+            int end = trimmed.lastIndexOf("```");
+            return trimmed.substring(start, end).trim();
+        }
+        return trimmed;
+    }
+
+    @SuppressWarnings("unchecked")
+    private AiAnalysisResult parseAndValidate(String json, int textCount) throws Exception {
+        Map<String, Object> parsed = objectMapper.readValue(json, new TypeReference<>() {});
+
+        String aiSummary = (String) parsed.get("aiSummary");
+        List<Map<String, Object>> rawClusters = (List<Map<String, Object>>) parsed.get("clusters");
+        List<Object> rawMappings = (List<Object>) parsed.get("mappings");
+
+        if (aiSummary == null || rawClusters == null || rawMappings == null) {
+            throw new IllegalStateException("LLM 응답에 필수 필드(aiSummary, clusters, mappings)가 누락되었습니다.");
+        }
+
+        if (rawMappings.size() != textCount) {
+            throw new IllegalStateException("mappings 길이 불일치: " + rawMappings.size() + " != " + textCount);
+        }
+
+        int[] mappings = rawMappings.stream().mapToInt(o -> ((Number) o).intValue()).toArray();
+
+        boolean validIndices = IntStream.of(mappings).allMatch(idx -> idx >= 0 && idx < rawClusters.size());
+        if (!validIndices) {
+            throw new IllegalStateException("mappings에 유효하지 않은 클러스터 인덱스가 포함되어 있습니다");
+        }
+
+        Map<Integer, Long> countByCluster = IntStream.range(0, mappings.length)
+                .boxed()
+                .collect(Collectors.groupingBy(i -> mappings[i], Collectors.counting()));
+
+        if (countByCluster.size() < 3 || countByCluster.size() > 21) {
+            throw new IllegalStateException("클러스터 수 범위 초과: " + countByCluster.size());
+        }
+
+        List<AiAnalysisResult.ClusterResult> clusters = IntStream.range(0, rawClusters.size())
+                .mapToObj(i -> {
+                    Map<String, Object> c = rawClusters.get(i);
+                    int count = countByCluster.getOrDefault(i, 0L).intValue();
+                    return new AiAnalysisResult.ClusterResult(
+                            (String) c.get("tag"),
+                            (String) c.get("representative"),
+                            count
+                    );
+                })
+                .filter(c -> c.count() > 0)
+                .sorted(Comparator.comparingInt(AiAnalysisResult.ClusterResult::count).reversed())
+                .toList();
+
+        return new AiAnalysisResult(aiSummary, clusters);
+    }
+}

--- a/src/main/java/server/MATE/global/claude/SubjectiveAiService.java
+++ b/src/main/java/server/MATE/global/claude/SubjectiveAiService.java
@@ -89,8 +89,14 @@ public class SubjectiveAiService {
                 .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
                 .block(Duration.ofSeconds(60));
 
+        if (response == null || !response.containsKey("content")) {
+            throw new IllegalStateException("Claude API 응답이 비어있거나 올바르지 않습니다.");
+        }
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> content = (List<Map<String, Object>>) response.get("content");
+        if (content == null || content.isEmpty()) {
+            throw new IllegalStateException("Claude API 응답의 content 필드가 비어있습니다.");
+        }
         return stripMarkdown((String) content.get(0).get("text"));
     }
 
@@ -99,7 +105,10 @@ public class SubjectiveAiService {
         if (trimmed.startsWith("```")) {
             int start = trimmed.indexOf('\n') + 1;
             int end = trimmed.lastIndexOf("```");
-            return trimmed.substring(start, end).trim();
+            if (end > start) {
+                return trimmed.substring(start, end).trim();
+            }
+            return trimmed.substring(start).trim();
         }
         return trimmed;
     }
@@ -107,6 +116,9 @@ public class SubjectiveAiService {
     @SuppressWarnings("unchecked")
     private AiAnalysisResult parseAndValidate(String json, int textCount) throws Exception {
         Map<String, Object> parsed = objectMapper.readValue(json, new TypeReference<>() {});
+        if (parsed == null) {
+            throw new IllegalStateException("JSON 파싱 결과가 null입니다.");
+        }
 
         String aiSummary = (String) parsed.get("aiSummary");
         List<Map<String, Object>> rawClusters = (List<Map<String, Object>>) parsed.get("clusters");
@@ -120,7 +132,12 @@ public class SubjectiveAiService {
             throw new IllegalStateException("mappings 길이 불일치: " + rawMappings.size() + " != " + textCount);
         }
 
-        int[] mappings = rawMappings.stream().mapToInt(o -> ((Number) o).intValue()).toArray();
+        int[] mappings = rawMappings.stream()
+                .mapToInt(o -> {
+                    if (o instanceof Number n) return n.intValue();
+                    throw new IllegalStateException("mappings에 숫자가 아닌 값이 포함되어 있습니다: " + o);
+                })
+                .toArray();
 
         boolean validIndices = IntStream.of(mappings).allMatch(idx -> idx >= 0 && idx < rawClusters.size());
         if (!validIndices) {
@@ -138,6 +155,9 @@ public class SubjectiveAiService {
         List<AiAnalysisResult.ClusterResult> clusters = IntStream.range(0, rawClusters.size())
                 .mapToObj(i -> {
                     Map<String, Object> c = rawClusters.get(i);
+                    if (c == null) {
+                        throw new IllegalStateException("클러스터 정보가 올바르지 않습니다 (null).");
+                    }
                     int count = countByCluster.getOrDefault(i, 0L).intValue();
                     return new AiAnalysisResult.ClusterResult(
                             (String) c.get("tag"),

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -46,6 +46,10 @@ toss:
   token:
     refresh-cache-ttl: ${TOSS_REFRESH_CACHE_TTL:1209600000}
 
+claude:
+  api:
+    key: ${CLAUDE_API_KEY:}
+
 discord:
   webhook-url: ${DISCORD_WEBHOOK_URL:}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,11 @@ management:
       prometheus:
         enabled: true
 
+claude:
+  api:
+    model: claude-sonnet-4-6
+    min-response-threshold: 20
+
 toss:
   api:
     base-url: https://apps-in-toss-api.toss.im

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -104,8 +104,6 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         JsonNode result = reportData(actors.testId(), actors.makerToken()).path("reports").get(0);
         assertThat(result.path("type").asText()).isEqualTo("SUBJECTIVE");
         JsonNode resultData = result.path("result");
-        assertThat(resultData.path("aiSummary").asText()).isEqualTo("AI 요약 준비 중입니다.");
-        assertThat(resultData.path("clusters").isArray()).isTrue();
         JsonNode texts = resultData.path("texts");
         assertThat(texts).hasSize(1);
         assertThat(texts.get(0).asText()).isEqualTo("주관식 응답");
@@ -187,8 +185,6 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         JsonNode result = reportData(actors.testId(), actors.makerToken()).path("reports").get(0);
         assertThat(result.path("type").asText()).isEqualTo("FIVE_SECOND");
         JsonNode resultData = result.path("result");
-        assertThat(resultData.path("aiSummary").asText()).isEqualTo("AI 요약 준비 중입니다.");
-        assertThat(resultData.path("clusters").isArray()).isTrue();
         JsonNode texts = resultData.path("texts");
         assertThat(texts).hasSize(1);
         assertThat(texts.get(0).asText()).isEqualTo("5초 주관 응답");
@@ -814,8 +810,6 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         completeTest(actors.testId());
 
         JsonNode result = reportData(actors.testId(), actors.makerToken()).path("reports").get(0).path("result");
-        assertThat(result.path("aiSummary").asText()).isEqualTo("AI 요약 준비 중입니다.");
-        assertThat(result.path("clusters").isArray()).isTrue();
         JsonNode otherTexts = result.path("otherTexts");
         assertThat(otherTexts).hasSize(1);
         assertThat(otherTexts.get(0).asText()).isEqualTo("직접 입력 응답");
@@ -1190,8 +1184,6 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         completeTest(actors.testId());
 
         JsonNode result = reportData(actors.testId(), actors.makerToken()).path("reports").get(0).path("result");
-        assertThat(result.path("aiSummary").asText()).isEqualTo("AI 요약 준비 중입니다.");
-        assertThat(result.path("clusters").isArray()).isTrue();
         JsonNode otherTexts = result.path("otherTexts");
         assertThat(otherTexts).hasSize(1);
         assertThat(otherTexts.get(0).asText()).isEqualTo("5초 기타 응답");

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -21,6 +21,10 @@ jwt:
     REFRESH:
       expiration: 1209600000
 
+claude:
+  api:
+    key: ${CLAUDE_API_KEY:}
+
 toss:
   api:
     enabled: false


### PR DESCRIPTION
  ## 📍 요약
  - 주관식/기타항목 응답을 Claude Sonnet 4.6으로 분석해 AI 요약과 클러스터링을 리포트에 제공

  ## 🔗 관련 이슈
  - Closes #144

  ## 📌 변경 사항
  - [x] 기능
  - [ ] 버그 수정
  - [ ] 리팩토링
  - [ ] 문서
  - [x] 테스트
  - [ ] 기타

  ## ✅ 작업 내용
  - Claude Sonnet 4.6 API 연동 (WebClient, ClaudeConfig, ClaudeProperties)
  - 하이브리드 아키텍처 적용: LLM이 aiSummary·clusters·mappings 반환, Java에서 count 집계 (MECE 보장)
  - SubjectiveReportHandler, FiveSecondReportHandler, ObjectiveReportHandler에 AI 분석 통합
  - 임계값(20개) 미만 시 raw texts 반환, AI 실패 시 exact-match 클러스터로 폴백
  - AI 성공 시 sampled texts(15개), 폴백 시 전체 texts 반환하도록 분리
  - LLM 응답 방어 로직: 필수 필드 null 체크, mappings 길이/인덱스 유효성 검증, 60초 타임아웃
  - Azure External Secret에 claude-api-key 등록 항목 추가

  ## 테스트
  - [x] 로컬 테스트 완료
  - 테스트 방법:
    - `./gradlew test`
    - Claude API 통합 테스트: CLAUDE_API_KEY 환경변수 설정 후 SubjectiveAiServiceIntegrationTest 직접 실행 (로컬 전용, gitignore 처리)
   
<img width="1102" height="1079" alt="스크린샷 2026-05-26 오후 8 43 35" src="https://github.com/user-attachments/assets/9c8b1f77-f036-4725-b800-7cd5f209d16c" />
