### PR TITLE
feat: PDF 서버 Ingress 추가

### DIFF
--- a/deploy/apps/mate/ingress-pdf.yaml
+++ b/deploy/apps/mate/ingress-pdf.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mate-pdf
+  labels:
+    app: mate-pdf
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: pdf.kusitms-mate.cloud
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mate-pdf
+                port:
+                  number: 80

--- a/deploy/apps/mate/kustomization.yaml
+++ b/deploy/apps/mate/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - externalsecret-pdf.yaml
   - deployment-pdf.yaml
   - service-pdf.yaml
+  - ingress-pdf.yaml
 images:
   - name: kusitmsmateacr.azurecr.io/mate
     newTag: gha-23


### PR DESCRIPTION
  ## 📍 요약
  프론트엔드에서 PDF 서버(`pdf.kusitms-mate.cloud`)에 직접 접근할 수 있도록 Ingress 추가
  
  ## 🔗 관련 이슈 (Closes #184)
  
  ## 📌 변경 사항 (기능)
  
  ## ✅ 작업 내용
  - `ingress-pdf.yaml` : `pdf.kusitms-mate.cloud` → mate-pdf 서비스로 라우팅하는 Ingress 추가
  - `kustomization.yaml` : ingress-pdf.yaml 리소스 등록
  
  ## 테스트 (로컬 테스트 완료 여부, 방법)
  - DNS 레코드(`pdf.kusitms-mate.cloud`) 추가 후 검증 예정