### PR TITLE
feat: 테스트 상태 변경 API 및 어드민 리포트 조회 권한 추가

### DIFF
--- a/src/main/java/server/MATE/domain/report/controller/ReportController.java
+++ b/src/main/java/server/MATE/domain/report/controller/ReportController.java
@@ -35,7 +35,7 @@ public class ReportController {
             summary = "✔️ 리포트 전체 조회",
             description = """
                     메이커가 자신의 테스트에 대한 질문 유형별 응답 리포트를 조회합니다. MKST_02 화면에 해당하는 api 입니다.
-                    - 테스트 소유자(메이커)만 조회할 수 있습니다.
+                    - 테스트 소유자(메이커) 또는 관리자가 조회할 수 있습니다.
                     - `testStatus`가 `COMPLETED`가 아니면 `reports`는 빈 리스트를 반환합니다.
                     - `testStatus`가 `COMPLETED`이고 `reportStatus`가 `IN_PROGRESS`이면 집계 중으로 `reports`는 빈 리스트입니다.
                     - `reportStatus`가 `COMPLETED`이면 `reports`를 반환합니다.
@@ -370,7 +370,7 @@ public class ReportController {
             @PathVariable Long testId,
             @AuthenticationPrincipal AuthenticatedUser user
     ) {
-        ReportResponse response = reportService.getReport(testId, user.getId());
+        ReportResponse response = reportService.getReport(testId, user.getId(), user.getRole());
         return ResponseEntity.ok(ApiResponse.ok("리포트를 조회했습니다.", response));
     }
 

--- a/src/main/java/server/MATE/domain/report/service/ReportService.java
+++ b/src/main/java/server/MATE/domain/report/service/ReportService.java
@@ -18,6 +18,7 @@ import server.MATE.domain.test.entity.ReportStatus;
 import server.MATE.domain.test.entity.Test;
 import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.domain.users.entity.Role;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
 
@@ -31,10 +32,10 @@ public class ReportService {
     private final QuestionRepository questionRepository;
     private final ReportRepository reportRepository;
 
-    public ReportResponse getReport(Long testId, Long makerId) {
+    public ReportResponse getReport(Long testId, Long userId, Role role) {
         Test test = testRepository.findByIdAndDeletedAtIsNull(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
-        if (!test.getMakerId().equals(makerId)) throw new BaseException(BaseErrorCode.TEST_005);
+        if (role != Role.ADMIN && !test.getMakerId().equals(userId)) throw new BaseException(BaseErrorCode.TEST_005);
 
         int questionCount = Math.toIntExact(questionRepository.countByTestIdAndDeletedAtIsNull(testId));
         ReportStatus reportStatus = test.getReportStatus() != null ? test.getReportStatus() : ReportStatus.PENDING;

--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -3,6 +3,7 @@ package server.MATE.domain.test.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -11,6 +12,8 @@ import server.MATE.domain.test.dto.response.LikedTestSummaryResponse;
 import server.MATE.domain.test.dto.response.MyTestSummaryResponse;
 import server.MATE.domain.test.dto.response.TestDetailResponse;
 import server.MATE.domain.test.dto.response.TestLikeResponse;
+import server.MATE.domain.test.dto.request.TestStatusUpdateRequest;
+import server.MATE.domain.test.dto.response.TestStatusUpdateResponse;
 import server.MATE.domain.test.dto.response.TestSummaryListResponse;
 import server.MATE.domain.test.dto.response.TestSummaryResponse;
 import server.MATE.domain.test.service.TestService;
@@ -107,6 +110,27 @@ public class TestController {
     ) {
         TestDetailResponse data = testService.getTest(testId, authenticatedUser.getId());
         return ResponseEntity.ok(ApiResponse.ok("테스트를 조회했습니다.", data));
+    }
+
+    @Operation(
+            summary = "✔️ 테스트 상태 변경",
+            description = """
+                    테스트 상태를 변경합니다.
+
+                    - `COMPLETED`: 메이커 본인만 가능, 현재 상태가 `IN_PROGRESS`일 때만 허용
+                    - `IN_PROGRESS`: 관리자만 가능 (테스트 승인)
+                    - `REJECTED`: 관리자만 가능 (테스트 반려)
+                    """
+    )
+    @PatchMapping("/{testId}/status")
+    public ResponseEntity<ApiResponse<TestStatusUpdateResponse>> updateTestStatus(
+            @PathVariable Long testId,
+            @RequestBody @Valid TestStatusUpdateRequest request,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        TestStatusUpdateResponse response = testService.updateTestStatus(
+                testId, authenticatedUser.getId(), authenticatedUser.getRole(), request.status());
+        return ResponseEntity.ok(ApiResponse.ok("테스트 상태가 변경되었습니다.", response));
     }
 
     @Operation(summary = "✔️ 테스트 찜하기",

--- a/src/main/java/server/MATE/domain/test/dto/request/TestStatusUpdateRequest.java
+++ b/src/main/java/server/MATE/domain/test/dto/request/TestStatusUpdateRequest.java
@@ -1,0 +1,10 @@
+package server.MATE.domain.test.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import server.MATE.domain.test.entity.TestStatus;
+
+public record TestStatusUpdateRequest(
+        @NotNull(message = "상태값은 필수입니다.")
+        TestStatus status
+) {
+}

--- a/src/main/java/server/MATE/domain/test/dto/response/TestStatusUpdateResponse.java
+++ b/src/main/java/server/MATE/domain/test/dto/response/TestStatusUpdateResponse.java
@@ -1,0 +1,9 @@
+package server.MATE.domain.test.dto.response;
+
+import server.MATE.domain.test.entity.TestStatus;
+
+public record TestStatusUpdateResponse(
+        Long testId,
+        TestStatus testStatus
+) {
+}

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -10,6 +10,8 @@ import server.MATE.domain.test.dto.response.MyTestSummaryItem;
 import server.MATE.domain.test.dto.response.MyTestSummaryResponse;
 import server.MATE.domain.test.dto.response.TestDetailResponse;
 import server.MATE.domain.test.dto.response.TestLikeResponse;
+import server.MATE.domain.test.dto.response.TestStatusUpdateResponse;
+import server.MATE.domain.users.entity.Role;
 import server.MATE.domain.test.dto.response.TestSummaryListResponse;
 import server.MATE.domain.test.dto.response.TestSummaryResponse;
 import server.MATE.domain.test.entity.Test;
@@ -79,6 +81,44 @@ public class TestService {
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
         boolean hasResponded = participationRepository.existsByTestIdAndTesterIdAndDeletedAtIsNull(testId, userId);
         return TestDetailResponse.from(test, toImageUrls(test.getImageKeys()), hasResponded);
+    }
+
+    public TestStatusUpdateResponse updateTestStatus(Long testId, Long userId, Role role, TestStatus status) {
+        Test test = testRepository.findByIdAndDeletedAtIsNull(testId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        switch (status) {
+            case COMPLETED -> {
+                if (!test.getMakerId().equals(userId)) {
+                    throw new BaseException(BaseErrorCode.COMMON_009);
+                }
+                if (test.getTestStatus() != TestStatus.IN_PROGRESS) {
+                    throw new BaseException(BaseErrorCode.TEST_007);
+                }
+                test.complete();
+            }
+            case IN_PROGRESS -> {
+                if (role != Role.ADMIN) {
+                    throw new BaseException(BaseErrorCode.COMMON_009);
+                }
+                if (test.getTestStatus() != TestStatus.WAITING) {
+                    throw new BaseException(BaseErrorCode.TEST_007);
+                }
+                test.start();
+            }
+            case REJECTED -> {
+                if (role != Role.ADMIN) {
+                    throw new BaseException(BaseErrorCode.COMMON_009);
+                }
+                if (test.getTestStatus() != TestStatus.WAITING) {
+                    throw new BaseException(BaseErrorCode.TEST_007);
+                }
+                test.reject();
+            }
+            default -> throw new BaseException(BaseErrorCode.COMMON_002);
+        }
+
+        return new TestStatusUpdateResponse(testId, test.getTestStatus());
     }
 
     public TestLikeResponse likeTest(Long testId, Long userId) {

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -42,6 +42,7 @@ public enum BaseErrorCode implements ErrorCode {
     TEST_004(HttpStatus.NOT_FOUND, "TEST_004", "테스트를 찾을 수 없습니다."),
     TEST_005(HttpStatus.FORBIDDEN, "TEST_005", "테스트 메이커만 조회할 수 있습니다."),
     TEST_006(HttpStatus.BAD_REQUEST, "TEST_006", "테스트가 종료된 후에 조회할 수 있습니다."),
+    TEST_007(HttpStatus.BAD_REQUEST, "TEST_007", "현재 상태에서는 변경할 수 없습니다."),
 
     // Test Draft
     DRAFT_001(HttpStatus.NOT_FOUND, "DRAFT_001", "테스트 초안을 찾을 수 없습니다."),

--- a/src/test/java/server/MATE/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/ReportServiceTest.java
@@ -16,6 +16,9 @@ import server.MATE.domain.report.repository.ReportRepository;
 import server.MATE.domain.test.entity.ReportStatus;
 import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.domain.users.entity.Role;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
 
 import java.util.List;
 import java.util.Map;
@@ -66,7 +69,7 @@ class ReportServiceTest {
         given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
         given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(0L);
 
-        ReportResponse response = reportService.getReport(10L, 1L);
+        ReportResponse response = reportService.getReport(10L, 1L, Role.USER);
 
         assertThat(response.testStatus()).isEqualTo(TestStatus.IN_PROGRESS);
         assertThat(response.reportStatus()).isEqualTo(ReportStatus.FAILED);
@@ -83,7 +86,7 @@ class ReportServiceTest {
         given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
         given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(0L);
 
-        ReportResponse response = reportService.getReport(10L, 1L);
+        ReportResponse response = reportService.getReport(10L, 1L, Role.USER);
 
         assertThat(response.testStatus()).isEqualTo(TestStatus.REJECTED);
         assertThat(response.reportStatus()).isEqualTo(ReportStatus.FAILED);
@@ -100,7 +103,7 @@ class ReportServiceTest {
         given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
         given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(2L);
 
-        ReportResponse response = reportService.getReport(10L, 1L);
+        ReportResponse response = reportService.getReport(10L, 1L, Role.USER);
 
         assertThat(response.testStatus()).isEqualTo(TestStatus.COMPLETED);
         assertThat(response.reportStatus()).isEqualTo(ReportStatus.IN_PROGRESS);
@@ -128,7 +131,7 @@ class ReportServiceTest {
                 new QuestionSummaryItem(101L, 1L, "질문", server.MATE.domain.question.entity.QuestionType.SUBJECTIVE)
         ));
 
-        ReportResponse response = reportService.getReport(10L, 1L);
+        ReportResponse response = reportService.getReport(10L, 1L, Role.USER);
 
         assertThat(response.reportStatus()).isEqualTo(ReportStatus.COMPLETED);
         assertThat(response.reports()).hasSize(1);
@@ -155,7 +158,7 @@ class ReportServiceTest {
                 new QuestionSummaryItem(102L, 2L, "질문2", server.MATE.domain.question.entity.QuestionType.SUBJECTIVE)
         ));
 
-        ReportResponse response = reportService.getReport(10L, 1L);
+        ReportResponse response = reportService.getReport(10L, 1L, Role.USER);
 
         assertThat(response.reportStatus()).isEqualTo(ReportStatus.FAILED);
         assertThat(response.reports()).isEmpty();
@@ -185,10 +188,35 @@ class ReportServiceTest {
                 new QuestionSummaryItem(101L, 1L, "질문", server.MATE.domain.question.entity.QuestionType.SUBJECTIVE)
         ));
 
-        ReportResponse response = reportService.getReport(10L, 1L);
+        ReportResponse response = reportService.getReport(10L, 1L, Role.USER);
 
         assertThat(response.reportStatus()).isEqualTo(ReportStatus.COMPLETED);
         assertThat(response.reports()).hasSize(1);
         assertThat(response.reports().getFirst().questionId()).isEqualTo(101L);
+    }
+
+    @Test
+    @DisplayName("메이커가 아닌 일반 사용자는 리포트를 조회할 수 없다")
+    void getReport_throwsExceptionWhenNotMaker() {
+        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+
+        BaseException exception = org.junit.jupiter.api.Assertions.assertThrows(BaseException.class,
+                () -> reportService.getReport(10L, 999L, Role.USER));
+
+        assertThat(exception.getErrorCode()).isEqualTo(BaseErrorCode.TEST_005);
+    }
+
+    @Test
+    @DisplayName("어드민은 메이커가 아니어도 리포트를 조회할 수 있다")
+    void getReport_adminCanViewAnyReport() {
+        ReflectionTestUtils.setField(test, "testStatus", TestStatus.IN_PROGRESS);
+        ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.PENDING);
+
+        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+        given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(0L);
+
+        ReportResponse response = reportService.getReport(10L, 999L, Role.ADMIN);
+
+        assertThat(response.testStatus()).isEqualTo(TestStatus.IN_PROGRESS);
     }
 }

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -8,7 +8,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import org.junit.jupiter.api.Assertions;
 import server.MATE.domain.participation.repository.ParticipationRepository;
+import server.MATE.domain.test.dto.response.TestStatusUpdateResponse;
+import server.MATE.domain.users.entity.Role;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
 import server.MATE.domain.test.dto.response.LikedTestSummaryItem;
 import server.MATE.domain.test.dto.response.LikedTestSummaryResponse;
 import server.MATE.domain.test.dto.response.MyTestSummaryResponse;
@@ -203,6 +208,102 @@ class TestServiceTest {
         assertThat(response.isLiked()).isFalse();
         assertThat(response.likeCount()).isZero();
         verify(testLikeRepository).delete(testLike);
+    }
+
+    @Test
+    void 메이커가_진행_중인_테스트를_종료한다() {
+        ReflectionTestUtils.setField(test, "testStatus", TestStatus.IN_PROGRESS);
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+
+        TestStatusUpdateResponse response = testService.updateTestStatus(TEST_ID, MAKER_ID, Role.USER, TestStatus.COMPLETED);
+
+        assertThat(response.testId()).isEqualTo(TEST_ID);
+        assertThat(response.testStatus()).isEqualTo(TestStatus.COMPLETED);
+    }
+
+    @Test
+    void 진행_중이_아닌_테스트를_종료하면_예외가_발생한다() {
+        ReflectionTestUtils.setField(test, "testStatus", TestStatus.WAITING);
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+
+        BaseException exception = Assertions.assertThrows(BaseException.class,
+                () -> testService.updateTestStatus(TEST_ID, MAKER_ID, Role.USER, TestStatus.COMPLETED));
+
+        assertThat(exception.getErrorCode()).isEqualTo(BaseErrorCode.TEST_007);
+    }
+
+    @Test
+    void 메이커가_아닌_사용자가_테스트를_종료하면_예외가_발생한다() {
+        ReflectionTestUtils.setField(test, "testStatus", TestStatus.IN_PROGRESS);
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+
+        BaseException exception = Assertions.assertThrows(BaseException.class,
+                () -> testService.updateTestStatus(TEST_ID, 999L, Role.USER, TestStatus.COMPLETED));
+
+        assertThat(exception.getErrorCode()).isEqualTo(BaseErrorCode.COMMON_009);
+    }
+
+    @Test
+    void 관리자가_검수_중인_테스트를_승인한다() {
+        ReflectionTestUtils.setField(test, "testStatus", TestStatus.WAITING);
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+
+        TestStatusUpdateResponse response = testService.updateTestStatus(TEST_ID, 999L, Role.ADMIN, TestStatus.IN_PROGRESS);
+
+        assertThat(response.testStatus()).isEqualTo(TestStatus.IN_PROGRESS);
+    }
+
+    @Test
+    void 관리자가_검수_중인_테스트를_반려한다() {
+        ReflectionTestUtils.setField(test, "testStatus", TestStatus.WAITING);
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+
+        TestStatusUpdateResponse response = testService.updateTestStatus(TEST_ID, 999L, Role.ADMIN, TestStatus.REJECTED);
+
+        assertThat(response.testStatus()).isEqualTo(TestStatus.REJECTED);
+    }
+
+    @Test
+    void 관리자가_검수_중이_아닌_테스트를_승인하면_예외가_발생한다() {
+        ReflectionTestUtils.setField(test, "testStatus", TestStatus.IN_PROGRESS);
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+
+        BaseException exception = Assertions.assertThrows(BaseException.class,
+                () -> testService.updateTestStatus(TEST_ID, 999L, Role.ADMIN, TestStatus.IN_PROGRESS));
+
+        assertThat(exception.getErrorCode()).isEqualTo(BaseErrorCode.TEST_007);
+    }
+
+    @Test
+    void 관리자가_검수_중이_아닌_테스트를_반려하면_예외가_발생한다() {
+        ReflectionTestUtils.setField(test, "testStatus", TestStatus.COMPLETED);
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+
+        BaseException exception = Assertions.assertThrows(BaseException.class,
+                () -> testService.updateTestStatus(TEST_ID, 999L, Role.ADMIN, TestStatus.REJECTED));
+
+        assertThat(exception.getErrorCode()).isEqualTo(BaseErrorCode.TEST_007);
+    }
+
+    @Test
+    void 일반_사용자가_승인을_시도하면_예외가_발생한다() {
+        ReflectionTestUtils.setField(test, "testStatus", TestStatus.WAITING);
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+
+        BaseException exception = Assertions.assertThrows(BaseException.class,
+                () -> testService.updateTestStatus(TEST_ID, 999L, Role.USER, TestStatus.IN_PROGRESS));
+
+        assertThat(exception.getErrorCode()).isEqualTo(BaseErrorCode.COMMON_009);
+    }
+
+    @Test
+    void WAITING_상태로_변경을_시도하면_예외가_발생한다() {
+        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+
+        BaseException exception = Assertions.assertThrows(BaseException.class,
+                () -> testService.updateTestStatus(TEST_ID, MAKER_ID, Role.USER, TestStatus.WAITING));
+
+        assertThat(exception.getErrorCode()).isEqualTo(BaseErrorCode.COMMON_002);
     }
 
     private server.MATE.domain.test.entity.Test createListTest(Long id, String title, TestStatus testStatus) {


### PR DESCRIPTION
  ## 📍 요약
  - 테스트 상태 변경 API를 구현하고, 어드민이 모든 테스트의 리포트를 조회할 수 있도록 권한을 추가합니다.

  ## 🔗 관련 이슈
  - Closes #178
  
  ## 📌 변경 사항                                                                                                     
  - [x] 기능
  - [ ] 버그 수정
  - [ ] 리팩토링
  - [ ] 문서
  - [x] 테스트
  - [ ] 기타

  ## ✅ 작업 내용
  - `PATCH /api/v1/tests/{testId}/status` 엔드포인트 추가
    - `COMPLETED`: 메이커 본인만 가능, 현재 상태가 `IN_PROGRESS`일 때만 허용
    - `IN_PROGRESS` (승인): 관리자만 가능, 현재 상태가 `WAITING`일 때만 허용
    - `REJECTED` (반려): 관리자만 가능, 현재 상태가 `WAITING`일 때만 허용
  - `BaseErrorCode.TEST_007` 추가 (현재 상태에서는 변경할 수 없습니다)
  - `ReportService.getReport` 시그니처에 `Role` 파라미터 추가 — 어드민은 메이커 여부 무관하게 조회 가능
  - `TestServiceTest` — `updateTestStatus` 케이스 9개 추가
  - `ReportServiceTest` — 어드민 접근 및 비메이커 차단 케이스 추가

  ## 테스트
  - [x] 로컬 테스트 완료
  - 테스트 방법:
    - `./gradlew test --tests "server.MATE.domain.test.service.TestServiceTest"`
    - `./gradlew test --tests "server.MATE.domain.report.service.ReportServiceTest"`