### PR TITLE
refactor: 테스트 조회 조건을 QueryDSL BooleanExpression으로 조합하도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,12 @@ dependencies {
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
   
     // azure SDK (런타임 Blob). prod 비밀은 클러스터에서 External Secrets → env 주입 — KV SDK 미사용.
     implementation 'com.azure:azure-storage-blob:12.29.1'

--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -97,7 +97,7 @@ public class AnswerService {
 
     @Transactional
     public AnswerBatchCreateResponse createAnswers(Long testId, Long testerId, AnswerCreateRequest request) {
-        Test test = testRepository.findByIdAndDeletedAtIsNullForUpdate(testId)
+        Test test = testRepository.findByIdForUpdate(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
         test.validateCanParticipate();

--- a/src/main/java/server/MATE/domain/question/service/QuestionService.java
+++ b/src/main/java/server/MATE/domain/question/service/QuestionService.java
@@ -58,7 +58,7 @@ public class QuestionService {
 
         // 테스트 내 질문의 시퀀스 할당 시 경쟁을 방지하기 위해 부모 행을 잠금
         // 이를 통해 MAX(sequence) 조회 및 생성 요청을 직렬화하여 처리함
-        Test test = testRepository.findByIdAndDeletedAtIsNullForUpdate(testId)
+        Test test = testRepository.findByIdForUpdate(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
         if (!test.getMakerId().equals(makerId)) throw new BaseException(BaseErrorCode.TEST_005);
@@ -102,7 +102,7 @@ public class QuestionService {
 
     @Transactional(readOnly = true)
     public QuestionsDetailResponse getQuestionsDetails(Long testId) {
-        testRepository.findByIdAndDeletedAtIsNull(testId)
+        testRepository.findActiveById(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
         List<Question> questions = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId);
@@ -113,7 +113,7 @@ public class QuestionService {
 
     @Transactional(readOnly = true)
     public QuestionDetailResponse getQuestionDetail(Long testId, Long questionId) {
-        testRepository.findByIdAndDeletedAtIsNull(testId)
+        testRepository.findActiveById(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
         Question question = questionRepository.findByIdAndTestIdAndDeletedAtIsNull(questionId, testId)
@@ -149,7 +149,7 @@ public class QuestionService {
 
     @Transactional(readOnly = true)
     public QuestionSummaryResponse getQuestionSummary(Long testId, Long makerId) {
-        Test test = testRepository.findByIdAndDeletedAtIsNull(testId)
+        Test test = testRepository.findActiveById(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
         if (!test.getMakerId().equals(makerId)) throw new BaseException(BaseErrorCode.TEST_005);

--- a/src/main/java/server/MATE/domain/report/event/ReportAggregateService.java
+++ b/src/main/java/server/MATE/domain/report/event/ReportAggregateService.java
@@ -55,7 +55,7 @@ public class ReportAggregateService {
             noRetryFor = {BaseException.class, DataIntegrityViolationException.class})
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public List<Report> aggregate(Long testId) {
-        Test test = testRepository.findByIdAndDeletedAtIsNull(testId)
+        Test test = testRepository.findActiveById(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
         long questionCount = questionRepository.countByTestIdAndDeletedAtIsNull(testId);
@@ -140,7 +140,7 @@ public class ReportAggregateService {
     }
 
     private void updateReportStatus(Long testId, Consumer<Test> action) {
-        testRepository.findByIdAndDeletedAtIsNull(testId).ifPresent(test -> {
+        testRepository.findActiveById(testId).ifPresent(test -> {
             action.accept(test);
             testRepository.save(test);
         });

--- a/src/main/java/server/MATE/domain/report/service/ReportService.java
+++ b/src/main/java/server/MATE/domain/report/service/ReportService.java
@@ -33,7 +33,7 @@ public class ReportService {
     private final ReportRepository reportRepository;
 
     public ReportResponse getReport(Long testId, Long userId, Role role) {
-        Test test = testRepository.findByIdAndDeletedAtIsNull(testId)
+        Test test = testRepository.findActiveById(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
         if (role != Role.ADMIN && !test.getMakerId().equals(userId)) throw new BaseException(BaseErrorCode.TEST_005);
 

--- a/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelExportSupport.java
+++ b/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelExportSupport.java
@@ -16,7 +16,7 @@ public class ReportExcelExportSupport {
     private final TestRepository testRepository;
 
     public Test requireExportReadyTest(Long testId, Long makerId) {
-        Test test = testRepository.findByIdAndDeletedAtIsNull(testId)
+        Test test = testRepository.findActiveById(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
         if (!test.getMakerId().equals(makerId)) {
             throw new BaseException(BaseErrorCode.TEST_005);

--- a/src/main/java/server/MATE/domain/test/entity/Test.java
+++ b/src/main/java/server/MATE/domain/test/entity/Test.java
@@ -19,7 +19,6 @@ import java.util.List;
 @Table(name = "test")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Test extends BaseEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -165,6 +164,9 @@ public class Test extends BaseEntity {
         this.reward = reward == null ? 300 : reward;
         this.pplCount = 0L;
         this.likeCount = 0L;
+        if (closedAt == null) {
+            throw new BaseException(BaseErrorCode.TEST_008);
+        }
         this.closedAt = closedAt;
     }
 }

--- a/src/main/java/server/MATE/domain/test/repository/TestQueryRepository.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestQueryRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface TestQueryRepository {
 
-    List<Test> findActiveTests(List<TestStatus> statuses, LocalDateTime closedAt);
+    List<Test> findAvailableTestsForUser(List<TestStatus> statuses, LocalDateTime closedAt, Long userId);
 
     List<Test> findByMakerId(Long makerId);
 

--- a/src/main/java/server/MATE/domain/test/repository/TestQueryRepository.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestQueryRepository.java
@@ -1,0 +1,23 @@
+package server.MATE.domain.test.repository;
+
+import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.entity.TestStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface TestQueryRepository {
+
+    List<Test> findActiveTests(List<TestStatus> statuses, LocalDateTime closedAt);
+
+    List<Test> findByMakerId(Long makerId);
+
+    List<Test> findLikedTests(Long userId, List<TestStatus> statuses);
+
+    Optional<Test> findActiveById(Long id);
+
+    Optional<Test> findWithCategoriesById(Long id);
+
+    Optional<Test> findByIdForUpdate(Long id);
+}

--- a/src/main/java/server/MATE/domain/test/repository/TestQueryRepositoryImpl.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestQueryRepositoryImpl.java
@@ -30,28 +30,26 @@ public class TestQueryRepositoryImpl implements TestQueryRepository {
 
     // 전달받은 ID와 테스트 ID가 같은 경우만 거르는 조건
     private static BooleanExpression idEq(Long id) {
-        return id != null ? test.id.eq(id) : null;
+        return test.id.eq(id);
     }
 
     // 전달받은 사용자와 테스트 생성자가 같은 경우만 거르는 조건
     private static BooleanExpression makerIdEq(Long makerId) {
-        return makerId != null ? test.makerId.eq(makerId) : null;
+        return test.makerId.eq(makerId);
     }
 
     // 전달받은 상태 목록(statuses)인 테스트만 가져오는 조건
     private static BooleanExpression statusIn(List<TestStatus> statuses) {
-        return (statuses != null && !statuses.isEmpty())
-                ? test.testStatus.in(statuses) : null;
+        return test.testStatus.in(statuses);
     }
 
     // 테스트 마감 기한이 기준 시간(time)과 같거나 이후인 경우만 거르는 조건
     private static BooleanExpression closedAtAfter(LocalDateTime time) {
-        return time != null ? test.closedAt.goe(time) : null;
+        return test.closedAt.goe(time);
     }
 
     // 현재 조회 중인 테스트에 해당 유저가 응답한 경우만 거르는 조건
     private static BooleanExpression participatedBy(Long userId) {
-        if (userId == null) return null;
         QParticipation p = QParticipation.participation;
         return JPAExpressions
                 .selectOne()
@@ -66,13 +64,16 @@ public class TestQueryRepositoryImpl implements TestQueryRepository {
 
     // 현재 조회 중인 테스트에 해당 유저가 응답하지 않은 경우만 거르는 조건
     private static BooleanExpression notParticipatedBy(Long userId) {
-        if (userId == null) return null;
         return participatedBy(userId).not();
     }
 
 
     @Override
     public List<Test> findAvailableTestsForUser(List<TestStatus> statuses, LocalDateTime closedAt, Long userId) {
+        if (statuses == null || statuses.isEmpty() || closedAt == null || userId == null) {
+            return List.of();
+        }
+
         return queryFactory
                 .selectFrom(test)
                 .leftJoin(test.categories).fetchJoin()
@@ -84,6 +85,10 @@ public class TestQueryRepositoryImpl implements TestQueryRepository {
 
     @Override
     public List<Test> findByMakerId(Long makerId) {
+        if (makerId == null) {
+            return List.of();
+        }
+
         return queryFactory
                 .selectFrom(test)
                 .where(makerIdEq(makerId), notDeleted())
@@ -93,6 +98,10 @@ public class TestQueryRepositoryImpl implements TestQueryRepository {
 
     @Override
     public List<Test> findLikedTests(Long userId, List<TestStatus> statuses) {
+        if (userId == null || statuses == null || statuses.isEmpty()) {
+            return List.of();
+        }
+
         QTestLike testLike = QTestLike.testLike;
         return queryFactory
                 .selectFrom(test)
@@ -108,6 +117,10 @@ public class TestQueryRepositoryImpl implements TestQueryRepository {
 
     @Override
     public Optional<Test> findActiveById(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+
         return Optional.ofNullable(
                 queryFactory
                         .selectFrom(test)
@@ -118,6 +131,10 @@ public class TestQueryRepositoryImpl implements TestQueryRepository {
 
     @Override
     public Optional<Test> findWithCategoriesById(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+
         return Optional.ofNullable(
                 queryFactory
                         .selectFrom(test)
@@ -132,6 +149,10 @@ public class TestQueryRepositoryImpl implements TestQueryRepository {
 
     @Override
     public Optional<Test> findByIdForUpdate(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+
         return Optional.ofNullable(
                 queryFactory
                         .selectFrom(test)

--- a/src/main/java/server/MATE/domain/test/repository/TestQueryRepositoryImpl.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestQueryRepositoryImpl.java
@@ -72,11 +72,11 @@ public class TestQueryRepositoryImpl implements TestQueryRepository {
 
 
     @Override
-    public List<Test> findActiveTests(List<TestStatus> statuses, LocalDateTime closedAt) {
+    public List<Test> findAvailableTestsForUser(List<TestStatus> statuses, LocalDateTime closedAt, Long userId) {
         return queryFactory
                 .selectFrom(test)
                 .leftJoin(test.categories).fetchJoin()
-                .where(statusIn(statuses), notDeleted(), closedAtAfter(closedAt))
+                .where(statusIn(statuses), notDeleted(), closedAtAfter(closedAt), notParticipatedBy(userId))
                 .orderBy(test.createdAt.desc())
                 .distinct()
                 .fetch();

--- a/src/main/java/server/MATE/domain/test/repository/TestQueryRepositoryImpl.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestQueryRepositoryImpl.java
@@ -7,7 +7,6 @@ import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import server.MATE.domain.participation.entity.QParticipation;
-import server.MATE.domain.test.entity.QTest;
 import server.MATE.domain.test.entity.QTestLike;
 import server.MATE.domain.test.entity.Test;
 import server.MATE.domain.test.entity.TestStatus;
@@ -16,41 +15,41 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static server.MATE.domain.test.entity.QTest.test;
+
 @Repository
 @RequiredArgsConstructor
 public class TestQueryRepositoryImpl implements TestQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    private static final QTest test = QTest.test;
-
-    // ── BooleanExpression 조각 ──────────────────────────────────────────────
-
+    // 삭제되지 않은 테스트만 가져오는 조건
     private static BooleanExpression notDeleted() {
         return test.deletedAt.isNull();
     }
 
+    // 전달받은 ID와 테스트 ID가 같은 경우만 거르는 조건
     private static BooleanExpression idEq(Long id) {
         return id != null ? test.id.eq(id) : null;
     }
 
+    // 전달받은 사용자와 테스트 생성자가 같은 경우만 거르는 조건
     private static BooleanExpression makerIdEq(Long makerId) {
         return makerId != null ? test.makerId.eq(makerId) : null;
     }
 
+    // 전달받은 상태 목록(statuses)인 테스트만 가져오는 조건
     private static BooleanExpression statusIn(List<TestStatus> statuses) {
         return (statuses != null && !statuses.isEmpty())
                 ? test.testStatus.in(statuses) : null;
     }
 
+    // 테스트 마감 기한이 기준 시간(time)과 같거나 이후인 경우만 거르는 조건
     private static BooleanExpression closedAtAfter(LocalDateTime time) {
         return time != null ? test.closedAt.goe(time) : null;
     }
 
-    /**
-     * 특정 유저가 이 테스트에 참여한 경우 true — 미래 메서드 조합용 조각.
-     * 사용 예: .where(notParticipatedBy(userId)) → 내가 아직 참여 안 한 테스트 필터
-     */
+    // 현재 조회 중인 테스트에 해당 유저가 응답한 경우만 거르는 조건
     private static BooleanExpression participatedBy(Long userId) {
         if (userId == null) return null;
         QParticipation p = QParticipation.participation;
@@ -65,40 +64,80 @@ public class TestQueryRepositoryImpl implements TestQueryRepository {
                 .exists();
     }
 
+    // 현재 조회 중인 테스트에 해당 유저가 응답하지 않은 경우만 거르는 조건
     private static BooleanExpression notParticipatedBy(Long userId) {
         if (userId == null) return null;
         return participatedBy(userId).not();
     }
 
-    // ── 메서드 구현 (스텁 — Task 4, 5에서 교체) ────────────────────────────
 
     @Override
     public List<Test> findActiveTests(List<TestStatus> statuses, LocalDateTime closedAt) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        return queryFactory
+                .selectFrom(test)
+                .leftJoin(test.categories).fetchJoin()
+                .where(statusIn(statuses), notDeleted(), closedAtAfter(closedAt))
+                .orderBy(test.createdAt.desc())
+                .distinct()
+                .fetch();
     }
 
     @Override
     public List<Test> findByMakerId(Long makerId) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        return queryFactory
+                .selectFrom(test)
+                .where(makerIdEq(makerId), notDeleted())
+                .orderBy(test.createdAt.desc())
+                .fetch();
     }
 
     @Override
     public List<Test> findLikedTests(Long userId, List<TestStatus> statuses) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        QTestLike testLike = QTestLike.testLike;
+        return queryFactory
+                .selectFrom(test)
+                .join(testLike).on(testLike.testId.eq(test.id))
+                .where(
+                        testLike.userId.eq(userId),
+                        notDeleted(),
+                        statusIn(statuses)
+                )
+                .orderBy(testLike.createdAt.desc())
+                .fetch();
     }
 
     @Override
     public Optional<Test> findActiveById(Long id) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(test)
+                        .where(idEq(id), notDeleted())
+                        .fetchOne()
+        );
     }
 
     @Override
     public Optional<Test> findWithCategoriesById(Long id) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(test)
+                        // categories를 fetch join하면 테스트가 중복 조회될 수 있어 distinct로 중복 제거함
+                        // 컬렉션 fetch join은 하나만 두는 편이 안전함
+                        .leftJoin(test.categories).fetchJoin()
+                        .where(idEq(id), notDeleted())
+                        .distinct()
+                        .fetchOne()
+        );
     }
 
     @Override
     public Optional<Test> findByIdForUpdate(Long id) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(test)
+                        .where(idEq(id), notDeleted())
+                        .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                        .fetchOne()
+        );
     }
 }

--- a/src/main/java/server/MATE/domain/test/repository/TestQueryRepositoryImpl.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestQueryRepositoryImpl.java
@@ -1,0 +1,104 @@
+package server.MATE.domain.test.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import server.MATE.domain.participation.entity.QParticipation;
+import server.MATE.domain.test.entity.QTest;
+import server.MATE.domain.test.entity.QTestLike;
+import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.entity.TestStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class TestQueryRepositoryImpl implements TestQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private static final QTest test = QTest.test;
+
+    // ── BooleanExpression 조각 ──────────────────────────────────────────────
+
+    private static BooleanExpression notDeleted() {
+        return test.deletedAt.isNull();
+    }
+
+    private static BooleanExpression idEq(Long id) {
+        return id != null ? test.id.eq(id) : null;
+    }
+
+    private static BooleanExpression makerIdEq(Long makerId) {
+        return makerId != null ? test.makerId.eq(makerId) : null;
+    }
+
+    private static BooleanExpression statusIn(List<TestStatus> statuses) {
+        return (statuses != null && !statuses.isEmpty())
+                ? test.testStatus.in(statuses) : null;
+    }
+
+    private static BooleanExpression closedAtAfter(LocalDateTime time) {
+        return time != null ? test.closedAt.goe(time) : null;
+    }
+
+    /**
+     * 특정 유저가 이 테스트에 참여한 경우 true — 미래 메서드 조합용 조각.
+     * 사용 예: .where(notParticipatedBy(userId)) → 내가 아직 참여 안 한 테스트 필터
+     */
+    private static BooleanExpression participatedBy(Long userId) {
+        if (userId == null) return null;
+        QParticipation p = QParticipation.participation;
+        return JPAExpressions
+                .selectOne()
+                .from(p)
+                .where(
+                        p.testId.eq(test.id),
+                        p.testerId.eq(userId),
+                        p.deletedAt.isNull()
+                )
+                .exists();
+    }
+
+    private static BooleanExpression notParticipatedBy(Long userId) {
+        if (userId == null) return null;
+        return participatedBy(userId).not();
+    }
+
+    // ── 메서드 구현 (스텁 — Task 4, 5에서 교체) ────────────────────────────
+
+    @Override
+    public List<Test> findActiveTests(List<TestStatus> statuses, LocalDateTime closedAt) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public List<Test> findByMakerId(Long makerId) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public List<Test> findLikedTests(Long userId, List<TestStatus> statuses) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public Optional<Test> findActiveById(Long id) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public Optional<Test> findWithCategoriesById(Long id) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public Optional<Test> findByIdForUpdate(Long id) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+}

--- a/src/main/java/server/MATE/domain/test/repository/TestRepository.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestRepository.java
@@ -1,53 +1,7 @@
 package server.MATE.domain.test.repository;
 
-import jakarta.persistence.LockModeType;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import server.MATE.domain.test.entity.Test;
-import server.MATE.domain.test.entity.TestStatus;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
-public interface TestRepository extends JpaRepository<Test, Long> {
-
-    @EntityGraph(attributePaths = {"categories"})
-    List<Test> findAllByTestStatusInAndDeletedAtIsNullAndClosedAtGreaterThanEqualOrderByCreatedAtDesc(
-            List<TestStatus> testStatuses,
-            LocalDateTime closedAt
-    );
-
-    List<Test> findAllByMakerIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long makerId);
-
-    @Query("""
-            select t
-            from Test t
-            join TestLike tl on tl.testId = t.id
-            where tl.userId = :userId
-              and t.deletedAt is null
-              and t.testStatus in :testStatuses
-            order by tl.createdAt desc
-            """)
-    List<Test> findLikedTestsByUserId(
-            @Param("userId") Long userId,
-            @Param("testStatuses") List<TestStatus> testStatuses
-    );
-
-    Optional<Test> findByIdAndDeletedAtIsNull(Long id);
-
-    @EntityGraph(attributePaths = {"categories"})
-    Optional<Test> findWithCategoriesByIdAndDeletedAtIsNull(Long id);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("""
-            select t
-            from Test t
-            where t.id = :id
-              and t.deletedAt is null
-            """)
-    Optional<Test> findByIdAndDeletedAtIsNullForUpdate(@Param("id") Long id);
+public interface TestRepository extends JpaRepository<Test, Long>, TestQueryRepository {
 }

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -47,9 +47,10 @@ public class TestService {
     @Transactional(readOnly = true)
     public TestSummaryListResponse listTests(Long userId) {
         LocalDateTime threshold = LocalDate.now(clock.withZone(KST)).atStartOfDay();
-        List<Test> tests = testRepository.findActiveTests(
+        List<Test> tests = testRepository.findAvailableTestsForUser(
                 List.of(TestStatus.IN_PROGRESS, TestStatus.WAITING),
-                threshold
+                threshold,
+                userId
         );
         return TestSummaryListResponse.from(toSummaryResponses(userId, tests));
     }

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -47,7 +47,7 @@ public class TestService {
     @Transactional(readOnly = true)
     public TestSummaryListResponse listTests(Long userId) {
         LocalDateTime threshold = LocalDate.now(clock.withZone(KST)).atStartOfDay();
-        List<Test> tests = testRepository.findAllByTestStatusInAndDeletedAtIsNullAndClosedAtGreaterThanEqualOrderByCreatedAtDesc(
+        List<Test> tests = testRepository.findActiveTests(
                 List.of(TestStatus.IN_PROGRESS, TestStatus.WAITING),
                 threshold
         );
@@ -56,7 +56,7 @@ public class TestService {
 
     @Transactional(readOnly = true)
     public MyTestSummaryResponse listMyTests(Long makerId) {
-        List<Test> tests = testRepository.findAllByMakerIdAndDeletedAtIsNullOrderByCreatedAtDesc(makerId);
+        List<Test> tests = testRepository.findByMakerId(makerId);
         List<MyTestSummaryItem> items = tests.stream()
                 .map(MyTestSummaryItem::from)
                 .toList();
@@ -65,7 +65,7 @@ public class TestService {
 
     @Transactional(readOnly = true)
     public LikedTestSummaryResponse listLikedTests(Long userId) {
-        List<Test> tests = testRepository.findLikedTestsByUserId(
+        List<Test> tests = testRepository.findLikedTests(
                 userId,
                 List.of(TestStatus.IN_PROGRESS, TestStatus.WAITING, TestStatus.COMPLETED)
         );
@@ -77,14 +77,14 @@ public class TestService {
 
     @Transactional(readOnly = true)
     public TestDetailResponse getTest(Long testId, Long userId) {
-        Test test = testRepository.findWithCategoriesByIdAndDeletedAtIsNull(testId)
+        Test test = testRepository.findWithCategoriesById(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
         boolean hasResponded = participationRepository.existsByTestIdAndTesterIdAndDeletedAtIsNull(testId, userId);
         return TestDetailResponse.from(test, toImageUrls(test.getImageKeys()), hasResponded);
     }
 
     public TestStatusUpdateResponse updateTestStatus(Long testId, Long userId, Role role, TestStatus status) {
-        Test test = testRepository.findByIdAndDeletedAtIsNull(testId)
+        Test test = testRepository.findActiveById(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
         switch (status) {
@@ -122,7 +122,7 @@ public class TestService {
     }
 
     public TestLikeResponse likeTest(Long testId, Long userId) {
-        Test test = testRepository.findByIdAndDeletedAtIsNullForUpdate(testId)
+        Test test = testRepository.findByIdForUpdate(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
         if (!testLikeRepository.existsByUserIdAndTestId(userId, testId)) {
@@ -137,7 +137,7 @@ public class TestService {
     }
 
     public TestLikeResponse unlikeTest(Long testId, Long userId) {
-        Test test = testRepository.findByIdAndDeletedAtIsNullForUpdate(testId)
+        Test test = testRepository.findByIdForUpdate(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
         testLikeRepository.findByUserIdAndTestId(userId, testId)

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -43,6 +43,7 @@ public enum BaseErrorCode implements ErrorCode {
     TEST_005(HttpStatus.FORBIDDEN, "TEST_005", "테스트 메이커만 조회할 수 있습니다."),
     TEST_006(HttpStatus.BAD_REQUEST, "TEST_006", "테스트가 종료된 후에 조회할 수 있습니다."),
     TEST_007(HttpStatus.BAD_REQUEST, "TEST_007", "현재 상태에서는 변경할 수 없습니다."),
+    TEST_008(HttpStatus.BAD_REQUEST, "TEST_008", "테스트 마감 기한은 필수입니다."),
 
     // Test Draft
     DRAFT_001(HttpStatus.NOT_FOUND, "DRAFT_001", "테스트 초안을 찾을 수 없습니다."),

--- a/src/main/java/server/MATE/global/config/QuerydslConfig.java
+++ b/src/main/java/server/MATE/global/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package server.MATE.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceIntegrationTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceIntegrationTest.java
@@ -211,6 +211,7 @@ class QuestionServiceIntegrationTest {
                 .serviceName("서비스")
                 .serviceDescription("서비스 설명")
                 .imageKeys(List.of())
+                .closedAt(LocalDateTime.of(2099, 12, 31, 23, 59, 59))
                 .build());
 
         QuestionCreateResponse createResponse = questionService.createQuestions(secondTest.getId(), 2L, new QuestionCreateRequest(List.of(
@@ -762,6 +763,7 @@ class QuestionServiceIntegrationTest {
                 .serviceName("서비스")
                 .serviceDescription("서비스 설명")
                 .imageKeys(List.of())
+                .closedAt(LocalDateTime.of(2099, 12, 31, 23, 59, 59))
                 .build());
     }
 }

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
@@ -129,7 +129,7 @@ class QuestionServiceTest {
         setQuestionId(objectiveQuestion, 201L);
         setQuestionId(scaleQuestion, 202L);
 
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
         given(questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID))
                 .willReturn(List.of(scaleQuestion, objectiveQuestion));
         given(objectiveFetcher.fetch(List.of(objectiveQuestion))).willReturn(Map.of(
@@ -176,7 +176,7 @@ class QuestionServiceTest {
     @Test
     @DisplayName("질문이 없는 테스트 조회는 빈 questions 배열을 반환한다")
     void returnsEmptyQuestionListWhenTestHasNoQuestions() {
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
         given(questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID))
                 .willReturn(List.of());
 
@@ -200,7 +200,7 @@ class QuestionServiceTest {
                 .build();
         setQuestionId(objectiveQuestion, 201L);
 
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
         given(questionRepository.findByIdAndTestIdAndDeletedAtIsNull(201L, TEST_ID))
                 .willReturn(Optional.of(objectiveQuestion));
         given(objectiveFetcher.fetch(List.of(objectiveQuestion))).willReturn(Map.of(
@@ -233,7 +233,7 @@ class QuestionServiceTest {
         setTestStatus(test, TestStatus.COMPLETED);
         setTestPplCount(test, 12L);
 
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
         given(questionRepository.findQuestionSummariesByTestId(TEST_ID)).willReturn(List.of(
                 new QuestionSummaryItem(202L, 1L, "척도 질문", QuestionType.SCALE),
                 new QuestionSummaryItem(201L, 2L, "객관식 질문", QuestionType.OBJECTIVE)
@@ -255,7 +255,7 @@ class QuestionServiceTest {
     void getQuestionSummaryReturnsWhenTestIsInProgress() {
         setTestStatus(test, TestStatus.IN_PROGRESS);
         setTestPplCount(test, 3L);
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
         given(questionRepository.findQuestionSummariesByTestId(TEST_ID)).willReturn(List.of(
                 new QuestionSummaryItem(301L, 1L, "진행 중 질문", QuestionType.SUBJECTIVE)
         ));
@@ -273,7 +273,7 @@ class QuestionServiceTest {
     @DisplayName("질문 요약 조회 요청자가 제작자가 아니면 TEST_005 예외가 발생한다")
     void getQuestionSummaryThrowsTest005WhenMakerDoesNotMatch() {
         setTestStatus(test, TestStatus.COMPLETED);
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
 
         assertThatThrownBy(() -> questionService.getQuestionSummary(TEST_ID, MAKER_ID + 1))
                 .isInstanceOf(BaseException.class)
@@ -286,7 +286,7 @@ class QuestionServiceTest {
     @Test
     @DisplayName("조회 대상 테스트가 없으면 TEST_004 예외가 발생한다")
     void getQuestionsThrowsTest004WhenTestDoesNotExist() {
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.empty());
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> questionService.getQuestionsDetails(TEST_ID))
                 .isInstanceOf(BaseException.class)
@@ -301,7 +301,7 @@ class QuestionServiceTest {
     @Test
     @DisplayName("삭제된 테스트는 조회 시 TEST_004 예외가 발생한다")
     void getQuestionsThrowsTest004WhenTestIsDeleted() {
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.empty());
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> questionService.getQuestionsDetails(TEST_ID))
                 .isInstanceOf(BaseException.class)
@@ -316,7 +316,7 @@ class QuestionServiceTest {
     @Test
     @DisplayName("문항 상세 조회 대상 테스트가 없으면 TEST_004 예외가 발생한다")
     void getQuestionDetailThrowsTest004WhenTestDoesNotExist() {
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.empty());
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> questionService.getQuestionDetail(TEST_ID, 201L))
                 .isInstanceOf(BaseException.class)
@@ -329,7 +329,7 @@ class QuestionServiceTest {
     @Test
     @DisplayName("문항 상세 조회 대상 문항이 없으면 QUESTION_005 예외가 발생한다")
     void getQuestionDetailThrowsQuestion005WhenQuestionDoesNotExist() {
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
         given(questionRepository.findByIdAndTestIdAndDeletedAtIsNull(201L, TEST_ID))
                 .willReturn(Optional.empty());
 
@@ -351,7 +351,7 @@ class QuestionServiceTest {
                 .build();
         setQuestionId(scaleQuestion, 202L);
 
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
         given(questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID))
                 .willReturn(List.of(scaleQuestion));
         given(scaleFetcher.fetch(List.of(scaleQuestion))).willReturn(Map.of(
@@ -380,7 +380,7 @@ class QuestionServiceTest {
     @Test
     @DisplayName("여러 문항을 요청 순서대로 등록하고 이미지 정리 이벤트를 한 번 발행한다")
     void createQuestionsInRequestOrderAndPublishSingleCleanupEvent() {
-        given(testRepository.findByIdAndDeletedAtIsNullForUpdate(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findByIdForUpdate(TEST_ID)).willReturn(Optional.of(test));
         given(questionRepository.findMaxSequenceByTestId(TEST_ID)).willReturn(5L);
 
         ObjectiveCreateRequest objective = new ObjectiveCreateRequest(
@@ -439,7 +439,7 @@ class QuestionServiceTest {
     @Test
     @DisplayName("혼합 요청은 OBJECTIVE, SCALE, TREE_TEST 순서대로 sequence가 부여된다")
     void assignsSequenceInMixedRequestOrder() {
-        given(testRepository.findByIdAndDeletedAtIsNullForUpdate(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findByIdForUpdate(TEST_ID)).willReturn(Optional.of(test));
         given(questionRepository.findMaxSequenceByTestId(TEST_ID)).willReturn(3L);
 
         ObjectiveCreateRequest objective = new ObjectiveCreateRequest(
@@ -497,7 +497,7 @@ class QuestionServiceTest {
     @Test
     @DisplayName("이미지가 없는 경우 정리 이벤트를 발행하지 않는다")
     void doesNotPublishCleanupEventWhenNoImagesExist() {
-        given(testRepository.findByIdAndDeletedAtIsNullForUpdate(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findByIdForUpdate(TEST_ID)).willReturn(Optional.of(test));
         given(questionRepository.findMaxSequenceByTestId(TEST_ID)).willReturn(0L);
 
         ScaleCreateRequest scale = new ScaleCreateRequest(
@@ -520,7 +520,7 @@ class QuestionServiceTest {
     @Test
     @DisplayName("테스트가 없으면 TEST_004 예외가 발생한다")
     void throwsTest004WhenTestDoesNotExist() {
-        given(testRepository.findByIdAndDeletedAtIsNullForUpdate(TEST_ID)).willReturn(Optional.empty());
+        given(testRepository.findByIdForUpdate(TEST_ID)).willReturn(Optional.empty());
 
         QuestionCreateRequest request = new QuestionCreateRequest(List.of(
                 new ScaleCreateRequest("척도 질문", "설명", null, "낮음", "높음", 5)
@@ -536,7 +536,7 @@ class QuestionServiceTest {
     @DisplayName("삭제된 테스트면 TEST_004 예외가 발생한다")
     void throwsTest004WhenTestIsDeleted() {
         test.delete(LocalDateTime.now());
-        given(testRepository.findByIdAndDeletedAtIsNullForUpdate(TEST_ID)).willReturn(Optional.empty());
+        given(testRepository.findByIdForUpdate(TEST_ID)).willReturn(Optional.empty());
 
         QuestionCreateRequest request = new QuestionCreateRequest(List.of(
                 new ScaleCreateRequest("척도 질문", "설명", null, "낮음", "높음", 5)
@@ -551,7 +551,7 @@ class QuestionServiceTest {
     @Test
     @DisplayName("제작자가 아니면 TEST_005 예외가 발생한다")
     void throwsTest005WhenMakerDoesNotMatch() {
-        given(testRepository.findByIdAndDeletedAtIsNullForUpdate(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findByIdForUpdate(TEST_ID)).willReturn(Optional.of(test));
 
         QuestionCreateRequest request = new QuestionCreateRequest(List.of(
                 new ScaleCreateRequest("척도 질문", "설명", null, "낮음", "높음", 5)
@@ -566,7 +566,7 @@ class QuestionServiceTest {
     @Test
     @DisplayName("핸들러 검증에서 실패하면 저장과 이벤트 발행이 중단된다")
     void stopsPersistenceAndEventPublishingWhenHandlerValidationFails() {
-        given(testRepository.findByIdAndDeletedAtIsNullForUpdate(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findByIdForUpdate(TEST_ID)).willReturn(Optional.of(test));
         given(questionRepository.findMaxSequenceByTestId(TEST_ID)).willReturn(0L);
 
         ScaleCreateRequest scale = new ScaleCreateRequest(
@@ -593,7 +593,7 @@ class QuestionServiceTest {
     @Test
     @DisplayName("중간 문항 처리에서 실패하면 이후 문항 처리와 이벤트 발행이 중단된다")
     void stopsProcessingRemainingItemsWhenIntermediateItemFails() {
-        given(testRepository.findByIdAndDeletedAtIsNullForUpdate(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findByIdForUpdate(TEST_ID)).willReturn(Optional.of(test));
         given(questionRepository.findMaxSequenceByTestId(TEST_ID)).willReturn(0L);
 
         ObjectiveCreateRequest objective = new ObjectiveCreateRequest(
@@ -644,7 +644,7 @@ class QuestionServiceTest {
     @Test
     @DisplayName("이미지가 포함된 문항이 모두 성공하면 cleanup 이벤트를 한 번만 발행한다")
     void publishesCleanupEventOnlyWhenRequestSucceeds() {
-        given(testRepository.findByIdAndDeletedAtIsNullForUpdate(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findByIdForUpdate(TEST_ID)).willReturn(Optional.of(test));
         given(questionRepository.findMaxSequenceByTestId(TEST_ID)).willReturn(10L);
 
         ObjectiveCreateRequest objective = new ObjectiveCreateRequest(
@@ -683,7 +683,7 @@ class QuestionServiceTest {
     @Test
     @DisplayName("중간 실패가 발생하면 cleanup 이벤트를 발행하지 않는다")
     void doesNotPublishCleanupEventWhenIntermediateItemFails() {
-        given(testRepository.findByIdAndDeletedAtIsNullForUpdate(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findByIdForUpdate(TEST_ID)).willReturn(Optional.of(test));
         given(questionRepository.findMaxSequenceByTestId(TEST_ID)).willReturn(0L);
 
         ObjectiveCreateRequest objective = new ObjectiveCreateRequest(

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
@@ -92,6 +92,7 @@ class QuestionServiceTest {
                 .serviceName("서비스")
                 .serviceDescription("서비스 설명")
                 .imageKeys(List.of())
+                .closedAt(LocalDateTime.of(2099, 12, 31, 23, 59, 59))
                 .build();
         lenient().when(objectiveHandler.supports()).thenReturn(QuestionType.OBJECTIVE);
         lenient().when(scaleHandler.supports()).thenReturn(QuestionType.SCALE);

--- a/src/test/java/server/MATE/domain/report/service/ReportAggregateServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/ReportAggregateServiceTest.java
@@ -73,7 +73,7 @@ class ReportAggregateServiceTest {
 
         given(questionRepository.countByTestIdAndDeletedAtIsNull(TEST_ID)).willReturn(2L);
         given(reportRepository.countByTestId(TEST_ID)).willReturn(2L);
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
         given(reportRepository.findAllByTestId(TEST_ID)).willReturn(List.of(report1, report2));
 
         List<Report> recovered = reportAggregateService.recover(
@@ -91,7 +91,7 @@ class ReportAggregateServiceTest {
 
         given(questionRepository.countByTestIdAndDeletedAtIsNull(TEST_ID)).willReturn(2L);
         given(reportRepository.countByTestId(TEST_ID)).willReturn(2L);
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
         given(reportRepository.findAllByTestId(TEST_ID)).willReturn(List.of(report1, report2));
 
         List<Report> recovered = reportAggregateService.recover(
@@ -106,7 +106,7 @@ class ReportAggregateServiceTest {
     void recover_whenReportsArePartiallyCreated_returnsEmptyListAndMarksFailed() {
         given(questionRepository.countByTestIdAndDeletedAtIsNull(TEST_ID)).willReturn(3L);
         given(reportRepository.countByTestId(TEST_ID)).willReturn(1L);
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
 
         List<Report> recovered = reportAggregateService.recover(
                 new DataIntegrityViolationException("duplicate key"), TEST_ID);
@@ -120,7 +120,7 @@ class ReportAggregateServiceTest {
     void recover_whenGenericExceptionAndNoReportsExist_returnsEmptyListAndMarksFailed() {
         given(questionRepository.countByTestIdAndDeletedAtIsNull(TEST_ID)).willReturn(2L);
         given(reportRepository.countByTestId(TEST_ID)).willReturn(0L);
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
 
         List<Report> recovered = reportAggregateService.recover(
                 new RuntimeException("aggregate failed"), TEST_ID);

--- a/src/test/java/server/MATE/domain/report/service/ReportAggregateServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/ReportAggregateServiceTest.java
@@ -17,6 +17,7 @@ import server.MATE.domain.report.repository.ReportRepository;
 import server.MATE.domain.test.entity.ReportStatus;
 import server.MATE.domain.test.repository.TestRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -61,6 +62,7 @@ class ReportAggregateServiceTest {
                 .serviceName("서비스")
                 .serviceDescription("서비스 설명")
                 .imageKeys(List.of())
+                .closedAt(LocalDateTime.of(2099, 12, 31, 23, 59, 59))
                 .build();
         ReflectionTestUtils.setField(test, "id", TEST_ID);
     }

--- a/src/test/java/server/MATE/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/ReportServiceTest.java
@@ -66,7 +66,7 @@ class ReportServiceTest {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.IN_PROGRESS);
         ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.FAILED);
 
-        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(10L)).willReturn(Optional.of(test));
         given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(0L);
 
         ReportResponse response = reportService.getReport(10L, 1L, Role.USER);
@@ -83,7 +83,7 @@ class ReportServiceTest {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.REJECTED);
         ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.FAILED);
 
-        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(10L)).willReturn(Optional.of(test));
         given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(0L);
 
         ReportResponse response = reportService.getReport(10L, 1L, Role.USER);
@@ -100,7 +100,7 @@ class ReportServiceTest {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.COMPLETED);
         ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.IN_PROGRESS);
 
-        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(10L)).willReturn(Optional.of(test));
         given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(2L);
 
         ReportResponse response = reportService.getReport(10L, 1L, Role.USER);
@@ -124,7 +124,7 @@ class ReportServiceTest {
                 .result(Map.of("count", 3))
                 .build();
 
-        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(10L)).willReturn(Optional.of(test));
         given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(1L);
         given(reportRepository.findAllByTestId(10L)).willReturn(List.of(report));
         given(questionRepository.findQuestionSummariesByTestId(10L)).willReturn(List.of(
@@ -150,7 +150,7 @@ class ReportServiceTest {
                 .result(Map.of("count", 3))
                 .build();
 
-        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(10L)).willReturn(Optional.of(test));
         given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(2L);
         given(reportRepository.findAllByTestId(10L)).willReturn(List.of(report));
         given(questionRepository.findQuestionSummariesByTestId(10L)).willReturn(List.of(
@@ -181,7 +181,7 @@ class ReportServiceTest {
                 .result(Map.of("count", 1))
                 .build();
 
-        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(10L)).willReturn(Optional.of(test));
         given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(1L);
         given(reportRepository.findAllByTestId(10L)).willReturn(List.of(activeReport, orphanReport));
         given(questionRepository.findQuestionSummariesByTestId(10L)).willReturn(List.of(
@@ -198,7 +198,7 @@ class ReportServiceTest {
     @Test
     @DisplayName("메이커가 아닌 일반 사용자는 리포트를 조회할 수 없다")
     void getReport_throwsExceptionWhenNotMaker() {
-        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(10L)).willReturn(Optional.of(test));
 
         BaseException exception = org.junit.jupiter.api.Assertions.assertThrows(BaseException.class,
                 () -> reportService.getReport(10L, 999L, Role.USER));
@@ -212,7 +212,7 @@ class ReportServiceTest {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.IN_PROGRESS);
         ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.PENDING);
 
-        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(10L)).willReturn(Optional.of(test));
         given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(0L);
 
         ReportResponse response = reportService.getReport(10L, 999L, Role.ADMIN);

--- a/src/test/java/server/MATE/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/ReportServiceTest.java
@@ -20,6 +20,7 @@ import server.MATE.domain.users.entity.Role;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -56,6 +57,7 @@ class ReportServiceTest {
                 .serviceDescription("서비스 설명")
                 .imageKeys(List.of())
                 .testStatus(TestStatus.WAITING)
+                .closedAt(LocalDateTime.of(2099, 12, 31, 23, 59, 59))
                 .build();
         ReflectionTestUtils.setField(test, "id", 10L);
     }

--- a/src/test/java/server/MATE/domain/report/service/excel/support/ReportExcelExportSupportTest.java
+++ b/src/test/java/server/MATE/domain/report/service/excel/support/ReportExcelExportSupportTest.java
@@ -35,7 +35,7 @@ class ReportExcelExportSupportTest {
                 .build();
         ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.PENDING);
 
-        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(10L)).willReturn(Optional.of(test));
 
         assertThatThrownBy(() -> reportExcelExportSupport.requireExportReadyTest(10L, 1L))
                 .isInstanceOfSatisfying(BaseException.class, exception ->
@@ -50,7 +50,7 @@ class ReportExcelExportSupportTest {
                 .build();
         ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.IN_PROGRESS);
 
-        given(testRepository.findByIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(10L)).willReturn(Optional.of(test));
 
         assertThatThrownBy(() -> reportExcelExportSupport.requireExportReadyTest(10L, 1L))
                 .isInstanceOfSatisfying(BaseException.class, exception ->

--- a/src/test/java/server/MATE/domain/report/service/excel/support/ReportExcelExportSupportTest.java
+++ b/src/test/java/server/MATE/domain/report/service/excel/support/ReportExcelExportSupportTest.java
@@ -12,6 +12,7 @@ import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,6 +33,7 @@ class ReportExcelExportSupportTest {
         server.MATE.domain.test.entity.Test test = server.MATE.domain.test.entity.Test.builder()
                 .makerId(1L)
                 .testStatus(TestStatus.IN_PROGRESS)
+                .closedAt(LocalDateTime.of(2099, 12, 31, 23, 59, 59))
                 .build();
         ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.PENDING);
 
@@ -47,6 +49,7 @@ class ReportExcelExportSupportTest {
         server.MATE.domain.test.entity.Test test = server.MATE.domain.test.entity.Test.builder()
                 .makerId(1L)
                 .testStatus(TestStatus.COMPLETED)
+                .closedAt(LocalDateTime.of(2099, 12, 31, 23, 59, 59))
                 .build();
         ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.IN_PROGRESS);
 

--- a/src/test/java/server/MATE/domain/test/entity/TestTest.java
+++ b/src/test/java/server/MATE/domain/test/entity/TestTest.java
@@ -1,0 +1,26 @@
+package server.MATE.domain.test.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TestTest {
+
+    @Test
+    @DisplayName("closedAt 없이 테스트를 생성하면 TEST_008 예외가 발생한다")
+    void createWithoutClosedAt_throwsTest008() {
+        BaseException exception = assertThrows(BaseException.class, () -> server.MATE.domain.test.entity.Test.builder()
+                .makerId(1L)
+                .title("테스트")
+                .description("설명")
+                .serviceName("서비스")
+                .serviceDescription("서비스 설명")
+                .build());
+
+        assertThat(exception.getErrorCode()).isEqualTo(BaseErrorCode.TEST_008);
+    }
+}

--- a/src/test/java/server/MATE/domain/test/repository/TestQueryRepositoryImplTest.java
+++ b/src/test/java/server/MATE/domain/test/repository/TestQueryRepositoryImplTest.java
@@ -1,0 +1,269 @@
+package server.MATE.domain.test.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import server.MATE.domain.test.entity.Category;
+import server.MATE.domain.test.entity.TestStatus;
+import server.MATE.global.config.ClockConfig;
+import server.MATE.global.config.JpaAuditingConfig;
+import server.MATE.global.config.QuerydslConfig;
+import server.MATE.domain.test.repository.TestLikeRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({QuerydslConfig.class, ClockConfig.class, JpaAuditingConfig.class})
+class TestQueryRepositoryImplTest {
+
+    @Autowired
+    private TestRepository testRepository;
+
+    @Autowired
+    private TestLikeRepository testLikeRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private server.MATE.domain.test.entity.Test savedTest;
+
+    @BeforeEach
+    void setUp() {
+        savedTest = em.persistAndFlush(
+                server.MATE.domain.test.entity.Test.builder()
+                        .makerId(1L)
+                        .title("테스트 제목")
+                        .testStatus(TestStatus.IN_PROGRESS)
+                        .goalPpl(10)
+                        .reward(300)
+                        .closedAt(LocalDateTime.now().plusDays(7))
+                        .build()
+        );
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("findActiveById: 삭제되지 않은 테스트를 id로 조회한다")
+    void findActiveById_returnsTest() {
+        Optional<server.MATE.domain.test.entity.Test> result =
+                testRepository.findActiveById(savedTest.getId());
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(savedTest.getId());
+    }
+
+    @Test
+    @DisplayName("findActiveById: deletedAt이 설정된 테스트는 조회하지 않는다")
+    void findActiveById_deletedTest_returnsEmpty() {
+        em.getEntityManager()
+                .createQuery("update Test t set t.deletedAt = :now where t.id = :id")
+                .setParameter("now", LocalDateTime.now())
+                .setParameter("id", savedTest.getId())
+                .executeUpdate();
+        em.clear();
+
+        Optional<server.MATE.domain.test.entity.Test> result =
+                testRepository.findActiveById(savedTest.getId());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findWithCategoriesById: 카테고리 없는 테스트도 정상 조회된다")
+    void findWithCategoriesById_noCategories_returnsTest() {
+        Optional<server.MATE.domain.test.entity.Test> result =
+                testRepository.findWithCategoriesById(savedTest.getId());
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getCategories()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findWithCategoriesById: 카테고리가 있는 테스트를 조회하면 categories가 fetchJoin으로 로드된다")
+    void findWithCategoriesById_withCategories_returnsCategoriesLoaded() {
+        server.MATE.domain.test.entity.Test managed =
+                em.getEntityManager().find(server.MATE.domain.test.entity.Test.class, savedTest.getId());
+        managed.addCategories(List.of(Category.DAILY, Category.FINANCE));
+        em.flush();
+        em.clear();
+
+        Optional<server.MATE.domain.test.entity.Test> result =
+                testRepository.findWithCategoriesById(savedTest.getId());
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getCategories()).hasSize(2);
+        assertThat(result.get().getCategories())
+                .extracting(tc -> tc.getCategory())
+                .containsExactlyInAnyOrder(Category.DAILY, Category.FINANCE);
+    }
+
+    @Test
+    @DisplayName("findWithCategoriesById: 삭제된 테스트는 조회하지 않는다")
+    void findWithCategoriesById_deletedTest_returnsEmpty() {
+        em.getEntityManager()
+                .createQuery("update Test t set t.deletedAt = :now where t.id = :id")
+                .setParameter("now", LocalDateTime.now())
+                .setParameter("id", savedTest.getId())
+                .executeUpdate();
+        em.clear();
+
+        Optional<server.MATE.domain.test.entity.Test> result =
+                testRepository.findWithCategoriesById(savedTest.getId());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByIdForUpdate: 테스트를 비관적 락으로 조회한다")
+    void findByIdForUpdate_returnsTest() {
+        Optional<server.MATE.domain.test.entity.Test> result =
+                testRepository.findByIdForUpdate(savedTest.getId());
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(savedTest.getId());
+    }
+
+    @Test
+    @DisplayName("findByIdForUpdate: deletedAt이 설정된 테스트는 조회하지 않는다")
+    void findByIdForUpdate_deletedTest_returnsEmpty() {
+        em.getEntityManager()
+                .createQuery("update Test t set t.deletedAt = :now where t.id = :id")
+                .setParameter("now", LocalDateTime.now())
+                .setParameter("id", savedTest.getId())
+                .executeUpdate();
+        em.clear();
+
+        Optional<server.MATE.domain.test.entity.Test> result =
+                testRepository.findByIdForUpdate(savedTest.getId());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByIdForUpdate: 존재하지 않는 id면 빈 Optional을 반환한다")
+    void findByIdForUpdate_notFound_returnsEmpty() {
+        Optional<server.MATE.domain.test.entity.Test> result =
+                testRepository.findByIdForUpdate(999L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findActiveTests: 주어진 상태와 마감일 조건에 맞는 테스트를 반환한다")
+    void findActiveTests_returnsMatchingTests() {
+        List<server.MATE.domain.test.entity.Test> result = testRepository.findActiveTests(
+                List.of(TestStatus.IN_PROGRESS),
+                LocalDateTime.now()
+        );
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(savedTest.getId());
+    }
+
+    @Test
+    @DisplayName("findActiveTests: 마감된 테스트는 결과에 포함하지 않는다")
+    void findActiveTests_excludesExpiredTests() {
+        em.getEntityManager()
+                .createQuery("update Test t set t.closedAt = :past where t.id = :id")
+                .setParameter("past", LocalDateTime.now().minusDays(1))
+                .setParameter("id", savedTest.getId())
+                .executeUpdate();
+        em.clear();
+
+        List<server.MATE.domain.test.entity.Test> result = testRepository.findActiveTests(
+                List.of(TestStatus.IN_PROGRESS),
+                LocalDateTime.now()
+        );
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findActiveTests: 삭제된 테스트는 결과에 포함하지 않는다")
+    void findActiveTests_excludesDeletedTests() {
+        em.getEntityManager()
+                .createQuery("update Test t set t.deletedAt = :now where t.id = :id")
+                .setParameter("now", LocalDateTime.now())
+                .setParameter("id", savedTest.getId())
+                .executeUpdate();
+        em.clear();
+
+        List<server.MATE.domain.test.entity.Test> result = testRepository.findActiveTests(
+                List.of(TestStatus.IN_PROGRESS),
+                LocalDateTime.now()
+        );
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByMakerId: 특정 제작자의 삭제되지 않은 테스트 목록을 반환한다")
+    void findByMakerId_returnsTestsByMaker() {
+        em.persistAndFlush(
+                server.MATE.domain.test.entity.Test.builder()
+                        .makerId(1L)
+                        .title("두 번째 테스트")
+                        .testStatus(TestStatus.WAITING)
+                        .goalPpl(10)
+                        .reward(300)
+                        .closedAt(LocalDateTime.now().plusDays(7))
+                        .build()
+        );
+        em.clear();
+
+        List<server.MATE.domain.test.entity.Test> result =
+                testRepository.findByMakerId(1L);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting("makerId").containsOnly(1L);
+    }
+
+    @Test
+    @DisplayName("findByMakerId: 다른 제작자의 테스트는 포함하지 않는다")
+    void findByMakerId_excludesOtherMakers() {
+        List<server.MATE.domain.test.entity.Test> result =
+                testRepository.findByMakerId(999L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findLikedTests: 유저가 좋아요한 테스트 목록을 반환한다")
+    void findLikedTests_returnsLikedTests() {
+        testLikeRepository.save(
+                server.MATE.domain.test.entity.TestLike.builder()
+                        .userId(10L)
+                        .testId(savedTest.getId())
+                        .build()
+        );
+        em.flush();
+        em.clear();
+
+        List<server.MATE.domain.test.entity.Test> result = testRepository.findLikedTests(
+                10L,
+                List.of(TestStatus.IN_PROGRESS)
+        );
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(savedTest.getId());
+    }
+
+    @Test
+    @DisplayName("findLikedTests: 좋아요하지 않은 테스트는 포함하지 않는다")
+    void findLikedTests_excludesNotLiked() {
+        List<server.MATE.domain.test.entity.Test> result = testRepository.findLikedTests(
+                10L,
+                List.of(TestStatus.IN_PROGRESS)
+        );
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/server/MATE/domain/test/repository/TestQueryRepositoryImplTest.java
+++ b/src/test/java/server/MATE/domain/test/repository/TestQueryRepositoryImplTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
+import server.MATE.domain.participation.entity.Participation;
 import server.MATE.domain.test.entity.Category;
 import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.global.config.ClockConfig;
@@ -157,11 +158,12 @@ class TestQueryRepositoryImplTest {
     }
 
     @Test
-    @DisplayName("findActiveTests: 주어진 상태와 마감일 조건에 맞는 테스트를 반환한다")
-    void findActiveTests_returnsMatchingTests() {
-        List<server.MATE.domain.test.entity.Test> result = testRepository.findActiveTests(
+    @DisplayName("findAvailableTestsForUser: 주어진 상태와 마감일 조건에 맞는 테스트를 반환한다")
+    void findAvailableTestsForUser_returnsMatchingTests() {
+        List<server.MATE.domain.test.entity.Test> result = testRepository.findAvailableTestsForUser(
                 List.of(TestStatus.IN_PROGRESS),
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                10L
         );
 
         assertThat(result).hasSize(1);
@@ -169,8 +171,8 @@ class TestQueryRepositoryImplTest {
     }
 
     @Test
-    @DisplayName("findActiveTests: 마감된 테스트는 결과에 포함하지 않는다")
-    void findActiveTests_excludesExpiredTests() {
+    @DisplayName("findAvailableTestsForUser: 마감된 테스트는 결과에 포함하지 않는다")
+    void findAvailableTestsForUser_excludesExpiredTests() {
         em.getEntityManager()
                 .createQuery("update Test t set t.closedAt = :past where t.id = :id")
                 .setParameter("past", LocalDateTime.now().minusDays(1))
@@ -178,17 +180,18 @@ class TestQueryRepositoryImplTest {
                 .executeUpdate();
         em.clear();
 
-        List<server.MATE.domain.test.entity.Test> result = testRepository.findActiveTests(
+        List<server.MATE.domain.test.entity.Test> result = testRepository.findAvailableTestsForUser(
                 List.of(TestStatus.IN_PROGRESS),
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                10L
         );
 
         assertThat(result).isEmpty();
     }
 
     @Test
-    @DisplayName("findActiveTests: 삭제된 테스트는 결과에 포함하지 않는다")
-    void findActiveTests_excludesDeletedTests() {
+    @DisplayName("findAvailableTestsForUser: 삭제된 테스트는 결과에 포함하지 않는다")
+    void findAvailableTestsForUser_excludesDeletedTests() {
         em.getEntityManager()
                 .createQuery("update Test t set t.deletedAt = :now where t.id = :id")
                 .setParameter("now", LocalDateTime.now())
@@ -196,9 +199,28 @@ class TestQueryRepositoryImplTest {
                 .executeUpdate();
         em.clear();
 
-        List<server.MATE.domain.test.entity.Test> result = testRepository.findActiveTests(
+        List<server.MATE.domain.test.entity.Test> result = testRepository.findAvailableTestsForUser(
                 List.of(TestStatus.IN_PROGRESS),
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                10L
+        );
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findAvailableTestsForUser: 이미 응답한 테스트는 결과에 포함하지 않는다")
+    void findAvailableTestsForUser_excludesParticipatedTests() {
+        em.persistAndFlush(Participation.builder()
+                .testId(savedTest.getId())
+                .testerId(10L)
+                .build());
+        em.clear();
+
+        List<server.MATE.domain.test.entity.Test> result = testRepository.findAvailableTestsForUser(
+                List.of(TestStatus.IN_PROGRESS),
+                LocalDateTime.now(),
+                10L
         );
 
         assertThat(result).isEmpty();

--- a/src/test/java/server/MATE/domain/test/repository/TestQueryRepositoryImplTest.java
+++ b/src/test/java/server/MATE/domain/test/repository/TestQueryRepositoryImplTest.java
@@ -190,6 +190,15 @@ class TestQueryRepositoryImplTest {
     }
 
     @Test
+    @DisplayName("findAvailableTestsForUser: 필수 인자가 없으면 빈 리스트를 반환한다")
+    void findAvailableTestsForUser_missingRequiredArgs_returnsEmpty() {
+        assertThat(testRepository.findAvailableTestsForUser(null, LocalDateTime.now(), 10L)).isEmpty();
+        assertThat(testRepository.findAvailableTestsForUser(List.of(), LocalDateTime.now(), 10L)).isEmpty();
+        assertThat(testRepository.findAvailableTestsForUser(List.of(TestStatus.IN_PROGRESS), null, 10L)).isEmpty();
+        assertThat(testRepository.findAvailableTestsForUser(List.of(TestStatus.IN_PROGRESS), LocalDateTime.now(), null)).isEmpty();
+    }
+
+    @Test
     @DisplayName("findAvailableTestsForUser: 삭제된 테스트는 결과에 포함하지 않는다")
     void findAvailableTestsForUser_excludesDeletedTests() {
         em.getEntityManager()
@@ -258,6 +267,12 @@ class TestQueryRepositoryImplTest {
     }
 
     @Test
+    @DisplayName("findByMakerId: makerId가 null이면 빈 리스트를 반환한다")
+    void findByMakerId_nullMakerId_returnsEmpty() {
+        assertThat(testRepository.findByMakerId(null)).isEmpty();
+    }
+
+    @Test
     @DisplayName("findLikedTests: 유저가 좋아요한 테스트 목록을 반환한다")
     void findLikedTests_returnsLikedTests() {
         testLikeRepository.save(
@@ -287,5 +302,31 @@ class TestQueryRepositoryImplTest {
         );
 
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findLikedTests: 필수 인자가 없으면 빈 리스트를 반환한다")
+    void findLikedTests_missingRequiredArgs_returnsEmpty() {
+        assertThat(testRepository.findLikedTests(null, List.of(TestStatus.IN_PROGRESS))).isEmpty();
+        assertThat(testRepository.findLikedTests(10L, null)).isEmpty();
+        assertThat(testRepository.findLikedTests(10L, List.of())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findActiveById: id가 null이면 빈 Optional을 반환한다")
+    void findActiveById_nullId_returnsEmpty() {
+        assertThat(testRepository.findActiveById(null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findWithCategoriesById: id가 null이면 빈 Optional을 반환한다")
+    void findWithCategoriesById_nullId_returnsEmpty() {
+        assertThat(testRepository.findWithCategoriesById(null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByIdForUpdate: id가 null이면 빈 Optional을 반환한다")
+    void findByIdForUpdate_nullId_returnsEmpty() {
+        assertThat(testRepository.findByIdForUpdate(null)).isEmpty();
     }
 }

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -89,7 +89,7 @@ class TestServiceTest {
         server.MATE.domain.test.entity.Test waitingTest = createListTest(11L, "검수 중 테스트", TestStatus.WAITING);
         ReflectionTestUtils.setField(waitingTest, "createdAt", LocalDateTime.now().minusDays(5));
 
-        given(testRepository.findAllByTestStatusInAndDeletedAtIsNullAndClosedAtGreaterThanEqualOrderByCreatedAtDesc(
+        given(testRepository.findActiveTests(
                 any(),
                 any()
         )).willReturn(List.of(inProgressTest, waitingTest));
@@ -107,7 +107,7 @@ class TestServiceTest {
     @Test
     void 테스트_상세_조회_시_상태와_응답_여부를_반환한다() {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.IN_PROGRESS);
-        given(testRepository.findWithCategoriesByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findWithCategoriesById(TEST_ID)).willReturn(Optional.of(test));
         given(participationRepository.existsByTestIdAndTesterIdAndDeletedAtIsNull(TEST_ID, MAKER_ID))
                 .willReturn(true);
 
@@ -121,7 +121,7 @@ class TestServiceTest {
     @Test
     void 종료된_테스트_상세_조회_시_상태를_반환한다() {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.COMPLETED);
-        given(testRepository.findWithCategoriesByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findWithCategoriesById(TEST_ID)).willReturn(Optional.of(test));
         given(participationRepository.existsByTestIdAndTesterIdAndDeletedAtIsNull(TEST_ID, MAKER_ID))
                 .willReturn(false);
 
@@ -143,7 +143,7 @@ class TestServiceTest {
                 .build();
         ReflectionTestUtils.setField(myTest, "id", TEST_ID);
 
-        given(testRepository.findAllByMakerIdAndDeletedAtIsNullOrderByCreatedAtDesc(MAKER_ID))
+        given(testRepository.findByMakerId(MAKER_ID))
                 .willReturn(List.of(myTest));
 
         MyTestSummaryResponse response = testService.listMyTests(MAKER_ID);
@@ -160,7 +160,7 @@ class TestServiceTest {
     @Test
     void 내가_찜한_테스트_목록을_조회한다() {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.IN_PROGRESS);
-        given(testRepository.findLikedTestsByUserId(
+        given(testRepository.findLikedTests(
                 MAKER_ID,
                 List.of(TestStatus.IN_PROGRESS, TestStatus.WAITING, TestStatus.COMPLETED)
         )).willReturn(List.of(test));
@@ -180,7 +180,7 @@ class TestServiceTest {
 
     @Test
     void 테스트_찜_시_찜_정보를_저장하고_카운트를_증가시킨다() {
-        given(testRepository.findByIdAndDeletedAtIsNullForUpdate(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findByIdForUpdate(TEST_ID)).willReturn(Optional.of(test));
         given(testLikeRepository.existsByUserIdAndTestId(MAKER_ID, TEST_ID)).willReturn(false);
 
         TestLikeResponse response = testService.likeTest(TEST_ID, MAKER_ID);
@@ -199,7 +199,7 @@ class TestServiceTest {
                 .build();
         test.incrementLikeCount();
 
-        given(testRepository.findByIdAndDeletedAtIsNullForUpdate(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findByIdForUpdate(TEST_ID)).willReturn(Optional.of(test));
         given(testLikeRepository.findByUserIdAndTestId(MAKER_ID, TEST_ID)).willReturn(Optional.of(testLike));
 
         TestLikeResponse response = testService.unlikeTest(TEST_ID, MAKER_ID);
@@ -213,7 +213,7 @@ class TestServiceTest {
     @Test
     void 메이커가_진행_중인_테스트를_종료한다() {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.IN_PROGRESS);
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
 
         TestStatusUpdateResponse response = testService.updateTestStatus(TEST_ID, MAKER_ID, Role.USER, TestStatus.COMPLETED);
 
@@ -224,7 +224,7 @@ class TestServiceTest {
     @Test
     void 진행_중이_아닌_테스트를_종료하면_예외가_발생한다() {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.WAITING);
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
 
         BaseException exception = Assertions.assertThrows(BaseException.class,
                 () -> testService.updateTestStatus(TEST_ID, MAKER_ID, Role.USER, TestStatus.COMPLETED));
@@ -235,7 +235,7 @@ class TestServiceTest {
     @Test
     void 메이커가_아닌_사용자가_테스트를_종료하면_예외가_발생한다() {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.IN_PROGRESS);
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
 
         BaseException exception = Assertions.assertThrows(BaseException.class,
                 () -> testService.updateTestStatus(TEST_ID, 999L, Role.USER, TestStatus.COMPLETED));
@@ -246,7 +246,7 @@ class TestServiceTest {
     @Test
     void 관리자가_검수_중인_테스트를_승인한다() {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.WAITING);
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
 
         TestStatusUpdateResponse response = testService.updateTestStatus(TEST_ID, 999L, Role.ADMIN, TestStatus.IN_PROGRESS);
 
@@ -256,7 +256,7 @@ class TestServiceTest {
     @Test
     void 관리자가_검수_중인_테스트를_반려한다() {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.WAITING);
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
 
         TestStatusUpdateResponse response = testService.updateTestStatus(TEST_ID, 999L, Role.ADMIN, TestStatus.REJECTED);
 
@@ -266,7 +266,7 @@ class TestServiceTest {
     @Test
     void 관리자가_검수_중이_아닌_테스트를_승인하면_예외가_발생한다() {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.IN_PROGRESS);
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
 
         BaseException exception = Assertions.assertThrows(BaseException.class,
                 () -> testService.updateTestStatus(TEST_ID, 999L, Role.ADMIN, TestStatus.IN_PROGRESS));
@@ -277,7 +277,7 @@ class TestServiceTest {
     @Test
     void 관리자가_검수_중이_아닌_테스트를_반려하면_예외가_발생한다() {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.COMPLETED);
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
 
         BaseException exception = Assertions.assertThrows(BaseException.class,
                 () -> testService.updateTestStatus(TEST_ID, 999L, Role.ADMIN, TestStatus.REJECTED));
@@ -288,7 +288,7 @@ class TestServiceTest {
     @Test
     void 일반_사용자가_승인을_시도하면_예외가_발생한다() {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.WAITING);
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
 
         BaseException exception = Assertions.assertThrows(BaseException.class,
                 () -> testService.updateTestStatus(TEST_ID, 999L, Role.USER, TestStatus.IN_PROGRESS));
@@ -298,7 +298,7 @@ class TestServiceTest {
 
     @Test
     void WAITING_상태로_변경을_시도하면_예외가_발생한다() {
-        given(testRepository.findByIdAndDeletedAtIsNull(TEST_ID)).willReturn(Optional.of(test));
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
 
         BaseException exception = Assertions.assertThrows(BaseException.class,
                 () -> testService.updateTestStatus(TEST_ID, MAKER_ID, Role.USER, TestStatus.WAITING));

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -74,6 +74,7 @@ class TestServiceTest {
                 .serviceName("기존 서비스")
                 .serviceDescription("기존 서비스 소개")
                 .imageKeys(new ArrayList<>(List.of("old-key-1", "old-key-2")))
+                .closedAt(LocalDateTime.of(2099, 12, 31, 23, 59, 59))
                 .build();
         ReflectionTestUtils.setField(test, "id", TEST_ID);
         test.addCategories(List.of(Category.FOOD));
@@ -140,6 +141,7 @@ class TestServiceTest {
                 .serviceName("서비스")
                 .serviceDescription("서비스 소개")
                 .imageKeys(List.of())
+                .closedAt(LocalDateTime.of(2099, 12, 31, 23, 59, 59))
                 .build();
         ReflectionTestUtils.setField(myTest, "id", TEST_ID);
 
@@ -315,6 +317,7 @@ class TestServiceTest {
                 .serviceDescription("서비스 소개")
                 .imageKeys(List.of())
                 .testStatus(testStatus)
+                .closedAt(LocalDateTime.of(2099, 12, 31, 23, 59, 59))
                 .build();
         ReflectionTestUtils.setField(listTest, "id", id);
         return listTest;

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -90,7 +90,8 @@ class TestServiceTest {
         server.MATE.domain.test.entity.Test waitingTest = createListTest(11L, "검수 중 테스트", TestStatus.WAITING);
         ReflectionTestUtils.setField(waitingTest, "createdAt", LocalDateTime.now().minusDays(5));
 
-        given(testRepository.findActiveTests(
+        given(testRepository.findAvailableTestsForUser(
+                any(),
                 any(),
                 any()
         )).willReturn(List.of(inProgressTest, waitingTest));

--- a/src/test/java/server/MATE/integration/BaseQuestionAnswerEndToEndTest.java
+++ b/src/test/java/server/MATE/integration/BaseQuestionAnswerEndToEndTest.java
@@ -139,6 +139,7 @@ abstract class BaseQuestionAnswerEndToEndTest {
                 .serviceDescription("서비스 설명")
                 .imageKeys(List.of())
                 .testStatus(TestStatus.IN_PROGRESS)
+                .closedAt(java.time.LocalDateTime.of(2099, 12, 31, 23, 59, 59))
                 .build());
         return new TestActors(
                 maker.getId(),

--- a/src/test/java/server/MATE/integration/DraftPaymentPublishEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/DraftPaymentPublishEndToEndIntegrationTest.java
@@ -382,9 +382,9 @@ class DraftPaymentPublishEndToEndIntegrationTest {
                         .header("Authorization", testerToken))
                 .andExpect(status().isOk())
                 .andReturn());
-        assertThat(listBody.path("data").isArray()).isTrue();
+        assertThat(listBody.path("data").path("tests").isArray()).isTrue();
         boolean existsInList = false;
-        for (JsonNode node : listBody.path("data")) {
+        for (JsonNode node : listBody.path("data").path("tests")) {
             if (node.path("id").asLong() == testId) {
                 assertThat(node.path("title").asText()).isEqualTo("신규 테스트");
                 existsInList = true;


### PR DESCRIPTION
## 📍 요약
- 테스트 조회 조건을 BooleanExpression 조합 방식으로 통합하여 조건 추가 시 새 조회 메서드를 계속 만들지 않도록 구조를 개선함

## 🔗 관련 이슈
- Closes #182 

## 📌 변경 사항
- [ ] 기능
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- TestQueryRepositoryImpl에서 공통 조회 조건을 BooleanExpression 메서드로 분리함
- 테스트 목록, 상세, 좋아요, 락 조회 등 테스트 조회 로직을 QueryRepository 메서드 조합 방식으로 수정
- 사용자 응답 여부, 마감일, 삭제 여부 같은 조건을 조합해 조회할 수 있도록 구조를 개선
- QueryRepository 동작 검증 테스트와 관련 서비스 테스트를 보완
- 테스트 목록 조회 api에서 로그인한 사용자가 응답하지 않은 테스트만 조회하도록 수정

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew test --tests "server.MATE.domain.test.service.TestServiceTest" --tests "server.MATE.domain.test.repository.TestQueryRepositoryImplTest"
