### PR TITLE
feat: 내 응답 목록 조회 API 구현

### DIFF
--- a/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
+++ b/src/main/java/server/MATE/domain/answer/controller/AnswerController.java
@@ -13,13 +13,14 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import server.MATE.domain.answer.dto.request.AnswerCreateRequest;
 import server.MATE.domain.answer.dto.response.AnswerBatchCreateResponse;
+import server.MATE.domain.answer.dto.response.MyAnswerResponse;
 import server.MATE.domain.answer.service.AnswerService;
 import server.MATE.global.common.response.ApiResponse;
 import server.MATE.global.security.principal.AuthenticatedUser;
 
 @Tag(name = "[ANSWER] 응답 API", description = "테스트 응답 관련 API")
 @RestController
-@RequestMapping("/api/v1/tests/{testId}/answers")
+@RequestMapping("/api/v1")
 @SecurityRequirement(name = "JWT")
 @RequiredArgsConstructor
 public class AnswerController {
@@ -43,7 +44,7 @@ public class AnswerController {
             - **CARD_SORTING**: groups 필수
             - **TREE_TEST**: nodeId 필수, path 필수 (루트부터 최종 노드까지 클릭 순서), 최종 선택은 leaf node여야 함
             """)
-    @PostMapping
+    @PostMapping("/tests/{testId}/answers")
     public ResponseEntity<ApiResponse<AnswerBatchCreateResponse>> createAnswers(
             @PathVariable Long testId,
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
@@ -186,5 +187,21 @@ public class AnswerController {
         AnswerBatchCreateResponse response = answerService.createAnswers(testId, authenticatedUser.getId(), request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created("응답이 등록되었습니다.", response));
+    }
+
+    @Operation(
+            summary = "✔️ 내 응답 목록 조회",
+            description = """
+                    현재 로그인한 사용자가 응답한 테스트 목록을 최신순으로 조회합니다. 참여기록20 화면에 해당하는 api 입니다.
+                    - createdAt은 yyyy.MM.dd 형식으로 반환합니다.
+                    - totalPromotionReward는 로그인한 사용자의 누적 프로모션 리워드 합계입니다.
+                    """
+    )
+    @GetMapping("/answers/me")
+    public ResponseEntity<ApiResponse<MyAnswerResponse>> listMyAnswers(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        MyAnswerResponse response = answerService.listMyAnswers(authenticatedUser.getId());
+        return ResponseEntity.ok(ApiResponse.ok("내 응답 목록을 조회했습니다.", response));
     }
 }

--- a/src/main/java/server/MATE/domain/answer/dto/response/MyAnswerItem.java
+++ b/src/main/java/server/MATE/domain/answer/dto/response/MyAnswerItem.java
@@ -1,0 +1,19 @@
+package server.MATE.domain.answer.dto.response;
+
+import server.MATE.global.common.util.DateFormatUtil;
+
+public record MyAnswerItem(
+        Long testId,
+        String testName,
+        String createdAt,
+        Integer reward
+) {
+    public static MyAnswerItem from(MyAnswerItemView view) {
+        return new MyAnswerItem(
+                view.testId(),
+                view.testName(),
+                DateFormatUtil.format(view.createdAt()),
+                view.reward()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/answer/dto/response/MyAnswerItemView.java
+++ b/src/main/java/server/MATE/domain/answer/dto/response/MyAnswerItemView.java
@@ -1,0 +1,11 @@
+package server.MATE.domain.answer.dto.response;
+
+import java.time.LocalDateTime;
+
+public record MyAnswerItemView(
+        Long testId,
+        String testName,
+        LocalDateTime createdAt,
+        Integer reward
+) {
+}

--- a/src/main/java/server/MATE/domain/answer/dto/response/MyAnswerResponse.java
+++ b/src/main/java/server/MATE/domain/answer/dto/response/MyAnswerResponse.java
@@ -1,0 +1,12 @@
+package server.MATE.domain.answer.dto.response;
+
+import java.util.List;
+
+public record MyAnswerResponse(
+        Integer totalPromotionReward,
+        List<MyAnswerItem> answers
+) {
+    public static MyAnswerResponse of(Integer totalPromotionReward, List<MyAnswerItem> answers) {
+        return new MyAnswerResponse(totalPromotionReward, answers);
+    }
+}

--- a/src/main/java/server/MATE/domain/answer/dto/response/MyAnswerResponse.java
+++ b/src/main/java/server/MATE/domain/answer/dto/response/MyAnswerResponse.java
@@ -3,10 +3,10 @@ package server.MATE.domain.answer.dto.response;
 import java.util.List;
 
 public record MyAnswerResponse(
-        Integer totalPromotionReward,
+        Long totalPromotionReward,
         List<MyAnswerItem> answers
 ) {
-    public static MyAnswerResponse of(Integer totalPromotionReward, List<MyAnswerItem> answers) {
+    public static MyAnswerResponse of(Long totalPromotionReward, List<MyAnswerItem> answers) {
         return new MyAnswerResponse(totalPromotionReward, answers);
     }
 }

--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -6,12 +6,16 @@ import org.springframework.transaction.annotation.Transactional;
 import server.MATE.domain.answer.dto.request.AnswerCreateItem;
 import server.MATE.domain.answer.dto.request.AnswerCreateRequest;
 import server.MATE.domain.answer.dto.response.AnswerBatchCreateResponse;
+import server.MATE.domain.answer.dto.response.MyAnswerItem;
+import server.MATE.domain.answer.dto.response.MyAnswerResponse;
 import server.MATE.domain.answer.entity.Answer;
 import server.MATE.domain.answer.repository.AnswerRepository;
 import server.MATE.domain.answer.service.handler.AnswerCreateHandler;
 import server.MATE.domain.participation.entity.Participation;
 import server.MATE.domain.participation.repository.ParticipationRepository;
+import server.MATE.domain.promotion.entity.PromotionRewardStatus;
 import server.MATE.domain.promotion.event.PromotionRewardRequestEvent;
+import server.MATE.domain.promotion.repository.PromotionRewardRepository;
 import server.MATE.domain.question.dto.response.AnswerQuestionTypeView;
 import server.MATE.domain.question.entity.CardSorting;
 import server.MATE.domain.question.entity.FiveSecond;
@@ -47,6 +51,7 @@ public class AnswerService {
     private final ScaleRepository scaleRepository;
     private final CardSortingRepository cardSortingRepository;
     private final TreeTestRepository treeTestRepository;
+    private final PromotionRewardRepository promotionRewardRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final Map<QuestionType, AnswerCreateHandler> handlerMap;
 
@@ -59,6 +64,7 @@ public class AnswerService {
                          ScaleRepository scaleRepository,
                          CardSortingRepository cardSortingRepository,
                          TreeTestRepository treeTestRepository,
+                         PromotionRewardRepository promotionRewardRepository,
                          ApplicationEventPublisher eventPublisher,
                          List<AnswerCreateHandler> handlers) {
         this.testRepository = testRepository;
@@ -70,8 +76,23 @@ public class AnswerService {
         this.scaleRepository = scaleRepository;
         this.cardSortingRepository = cardSortingRepository;
         this.treeTestRepository = treeTestRepository;
+        this.promotionRewardRepository = promotionRewardRepository;
         this.eventPublisher = eventPublisher;
         this.handlerMap = buildHandlerMap(handlers);
+    }
+
+    public MyAnswerResponse listMyAnswers(Long testerId) {
+        List<MyAnswerItem> answers = participationRepository.findMyAnswerItemsByTesterIdOrderByCreatedAtDesc(testerId)
+                .stream()
+                .map(MyAnswerItem::from)
+                .toList();
+
+        Integer totalPromotionReward = promotionRewardRepository.sumRewardAmountByTesterIdAndStatus(
+                testerId,
+                PromotionRewardStatus.SUCCEEDED
+        );
+
+        return MyAnswerResponse.of(totalPromotionReward, answers);
     }
 
     @Transactional

--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -87,7 +87,7 @@ public class AnswerService {
                 .map(MyAnswerItem::from)
                 .toList();
 
-        Integer totalPromotionReward = promotionRewardRepository.sumRewardAmountByTesterIdAndStatus(
+        Long totalPromotionReward = promotionRewardRepository.sumRewardAmountByTesterIdAndStatus(
                 testerId,
                 PromotionRewardStatus.SUCCEEDED
         );

--- a/src/main/java/server/MATE/domain/participation/repository/ParticipationRepository.java
+++ b/src/main/java/server/MATE/domain/participation/repository/ParticipationRepository.java
@@ -1,11 +1,31 @@
 package server.MATE.domain.participation.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import server.MATE.domain.answer.dto.response.MyAnswerItemView;
 import server.MATE.domain.participation.entity.Participation;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
 
     boolean existsByTestIdAndTesterIdAndDeletedAtIsNull(Long testId, Long testerId);
+
+    @Query("""
+            select new server.MATE.domain.answer.dto.response.MyAnswerItemView(
+                t.id,
+                t.title,
+                p.createdAt,
+                t.reward
+            )
+            from Participation p
+            join Test t on t.id = p.testId
+            where p.testerId = :testerId
+              and p.deletedAt is null
+              and t.deletedAt is null
+            order by p.createdAt desc
+            """)
+    List<MyAnswerItemView> findMyAnswerItemsByTesterIdOrderByCreatedAtDesc(@Param("testerId") Long testerId);
 }

--- a/src/main/java/server/MATE/domain/promotion/repository/PromotionRewardRepository.java
+++ b/src/main/java/server/MATE/domain/promotion/repository/PromotionRewardRepository.java
@@ -3,9 +3,21 @@ package server.MATE.domain.promotion.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import server.MATE.domain.promotion.entity.PromotionReward;
+import server.MATE.domain.promotion.entity.PromotionRewardStatus;
 
 public interface PromotionRewardRepository extends JpaRepository<PromotionReward, Long> {
 
     Optional<PromotionReward> findByParticipationId(Long participationId);
+
+    @Query("""
+            select coalesce(sum(pr.rewardAmount), 0)
+            from PromotionReward pr
+            where pr.testerId = :testerId
+              and pr.status = :status
+            """)
+    Integer sumRewardAmountByTesterIdAndStatus(@Param("testerId") Long testerId,
+                                               @Param("status") PromotionRewardStatus status);
 }

--- a/src/main/java/server/MATE/domain/promotion/repository/PromotionRewardRepository.java
+++ b/src/main/java/server/MATE/domain/promotion/repository/PromotionRewardRepository.java
@@ -18,6 +18,6 @@ public interface PromotionRewardRepository extends JpaRepository<PromotionReward
             where pr.testerId = :testerId
               and pr.status = :status
             """)
-    Integer sumRewardAmountByTesterIdAndStatus(@Param("testerId") Long testerId,
-                                               @Param("status") PromotionRewardStatus status);
+    Long sumRewardAmountByTesterIdAndStatus(@Param("testerId") Long testerId,
+                                            @Param("status") PromotionRewardStatus status);
 }

--- a/src/main/java/server/MATE/global/common/util/DateFormatUtil.java
+++ b/src/main/java/server/MATE/global/common/util/DateFormatUtil.java
@@ -1,0 +1,19 @@
+package server.MATE.global.common.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public final class DateFormatUtil {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+    private DateFormatUtil() {
+    }
+
+    public static String format(LocalDateTime dateTime) {
+        if (dateTime == null) {
+            return null;
+        }
+        return dateTime.format(FORMATTER);
+    }
+}

--- a/src/test/java/server/MATE/integration/MyAnswerIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/MyAnswerIntegrationTest.java
@@ -1,0 +1,116 @@
+package server.MATE.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.participation.entity.Participation;
+import server.MATE.domain.promotion.entity.PromotionReward;
+import server.MATE.domain.promotion.entity.PromotionRewardStatus;
+import server.MATE.domain.test.entity.TestStatus;
+import server.MATE.domain.users.entity.Users;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MyAnswerIntegrationTest extends BaseQuestionAnswerEndToEndTest {
+
+    @Test
+    @Transactional
+    @DisplayName("내 응답 목록을 최신순으로 조회하고 totalPromotionReward를 반환한다")
+    void listMyAnswers() throws Exception {
+        Users maker = usersRepository.save(Users.builder()
+                .ci("maker-" + System.nanoTime())
+                .name("maker")
+                .build());
+        Users tester = usersRepository.save(Users.builder()
+                .ci("tester-" + System.nanoTime())
+                .name("tester")
+                .build());
+
+        server.MATE.domain.test.entity.Test firstTest = testRepository.save(server.MATE.domain.test.entity.Test.builder()
+                .makerId(maker.getId())
+                .title("첫 번째 테스트")
+                .description("설명")
+                .serviceName("서비스")
+                .serviceDescription("설명")
+                .imageKeys(List.of())
+                .reward(300)
+                .testStatus(TestStatus.IN_PROGRESS)
+                .closedAt(LocalDateTime.parse("2099-05-31T23:59:59"))
+                .build());
+
+        server.MATE.domain.test.entity.Test secondTest = testRepository.save(server.MATE.domain.test.entity.Test.builder()
+                .makerId(maker.getId())
+                .title("두 번째 테스트")
+                .description("설명")
+                .serviceName("서비스")
+                .serviceDescription("설명")
+                .imageKeys(List.of())
+                .reward(400)
+                .testStatus(TestStatus.IN_PROGRESS)
+                .closedAt(LocalDateTime.parse("2099-05-31T23:59:59"))
+                .build());
+
+        Participation firstParticipation = participationRepository.save(Participation.builder()
+                .testId(firstTest.getId())
+                .testerId(tester.getId())
+                .build());
+        Participation secondParticipation = participationRepository.save(Participation.builder()
+                .testId(secondTest.getId())
+                .testerId(tester.getId())
+                .build());
+
+        entityManager.createNativeQuery("update participation set created_at = :createdAt where id = :id")
+                .setParameter("createdAt", LocalDateTime.parse("2026-05-13T10:00:00"))
+                .setParameter("id", firstParticipation.getId())
+                .executeUpdate();
+        entityManager.createNativeQuery("update participation set created_at = :createdAt where id = :id")
+                .setParameter("createdAt", LocalDateTime.parse("2026-05-20T10:00:00"))
+                .setParameter("id", secondParticipation.getId())
+                .executeUpdate();
+
+        promotionRewardRepository.save(PromotionReward.builder()
+                .participationId(firstParticipation.getId())
+                .testId(firstTest.getId())
+                .testerId(tester.getId())
+                .rewardAmount(300)
+                .status(PromotionRewardStatus.SUCCEEDED)
+                .build());
+        promotionRewardRepository.save(PromotionReward.builder()
+                .participationId(secondParticipation.getId())
+                .testId(secondTest.getId())
+                .testerId(tester.getId())
+                .rewardAmount(400)
+                .status(PromotionRewardStatus.SUCCEEDED)
+                .build());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        var result = mockMvc.perform(get("/api/v1/answers/me")
+                        .header("Authorization", bearerToken(tester)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        var body = parseBody(result);
+        assertThat(body.path("message").asText()).isEqualTo("내 응답 목록을 조회했습니다.");
+        assertThat(body.path("data").path("totalPromotionReward").asInt()).isEqualTo(700);
+        assertThat(body.path("data").path("answers")).hasSize(2);
+        assertThat(body.path("data").path("answers").get(0).path("testId").asLong()).isEqualTo(secondTest.getId());
+        assertThat(body.path("data").path("answers").get(0).path("testName").asText()).isEqualTo("두 번째 테스트");
+        assertThat(body.path("data").path("answers").get(0).path("createdAt").asText()).isEqualTo("2026.05.20");
+        assertThat(body.path("data").path("answers").get(0).path("reward").asInt()).isEqualTo(400);
+        assertThat(body.path("data").path("answers").get(1).path("testId").asLong()).isEqualTo(firstTest.getId());
+        assertThat(body.path("data").path("answers").get(1).path("createdAt").asText()).isEqualTo("2026.05.13");
+    }
+}

--- a/src/test/java/server/MATE/integration/MyAnswerIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/MyAnswerIntegrationTest.java
@@ -104,7 +104,7 @@ class MyAnswerIntegrationTest extends BaseQuestionAnswerEndToEndTest {
 
         var body = parseBody(result);
         assertThat(body.path("message").asText()).isEqualTo("내 응답 목록을 조회했습니다.");
-        assertThat(body.path("data").path("totalPromotionReward").asInt()).isEqualTo(700);
+        assertThat(body.path("data").path("totalPromotionReward").asLong()).isEqualTo(700L);
         assertThat(body.path("data").path("answers")).hasSize(2);
         assertThat(body.path("data").path("answers").get(0).path("testId").asLong()).isEqualTo(secondTest.getId());
         assertThat(body.path("data").path("answers").get(0).path("testName").asText()).isEqualTo("두 번째 테스트");


### PR DESCRIPTION
## 📍 요약
- 로그인 사용자의 응답한 테스트 목록을 최신순으로 조회함

## 🔗 관련 이슈
- Closes #175 

## 📌 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- 날짜 포맷팅 공통 유틸 DateFormatUtil를 추가함. yyyy.MM.dd 형식으로 반환함.
- 참여 목록, 프로모션 합계 조회 repository 쿼리를 구현함

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew test --tests "server.MATE.integration.MyAnswerIntegrationTest"
