### PR TITLE
fix: AI 요약 응답 구조 통일 및 클러스터 필드 개선 

### DIFF
--- a/src/main/java/server/MATE/domain/report/controller/ReportController.java
+++ b/src/main/java/server/MATE/domain/report/controller/ReportController.java
@@ -40,6 +40,17 @@ public class ReportController {
                     - `testStatus`가 `COMPLETED`이고 `reportStatus`가 `IN_PROGRESS`이면 집계 중으로 `reports`는 빈 리스트입니다.
                     - `reportStatus`가 `COMPLETED`이면 `reports`를 반환합니다.
                     - `reports[].result` 구조는 질문 유형(`type`)마다 다릅니다. 아래 예시 응답을 참고해주세요.
+
+                    #### 주관식 응답 집계 필드(`aiSummary` / `clusters` / `texts` · `otherTexts`) 반환 규칙
+                    주관식(SUBJECTIVE), 객관식 기타입력(OBJECTIVE + isOther), 5초테스트(FIVE_SECOND) 유형에 포함됩니다.
+
+                    | 상황 | aiSummary | clusters | texts / otherTexts |
+                    |------|-----------|----------|--------------------|
+                    | 응답 수 < 기준치 | `null` | `[]` | 전체 응답 |
+                    | 응답 수 ≥ 기준치, AI 요약 성공 | AI 요약 문자열 | AI 클러스터 목록 | 최대 15개 샘플 |
+                    | 응답 수 ≥ 기준치, AI 요약 실패 | `null` | 동일 응답 기준 그룹화 | 최대 15개 샘플 |
+
+                    각 클러스터 오브젝트: `{ "representative": string, "count": number, "responses": string[] }`
                     """
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -85,7 +96,7 @@ public class ReportController {
                                                     "title": "서비스에서 불편한 점은?",
                                                     "type": "SUBJECTIVE",
                                                     "result": {
-                                                      "aiSummary": "AI 요약 준비 중입니다.",
+                                                      "aiSummary": "AI 요약을 적어줍니다. 최대 3줄까지 보여줍니다. ",
                                                       "clusters": [
                                                         { "representative": "버튼이 너무 작아요.", "count": 2, "responses": ["버튼이 너무 작아요.", "버튼이 너무 작아요."] },
                                                         { "representative": "로딩이 느립니다.", "count": 1, "responses": ["로딩이 느립니다."] }
@@ -127,7 +138,7 @@ public class ReportController {
                                                         { "optionId": 102, "content": "검색", "count": 3, "ratio": 0.3 },
                                                         { "optionId": 103, "content": "기타", "count": 1, "ratio": 0.1 }
                                                       ],
-                                                      "aiSummary": "AI 요약 준비 중입니다.",
+                                                      "aiSummary": "AI 요약을 적어줍니다. 최대 3줄까지 보여줍니다. ",
                                                       "clusters": [
                                                         { "representative": "알림 기능을 자주 씁니다.", "count": 1, "responses": ["알림 기능을 자주 씁니다."] }
                                                       ],
@@ -159,7 +170,7 @@ public class ReportController {
                                                     "title": "화면에서 가장 먼저 눈에 띈 것은?",
                                                     "type": "FIVE_SECOND",
                                                     "result": {
-                                                      "aiSummary": "AI 요약 준비 중입니다.",
+                                                      "aiSummary": "AI 요약을 적어줍니다. 최대 3줄까지 보여줍니다. ",
                                                       "clusters": [
                                                         { "representative": "상단 배너가 눈에 들어왔어요.", "count": 1, "responses": ["상단 배너가 눈에 들어왔어요."] },
                                                         { "representative": "검색창이 먼저 보였습니다.", "count": 1, "responses": ["검색창이 먼저 보였습니다."] }
@@ -199,7 +210,7 @@ public class ReportController {
                                                         { "optionId": 201, "content": "검색창", "count": 4, "ratio": 0.667 },
                                                         { "optionId": 202, "content": "배너", "count": 2, "ratio": 0.333 }
                                                       ],
-                                                      "aiSummary": "AI 요약 준비 중입니다.",
+                                                      "aiSummary": "AI 요약을 적어줍니다. 최대 3줄까지 보여줍니다. ",
                                                       "clusters": [
                                                         { "representative": "하단 버튼이요", "count": 1, "responses": ["하단 버튼이요"] }
                                                       ],

--- a/src/main/java/server/MATE/domain/report/service/handler/FiveSecondReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/FiveSecondReportHandler.java
@@ -98,6 +98,8 @@ public class FiveSecondReportHandler implements ReportHandler {
 
     private void appendAiResult(Map<String, Object> result, List<String> texts, String rawTextsKey) {
         if (texts.size() < aiService.getMinResponseThreshold()) {
+            result.put("aiSummary", null);
+            result.put("clusters", List.of());
             result.put(rawTextsKey, texts);
             return;
         }
@@ -109,8 +111,9 @@ public class FiveSecondReportHandler implements ReportHandler {
                     result.put(rawTextsKey, ReportHandlerUtils.sampleTexts(texts));
                 },
                 () -> {
+                    result.put("aiSummary", null);
                     result.put("clusters", ReportHandlerUtils.buildClusters(texts));
-                    result.put(rawTextsKey, texts);
+                    result.put(rawTextsKey, ReportHandlerUtils.sampleTexts(texts));
                 }
         );
     }

--- a/src/main/java/server/MATE/domain/report/service/handler/ObjectiveReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/ObjectiveReportHandler.java
@@ -84,6 +84,8 @@ public class ObjectiveReportHandler implements ReportHandler {
 
     private void appendAiResult(Map<String, Object> result, List<String> texts) {
         if (texts.size() < aiService.getMinResponseThreshold()) {
+            result.put("aiSummary", null);
+            result.put("clusters", List.of());
             result.put("otherTexts", texts);
             return;
         }
@@ -95,8 +97,9 @@ public class ObjectiveReportHandler implements ReportHandler {
                     result.put("otherTexts", ReportHandlerUtils.sampleTexts(texts));
                 },
                 () -> {
+                    result.put("aiSummary", null);
                     result.put("clusters", ReportHandlerUtils.buildClusters(texts));
-                    result.put("otherTexts", texts);
+                    result.put("otherTexts", ReportHandlerUtils.sampleTexts(texts));
                 }
         );
     }

--- a/src/main/java/server/MATE/domain/report/service/handler/ReportHandlerUtils.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/ReportHandlerUtils.java
@@ -30,9 +30,9 @@ public final class ReportHandlerUtils {
                         Comparator.comparingInt(List::size)).reversed())
                 .map(e -> {
                     Map<String, Object> cluster = new LinkedHashMap<>();
-                    cluster.put("tag", null);
                     cluster.put("representative", e.getKey());
                     cluster.put("count", e.getValue().size());
+                    cluster.put("responses", e.getValue());
                     return cluster;
                 })
                 .toList();

--- a/src/main/java/server/MATE/domain/report/service/handler/SubjectiveReportHandler.java
+++ b/src/main/java/server/MATE/domain/report/service/handler/SubjectiveReportHandler.java
@@ -44,6 +44,8 @@ public class SubjectiveReportHandler implements ReportHandler {
         Map<String, Object> result = new LinkedHashMap<>();
 
         if (allTexts.size() < aiService.getMinResponseThreshold()) {
+            result.put("aiSummary", null);
+            result.put("clusters", List.of());
             result.put("texts", allTexts);
             return result;
         }
@@ -55,8 +57,9 @@ public class SubjectiveReportHandler implements ReportHandler {
                     result.put("texts", ReportHandlerUtils.sampleTexts(allTexts));
                 },
                 () -> {
+                    result.put("aiSummary", null);
                     result.put("clusters", ReportHandlerUtils.buildClusters(allTexts));
-                    result.put("texts", allTexts);
+                    result.put("texts", ReportHandlerUtils.sampleTexts(allTexts));
                 }
         );
         return result;

--- a/src/main/java/server/MATE/global/claude/AiAnalysisResult.java
+++ b/src/main/java/server/MATE/global/claude/AiAnalysisResult.java
@@ -6,15 +6,15 @@ import java.util.Map;
 
 public record AiAnalysisResult(String aiSummary, List<ClusterResult> clusters) {
 
-    public record ClusterResult(String tag, String representative, int count) {}
+    public record ClusterResult(String tag, String representative, int count, List<String> responses) {}
 
     public List<Map<String, Object>> toClusterMaps() {
         return clusters.stream()
                 .map(c -> {
                     Map<String, Object> m = new LinkedHashMap<>();
-                    m.put("tag", c.tag());
                     m.put("representative", c.representative());
                     m.put("count", c.count());
+                    m.put("responses", c.responses());
                     return m;
                 })
                 .toList();

--- a/src/main/java/server/MATE/global/claude/SubjectiveAiService.java
+++ b/src/main/java/server/MATE/global/claude/SubjectiveAiService.java
@@ -50,7 +50,7 @@ public class SubjectiveAiService {
     public Optional<AiAnalysisResult> analyze(List<String> texts) {
         try {
             String rawJson = callClaude(texts);
-            return Optional.of(parseAndValidate(rawJson, texts.size()));
+            return Optional.of(parseAndValidate(rawJson, texts));
         } catch (Exception e) {
             log.warn("Claude AI 분석 실패, 폴백 처리: {}", e.getMessage());
             return Optional.empty();
@@ -114,7 +114,7 @@ public class SubjectiveAiService {
     }
 
     @SuppressWarnings("unchecked")
-    private AiAnalysisResult parseAndValidate(String json, int textCount) throws Exception {
+    private AiAnalysisResult parseAndValidate(String json, List<String> texts) throws Exception {
         Map<String, Object> parsed = objectMapper.readValue(json, new TypeReference<>() {});
         if (parsed == null) {
             throw new IllegalStateException("JSON 파싱 결과가 null입니다.");
@@ -128,8 +128,8 @@ public class SubjectiveAiService {
             throw new IllegalStateException("LLM 응답에 필수 필드(aiSummary, clusters, mappings)가 누락되었습니다.");
         }
 
-        if (rawMappings.size() != textCount) {
-            throw new IllegalStateException("mappings 길이 불일치: " + rawMappings.size() + " != " + textCount);
+        if (rawMappings.size() != texts.size()) {
+            throw new IllegalStateException("mappings 길이 불일치: " + rawMappings.size() + " != " + texts.size());
         }
 
         int[] mappings = rawMappings.stream()
@@ -152,6 +152,13 @@ public class SubjectiveAiService {
             throw new IllegalStateException("클러스터 수 범위 초과: " + countByCluster.size());
         }
 
+        Map<Integer, List<String>> responsesByCluster = IntStream.range(0, mappings.length)
+                .boxed()
+                .collect(Collectors.groupingBy(
+                        i -> mappings[i],
+                        Collectors.mapping(texts::get, Collectors.toList())
+                ));
+
         List<AiAnalysisResult.ClusterResult> clusters = IntStream.range(0, rawClusters.size())
                 .mapToObj(i -> {
                     Map<String, Object> c = rawClusters.get(i);
@@ -159,10 +166,12 @@ public class SubjectiveAiService {
                         throw new IllegalStateException("클러스터 정보가 올바르지 않습니다 (null).");
                     }
                     int count = countByCluster.getOrDefault(i, 0L).intValue();
+                    List<String> responses = responsesByCluster.getOrDefault(i, List.of());
                     return new AiAnalysisResult.ClusterResult(
                             (String) c.get("tag"),
                             (String) c.get("representative"),
-                            count
+                            count,
+                            responses
                     );
                 })
                 .filter(c -> c.count() > 0)

--- a/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/ReportEndToEndIntegrationTest.java
@@ -104,6 +104,9 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         JsonNode result = reportData(actors.testId(), actors.makerToken()).path("reports").get(0);
         assertThat(result.path("type").asText()).isEqualTo("SUBJECTIVE");
         JsonNode resultData = result.path("result");
+        assertThat(resultData.path("aiSummary").isNull()).isTrue();
+        assertThat(resultData.path("clusters").isArray()).isTrue();
+        assertThat(resultData.path("clusters")).isEmpty();
         JsonNode texts = resultData.path("texts");
         assertThat(texts).hasSize(1);
         assertThat(texts.get(0).asText()).isEqualTo("주관식 응답");
@@ -185,6 +188,9 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         JsonNode result = reportData(actors.testId(), actors.makerToken()).path("reports").get(0);
         assertThat(result.path("type").asText()).isEqualTo("FIVE_SECOND");
         JsonNode resultData = result.path("result");
+        assertThat(resultData.path("aiSummary").isNull()).isTrue();
+        assertThat(resultData.path("clusters").isArray()).isTrue();
+        assertThat(resultData.path("clusters")).isEmpty();
         JsonNode texts = resultData.path("texts");
         assertThat(texts).hasSize(1);
         assertThat(texts.get(0).asText()).isEqualTo("5초 주관 응답");
@@ -369,29 +375,35 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
     }
 
     @Test
-    @DisplayName("응답이 없는 SUBJECTIVE 질문의 리포트는 texts가 빈 리스트다")
+    @DisplayName("응답이 없는 SUBJECTIVE 질문의 리포트는 aiSummary가 null이고 clusters가 빈 배열이며 texts가 빈 리스트다")
     void getReport_withNoSubjectiveAnswers_returnsEmptyTexts() throws Exception {
         TestActors actors = createActors();
         createSingleSubjectiveQuestion(actors.testId(), actors.makerToken());
         completeTest(actors.testId());
 
-        JsonNode texts = reportData(actors.testId(), actors.makerToken())
-                .path("reports").get(0).path("result").path("texts");
-        assertThat(texts.isArray()).isTrue();
-        assertThat(texts).isEmpty();
+        JsonNode result = reportData(actors.testId(), actors.makerToken())
+                .path("reports").get(0).path("result");
+        assertThat(result.path("aiSummary").isNull()).isTrue();
+        assertThat(result.path("clusters").isArray()).isTrue();
+        assertThat(result.path("clusters")).isEmpty();
+        assertThat(result.path("texts").isArray()).isTrue();
+        assertThat(result.path("texts")).isEmpty();
     }
 
     @Test
-    @DisplayName("응답이 없는 FIVE_SECOND 주관식 질문의 리포트는 texts가 빈 리스트다")
+    @DisplayName("응답이 없는 FIVE_SECOND 주관식 질문의 리포트는 aiSummary가 null이고 clusters가 빈 배열이며 texts가 빈 리스트다")
     void getReport_withNoFiveSecondSubjectiveAnswers_returnsEmptyTexts() throws Exception {
         TestActors actors = createActors();
         createFiveSecondSubjectiveQuestion(actors.testId(), actors.makerToken());
         completeTest(actors.testId());
 
-        JsonNode texts = reportData(actors.testId(), actors.makerToken())
-                .path("reports").get(0).path("result").path("texts");
-        assertThat(texts.isArray()).isTrue();
-        assertThat(texts).isEmpty();
+        JsonNode result = reportData(actors.testId(), actors.makerToken())
+                .path("reports").get(0).path("result");
+        assertThat(result.path("aiSummary").isNull()).isTrue();
+        assertThat(result.path("clusters").isArray()).isTrue();
+        assertThat(result.path("clusters")).isEmpty();
+        assertThat(result.path("texts").isArray()).isTrue();
+        assertThat(result.path("texts")).isEmpty();
     }
 
     @Test
@@ -792,7 +804,7 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
     }
 
     @Test
-    @DisplayName("OBJECTIVE isOther=true 응답 시 리포트에 clusters와 texts가 포함된다")
+    @DisplayName("OBJECTIVE isOther=true 응답 시 threshold 미만이면 aiSummary가 null이고 clusters가 빈 배열이며 otherTexts가 반환된다")
     void getReport_withObjectiveOtherText_returnsClustersAndTexts() throws Exception {
         TestActors actors = createActors();
         createObjectiveQuestion(actors.testId(), actors.makerToken(), false, null, null, true);
@@ -810,6 +822,9 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         completeTest(actors.testId());
 
         JsonNode result = reportData(actors.testId(), actors.makerToken()).path("reports").get(0).path("result");
+        assertThat(result.path("aiSummary").isNull()).isTrue();
+        assertThat(result.path("clusters").isArray()).isTrue();
+        assertThat(result.path("clusters")).isEmpty();
         JsonNode otherTexts = result.path("otherTexts");
         assertThat(otherTexts).hasSize(1);
         assertThat(otherTexts.get(0).asText()).isEqualTo("직접 입력 응답");
@@ -1159,7 +1174,7 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
     }
 
     @Test
-    @DisplayName("FIVE_SECOND isOther=true 응답 시 리포트에 clusters와 texts가 포함된다")
+    @DisplayName("FIVE_SECOND isOther=true 응답 시 threshold 미만이면 aiSummary가 null이고 clusters가 빈 배열이며 otherTexts가 반환된다")
     void getReport_withFiveSecondOtherText_returnsClustersAndTexts() throws Exception {
         TestActors actors = createActors();
         createFiveSecondObjectiveQuestion(actors.testId(), actors.makerToken(), false, null, null, true);
@@ -1184,6 +1199,9 @@ class ReportEndToEndIntegrationTest extends BaseQuestionAnswerEndToEndTest {
         completeTest(actors.testId());
 
         JsonNode result = reportData(actors.testId(), actors.makerToken()).path("reports").get(0).path("result");
+        assertThat(result.path("aiSummary").isNull()).isTrue();
+        assertThat(result.path("clusters").isArray()).isTrue();
+        assertThat(result.path("clusters")).isEmpty();
         JsonNode otherTexts = result.path("otherTexts");
         assertThat(otherTexts).hasSize(1);
         assertThat(otherTexts.get(0).asText()).isEqualTo("5초 기타 응답");


### PR DESCRIPTION
  ## 📍 요약
  threshold 미만/이상 모든 케이스에서 동일한 응답 구조를 반환하도록 통일하고,
  클러스터 응답 필드를 개선.
  
  ## 🔗 관련 이슈
  - Closes #181
  
  ## 📌 변경 사항
  - [x] 기능
  - [x] 버그 수정
  - [ ] 리팩토링
  - [x] 문서
  - [ ] 테스트
  - [ ] 기타
  
  ## ✅ 작업 내용
  - threshold 미만 시 `aiSummary: null`, `clusters: []` 명시적 반환 (기존: 필드 누락)
  - Claude 실패 시 `texts` / `otherTexts`도 최대 15개 샘플로 제한 (기존: 전체 반환)
  - 클러스터 응답에 `responses` 필드 추가 — 해당 클러스터 원문 응답 목록 
  - 클러스터 응답에서 `tag` 필드 제거 (내부적으로는 유지) 
  - 리포트 조회 API Swagger 설명에 케이스별 응답 구조 표 추가
  
  | 상황 | aiSummary | clusters | texts / otherTexts |
  |------|-----------|----------|--------------------|
  | 응답 수 < 기준치 | null | [] | 전체 응답 |
  | 응답 수 ≥ 기준치, AI 요약 성공 | AI 요약 문자열 | AI 클러스터 목록 | 최대 15개 샘플 |
  | 응답 수 ≥ 기준치, AI 요약 실패 | null | 동일 응답 기준 그룹화 | 최대 15개 샘플 |
  
  ## 테스트
  로컬 통합 테스트 완료