### PR TITLE
fix: 테스트 등록 publish 후 테스트 draft를 삭제하도록 수정

### DIFF
--- a/src/main/java/server/MATE/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/server/MATE/domain/payment/repository/PaymentRepository.java
@@ -1,6 +1,10 @@
 package server.MATE.domain.payment.repository;
 
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import server.MATE.domain.payment.entity.Payment;
 
 import java.util.Optional;
@@ -12,4 +16,12 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     Optional<Payment> findByOrderNo(String orderNo);
 
     Optional<Payment> findByDraftId(Long draftId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            select p
+            from Payment p
+            where p.id = :id
+            """)
+    Optional<Payment> findByIdForUpdate(@Param("id") Long id);
 }

--- a/src/main/java/server/MATE/domain/test/service/TestPublishService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestPublishService.java
@@ -39,7 +39,7 @@ public class TestPublishService {
     private final Validator validator;
 
     public Long publish(Long paymentId) {
-        Payment payment = paymentRepository.findById(paymentId)
+        Payment payment = paymentRepository.findByIdForUpdate(paymentId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.PAYMENT_001));
         if (payment.getTestId() != null) {
             return payment.getTestId();

--- a/src/main/java/server/MATE/domain/test/service/TestPublishService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestPublishService.java
@@ -41,6 +41,10 @@ public class TestPublishService {
     public Long publish(Long paymentId) {
         Payment payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.PAYMENT_001));
+        if (payment.getTestId() != null) {
+            return payment.getTestId();
+        }
+
         TestDraft draft = testDraftRepository.findByIdForUpdate(payment.getDraftId())
                 .orElseThrow(() -> new BaseException(BaseErrorCode.DRAFT_001));
 
@@ -81,6 +85,7 @@ public class TestPublishService {
 
         payment.linkTest(test.getId());
         draft.markPublished(test.getId());
+        testDraftRepository.delete(draft);
         return test.getId();
     }
 

--- a/src/test/java/server/MATE/domain/test/service/TestPublishServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestPublishServiceTest.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -131,20 +132,15 @@ class TestPublishServiceTest {
         assertThat(savedTest.getCategories()).hasSize(2);
 
         verify(questionService).createQuestions(any(Long.class), any(Long.class), any(QuestionCreateRequest.class));
+        verify(testDraftRepository).delete(draft);
     }
 
     @Test
-    @DisplayName("이미 publish된 draft면 기존 testId를 그대로 반환한다")
-    void returnsExistingPublishedTestId() {
-        TestDraft draft = TestDraft.builder()
-                .makerId(1L)
-                .status(TestDraftStatus.PUBLISHED)
-                .publishedTestId(99L)
-                .build();
-        ReflectionTestUtils.setField(draft, "id", 10L);
-
+    @DisplayName("payment에 이미 testId가 연결되어 있으면 draft 없이 기존 testId를 그대로 반환한다")
+    void returnsExistingLinkedTestIdWithoutDraft() {
         Payment payment = Payment.builder()
                 .draftId(10L)
+                .testId(99L)
                 .makerId(1L)
                 .payStatus(PayStatus.PAY_SUCCEEDED)
                 .build();
@@ -152,12 +148,12 @@ class TestPublishServiceTest {
         ReflectionTestUtils.setField(payment, "id", 20L);
 
         given(paymentRepository.findById(20L)).willReturn(Optional.of(payment));
-        given(testDraftRepository.findByIdForUpdate(10L)).willReturn(Optional.of(draft));
 
         Long testId = testPublishService.publish(20L);
 
         assertThat(testId).isEqualTo(99L);
         assertThat(payment.getTestId()).isEqualTo(99L);
+        verify(testDraftRepository, never()).findByIdForUpdate(any(Long.class));
     }
 
     @Test

--- a/src/test/java/server/MATE/domain/test/service/TestPublishServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestPublishServiceTest.java
@@ -107,7 +107,7 @@ class TestPublishServiceTest {
 
         ReflectionTestUtils.setField(payment, "id", 20L);
 
-        given(paymentRepository.findById(20L)).willReturn(Optional.of(payment));
+        given(paymentRepository.findByIdForUpdate(20L)).willReturn(Optional.of(payment));
         given(testDraftRepository.findByIdForUpdate(10L)).willReturn(Optional.of(draft));
         given(testRepository.save(any(server.MATE.domain.test.entity.Test.class))).willAnswer(invocation -> {
             server.MATE.domain.test.entity.Test saved = invocation.getArgument(0);
@@ -147,7 +147,7 @@ class TestPublishServiceTest {
 
         ReflectionTestUtils.setField(payment, "id", 20L);
 
-        given(paymentRepository.findById(20L)).willReturn(Optional.of(payment));
+        given(paymentRepository.findByIdForUpdate(20L)).willReturn(Optional.of(payment));
 
         Long testId = testPublishService.publish(20L);
 
@@ -187,7 +187,7 @@ class TestPublishServiceTest {
                 .build();
         ReflectionTestUtils.setField(payment, "id", 20L);
 
-        given(paymentRepository.findById(20L)).willReturn(Optional.of(payment));
+        given(paymentRepository.findByIdForUpdate(20L)).willReturn(Optional.of(payment));
         given(testDraftRepository.findByIdForUpdate(10L)).willReturn(Optional.of(draft));
 
         assertThatThrownBy(() -> testPublishService.publish(20L))
@@ -224,7 +224,7 @@ class TestPublishServiceTest {
                 .build();
         ReflectionTestUtils.setField(payment, "id", 20L);
 
-        given(paymentRepository.findById(20L)).willReturn(Optional.of(payment));
+        given(paymentRepository.findByIdForUpdate(20L)).willReturn(Optional.of(payment));
         given(testDraftRepository.findByIdForUpdate(10L)).willReturn(Optional.of(draft));
 
         assertThatThrownBy(() -> testPublishService.publish(20L))


### PR DESCRIPTION
## 📍 요약
- 테스트 등록 publish 후 남아있는 테스트 draft를 삭제함

## 🔗 관련 이슈
- Closes #156 

## 📌 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- TestPublishService에서 publish 성공 후 test_draft를 삭제하도록 수정
- draft 삭제 이후 동일 paymentId로 재호출돼도 payment.testId를 반환하도록 idempotency 보강

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew test --tests server.MATE.domain.test.service.TestPublishServiceTest --tests server.MATE.domain.payment.service.MockPaymentServiceTest
