### PR TITLE
refactor: 질문 조회 조건을 QueryDSL BooleanExpression으로 조합하도록 수정

### DIFF
--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -107,7 +107,7 @@ public class AnswerService {
         }
 
         Map<Long, AnswerQuestionTypeView> questionMap = questionRepository
-                .findAnswerQuestionTypeViewsByTestId(testId)
+                .findAnswerQuestionTypesInTest(testId)
                 .stream()
                 .collect(Collectors.toMap(AnswerQuestionTypeView::questionId, view -> view));
 

--- a/src/main/java/server/MATE/domain/question/repository/QuestionQueryRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/QuestionQueryRepository.java
@@ -1,0 +1,21 @@
+package server.MATE.domain.question.repository;
+
+import server.MATE.domain.question.dto.response.AnswerQuestionTypeView;
+import server.MATE.domain.question.dto.response.QuestionSummaryItem;
+import server.MATE.domain.question.entity.Question;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface QuestionQueryRepository {
+
+    Optional<Question> findQuestionByIdInTest(Long questionId, Long testId);
+
+    long countQuestionsInTest(Long testId);
+
+    List<Question> findQuestionsInTest(Long testId);
+
+    List<AnswerQuestionTypeView> findAnswerQuestionTypesInTest(Long testId);
+
+    List<QuestionSummaryItem> findQuestionSummariesInTest(Long testId);
+}

--- a/src/main/java/server/MATE/domain/question/repository/QuestionQueryRepositoryImpl.java
+++ b/src/main/java/server/MATE/domain/question/repository/QuestionQueryRepositoryImpl.java
@@ -1,0 +1,116 @@
+package server.MATE.domain.question.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import server.MATE.domain.question.dto.response.AnswerQuestionTypeView;
+import server.MATE.domain.question.dto.response.QuestionSummaryItem;
+import server.MATE.domain.question.entity.Question;
+
+import java.util.List;
+import java.util.Optional;
+
+import static server.MATE.domain.question.entity.QQuestion.question;
+
+@Repository
+@RequiredArgsConstructor
+public class QuestionQueryRepositoryImpl implements QuestionQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    // 삭제되지 않은 질문만 가져오는 조건
+    private static BooleanExpression notDeleted() {
+        return question.deletedAt.isNull();
+    }
+
+    // 전달받은 ID와 질문 ID가 같은 경우만 거르는 조건
+    private static BooleanExpression idEq(Long questionId) {
+        return question.id.eq(questionId);
+    }
+
+    // 전달받은 테스트 ID와 질문의 테스트 ID가 같은 경우만 거르는 조건
+    private static BooleanExpression testIdEq(Long testId) {
+        return question.testId.eq(testId);
+    }
+
+    @Override
+    public Optional<Question> findQuestionByIdInTest(Long questionId, Long testId) {
+        if (questionId == null || testId == null) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(question)
+                        .where(idEq(questionId), testIdEq(testId), notDeleted())
+                        .fetchOne()
+        );
+    }
+
+    @Override
+    public long countQuestionsInTest(Long testId) {
+        if (testId == null) {
+            return 0L;
+        }
+
+        Long count = queryFactory
+                .select(question.count())
+                .from(question)
+                .where(testIdEq(testId), notDeleted())
+                .fetchOne();
+
+        return count == null ? 0L : count;
+    }
+
+    @Override
+    public List<Question> findQuestionsInTest(Long testId) {
+        if (testId == null) {
+            return List.of();
+        }
+
+        return queryFactory
+                .selectFrom(question)
+                .where(testIdEq(testId), notDeleted())
+                .orderBy(question.sequence.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<AnswerQuestionTypeView> findAnswerQuestionTypesInTest(Long testId) {
+        if (testId == null) {
+            return List.of();
+        }
+
+        return queryFactory
+                .select(Projections.constructor(
+                        AnswerQuestionTypeView.class,
+                        question.id,
+                        question.questionType
+                ))
+                .from(question)
+                .where(testIdEq(testId), notDeleted())
+                .fetch();
+    }
+
+    @Override
+    public List<QuestionSummaryItem> findQuestionSummariesInTest(Long testId) {
+        if (testId == null) {
+            return List.of();
+        }
+
+        return queryFactory
+                .select(Projections.constructor(
+                        QuestionSummaryItem.class,
+                        question.id,
+                        question.sequence,
+                        question.title,
+                        question.questionType
+                ))
+                .from(question)
+                .where(testIdEq(testId), notDeleted())
+                .orderBy(question.sequence.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/server/MATE/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/QuestionRepository.java
@@ -2,46 +2,10 @@ package server.MATE.domain.question.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import server.MATE.domain.question.dto.response.AnswerQuestionTypeView;
-import server.MATE.domain.question.dto.response.QuestionSummaryItem;
 import server.MATE.domain.question.entity.Question;
 
-import java.util.List;
-import java.util.Optional;
-
-public interface QuestionRepository extends JpaRepository<Question, Long> {
+public interface QuestionRepository extends JpaRepository<Question, Long>, QuestionQueryRepository {
 
     @Query("SELECT COALESCE(MAX(q.sequence), 0) FROM Question q WHERE q.testId = :testId")
     Long findMaxSequenceByTestId(Long testId);
-
-    Optional<Question> findByIdAndTestIdAndDeletedAtIsNull(Long id, Long testId);
-
-    long countByTestIdAndDeletedAtIsNull(Long testId);
-
-    List<Question> findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(Long testId);
-
-    @Query("""
-            select new server.MATE.domain.question.dto.response.AnswerQuestionTypeView(
-                q.id,
-                q.questionType
-            )
-            from Question q
-            where q.testId = :testId
-              and q.deletedAt is null
-            """)
-    List<AnswerQuestionTypeView> findAnswerQuestionTypeViewsByTestId(Long testId);
-
-    @Query("""
-            select new server.MATE.domain.question.dto.response.QuestionSummaryItem(
-                q.id,
-                q.sequence,
-                q.title,
-                q.questionType
-            )
-            from Question q
-            where q.testId = :testId
-              and q.deletedAt is null
-            order by q.sequence asc
-            """)
-    List<QuestionSummaryItem> findQuestionSummariesByTestId(Long testId);
 }

--- a/src/main/java/server/MATE/domain/question/service/QuestionService.java
+++ b/src/main/java/server/MATE/domain/question/service/QuestionService.java
@@ -105,7 +105,7 @@ public class QuestionService {
         testRepository.findActiveById(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
-        List<Question> questions = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId);
+        List<Question> questions = questionRepository.findQuestionsInTest(testId);
         List<QuestionDetailItem> questionDetails = buildQuestionDetails(questions);
 
         return new QuestionsDetailResponse(testId, questionDetails);
@@ -116,7 +116,7 @@ public class QuestionService {
         testRepository.findActiveById(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
-        Question question = questionRepository.findByIdAndTestIdAndDeletedAtIsNull(questionId, testId)
+        Question question = questionRepository.findQuestionByIdInTest(questionId, testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.QUESTION_005));
 
         List<QuestionDetailItem> questionDetails = buildQuestionDetails(List.of(question));
@@ -154,7 +154,7 @@ public class QuestionService {
 
         if (!test.getMakerId().equals(makerId)) throw new BaseException(BaseErrorCode.TEST_005);
 
-        List<QuestionSummaryItem> questions = questionRepository.findQuestionSummariesByTestId(testId);
+        List<QuestionSummaryItem> questions = questionRepository.findQuestionSummariesInTest(testId);
         return new QuestionSummaryResponse(
                 test.getTestStatus(),
                 questions.size(),

--- a/src/main/java/server/MATE/domain/report/event/ReportAggregateService.java
+++ b/src/main/java/server/MATE/domain/report/event/ReportAggregateService.java
@@ -58,7 +58,7 @@ public class ReportAggregateService {
         Test test = testRepository.findActiveById(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
-        long questionCount = questionRepository.countByTestIdAndDeletedAtIsNull(testId);
+        long questionCount = questionRepository.countQuestionsInTest(testId);
         long reportCount = reportRepository.countByTestId(testId);
 
         // 질문 수와 리포트 수가 같으면 이미 전체 집계가 끝난 상태로 처리
@@ -78,7 +78,7 @@ public class ReportAggregateService {
             return List.of();
         }
 
-        List<Question> questions = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId);
+        List<Question> questions = questionRepository.findQuestionsInTest(testId);
         List<Long> questionIds = questions.stream().map(Question::getId).toList();
         List<Answer> allAnswers = answerRepository.findAllByQuestionIdInAndDeletedAtIsNull(questionIds);
 
@@ -118,7 +118,7 @@ public class ReportAggregateService {
     @Recover
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public List<Report> recover(Exception e, Long testId) {
-        long questionCount = questionRepository.countByTestIdAndDeletedAtIsNull(testId);
+        long questionCount = questionRepository.countQuestionsInTest(testId);
         long reportCount = reportRepository.countByTestId(testId);
 
         if (e instanceof DataIntegrityViolationException || reportCount > 0) {

--- a/src/main/java/server/MATE/domain/report/service/ReportService.java
+++ b/src/main/java/server/MATE/domain/report/service/ReportService.java
@@ -37,7 +37,7 @@ public class ReportService {
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
         if (role != Role.ADMIN && !test.getMakerId().equals(userId)) throw new BaseException(BaseErrorCode.TEST_005);
 
-        int questionCount = Math.toIntExact(questionRepository.countByTestIdAndDeletedAtIsNull(testId));
+        int questionCount = Math.toIntExact(questionRepository.countQuestionsInTest(testId));
         ReportStatus reportStatus = test.getReportStatus() != null ? test.getReportStatus() : ReportStatus.PENDING;
 
         switch (test.getTestStatus()) {
@@ -67,7 +67,7 @@ public class ReportService {
 
         // 테스트가 종료됐고 리포트 집계가 끝났다면 리포트를 반환함
         List<Report> aggregations = reportRepository.findAllByTestId(testId);
-        List<QuestionSummaryItem> questionSummaries = questionRepository.findQuestionSummariesByTestId(testId);
+        List<QuestionSummaryItem> questionSummaries = questionRepository.findQuestionSummariesInTest(testId);
 
         Map<Long, Map<String, Object>> resultByQuestionId = aggregations.stream()
                 .collect(Collectors.toMap(Report::getQuestionId, Report::getResult));

--- a/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelExportContextLoader.java
+++ b/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelExportContextLoader.java
@@ -46,7 +46,7 @@ public class ReportExcelExportContextLoader {
 
     public ReportExcelExportContext load(Long testId, Long makerId) {
         Test test = reportExcelExportSupport.requireExportReadyTest(testId, makerId);
-        List<Question> questions = questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(testId);
+        List<Question> questions = questionRepository.findQuestionsInTest(testId);
         List<QuestionSummaryItem> questionSummaries = questions.stream()
                 .map(question -> new QuestionSummaryItem(
                         question.getId(),

--- a/src/test/java/server/MATE/domain/answer/service/AnswerServiceTest.java
+++ b/src/test/java/server/MATE/domain/answer/service/AnswerServiceTest.java
@@ -1,0 +1,169 @@
+package server.MATE.domain.answer.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+import server.MATE.domain.answer.dto.request.AnswerCreateRequest;
+import server.MATE.domain.answer.dto.request.SubjectiveAnswerCreateRequest;
+import server.MATE.domain.answer.dto.response.AnswerBatchCreateResponse;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.answer.repository.AnswerRepository;
+import server.MATE.domain.answer.service.handler.AnswerCreateHandler;
+import server.MATE.domain.participation.entity.Participation;
+import server.MATE.domain.participation.repository.ParticipationRepository;
+import server.MATE.domain.promotion.event.PromotionRewardRequestEvent;
+import server.MATE.domain.promotion.repository.PromotionRewardRepository;
+import server.MATE.domain.question.dto.response.AnswerQuestionTypeView;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.repository.CardSortingRepository;
+import server.MATE.domain.question.repository.FiveSecondRepository;
+import server.MATE.domain.question.repository.ObjectiveRepository;
+import server.MATE.domain.question.repository.QuestionRepository;
+import server.MATE.domain.question.repository.ScaleRepository;
+import server.MATE.domain.question.repository.TreeTestRepository;
+import server.MATE.domain.test.entity.TestStatus;
+import server.MATE.domain.test.repository.TestRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AnswerServiceTest {
+
+    private static final Long TEST_ID = 10L;
+    private static final Long TESTER_ID = 20L;
+    private static final Long QUESTION_ID = 201L;
+    private static final Long PARTICIPATION_ID = 301L;
+
+    @Mock
+    private TestRepository testRepository;
+
+    @Mock
+    private ParticipationRepository participationRepository;
+
+    @Mock
+    private QuestionRepository questionRepository;
+
+    @Mock
+    private AnswerRepository answerRepository;
+
+    @Mock
+    private ObjectiveRepository objectiveRepository;
+
+    @Mock
+    private FiveSecondRepository fiveSecondRepository;
+
+    @Mock
+    private ScaleRepository scaleRepository;
+
+    @Mock
+    private CardSortingRepository cardSortingRepository;
+
+    @Mock
+    private TreeTestRepository treeTestRepository;
+
+    @Mock
+    private PromotionRewardRepository promotionRewardRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private AnswerCreateHandler subjectiveHandler;
+
+    private AnswerService answerService;
+
+    private server.MATE.domain.test.entity.Test test;
+
+    @BeforeEach
+    void setUp() {
+        given(subjectiveHandler.supports()).willReturn(QuestionType.SUBJECTIVE);
+
+        answerService = new AnswerService(
+                testRepository,
+                participationRepository,
+                questionRepository,
+                answerRepository,
+                objectiveRepository,
+                fiveSecondRepository,
+                scaleRepository,
+                cardSortingRepository,
+                treeTestRepository,
+                promotionRewardRepository,
+                eventPublisher,
+                List.of(subjectiveHandler)
+        );
+
+        test = server.MATE.domain.test.entity.Test.builder()
+                .makerId(1L)
+                .title("테스트")
+                .description("설명")
+                .serviceName("서비스")
+                .serviceDescription("서비스 설명")
+                .imageKeys(List.of())
+                .goalPpl(2)
+                .reward(300)
+                .testStatus(TestStatus.IN_PROGRESS)
+                .closedAt(LocalDateTime.of(2099, 12, 31, 23, 59, 59))
+                .build();
+        ReflectionTestUtils.setField(test, "id", TEST_ID);
+    }
+
+    @Test
+    @DisplayName("createAnswers는 질문 유형 projection을 조회해 검증 후 응답을 저장한다")
+    void createAnswers_usesQuestionTypeProjectionAndPersistsAnswers() {
+        AnswerCreateRequest request = new AnswerCreateRequest(List.of(
+                new SubjectiveAnswerCreateRequest(QUESTION_ID, "응답 내용")
+        ));
+
+        Answer builtAnswer = Answer.builder()
+                .participationId(PARTICIPATION_ID)
+                .questionId(QUESTION_ID)
+                .questionType(QuestionType.SUBJECTIVE)
+                .answer(Map.of("text", "응답 내용"))
+                .build();
+
+        given(testRepository.findByIdForUpdate(TEST_ID)).willReturn(Optional.of(test));
+        given(participationRepository.existsByTestIdAndTesterIdAndDeletedAtIsNull(TEST_ID, TESTER_ID)).willReturn(false);
+        given(questionRepository.findAnswerQuestionTypesInTest(TEST_ID)).willReturn(List.of(
+                new AnswerQuestionTypeView(QUESTION_ID, QuestionType.SUBJECTIVE)
+        ));
+        given(participationRepository.save(any(Participation.class))).willAnswer(invocation -> {
+            Participation participation = invocation.getArgument(0);
+            ReflectionTestUtils.setField(participation, "id", PARTICIPATION_ID);
+            return participation;
+        });
+        given(subjectiveHandler.build(anyLong(), any(), any())).willReturn(builtAnswer);
+        given(answerRepository.saveAll(anyList())).willReturn(List.of(builtAnswer));
+
+        AnswerBatchCreateResponse response = answerService.createAnswers(TEST_ID, TESTER_ID, request);
+
+        assertThat(response.participationId()).isEqualTo(PARTICIPATION_ID);
+        verify(questionRepository).findAnswerQuestionTypesInTest(TEST_ID);
+        verify(subjectiveHandler).validate(any(), any());
+        verify(subjectiveHandler).build(eq(PARTICIPATION_ID), eq(request.answers().getFirst()), any());
+        verify(answerRepository).saveAll(List.of(builtAnswer));
+
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue()).isInstanceOf(PromotionRewardRequestEvent.class);
+        verify(eventPublisher, never()).publishEvent(any(server.MATE.domain.test.event.TestCompleteEvent.class));
+    }
+}

--- a/src/test/java/server/MATE/domain/question/repository/QuestionQueryRepositoryImplTest.java
+++ b/src/test/java/server/MATE/domain/question/repository/QuestionQueryRepositoryImplTest.java
@@ -1,0 +1,178 @@
+package server.MATE.domain.question.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import server.MATE.domain.question.dto.response.AnswerQuestionTypeView;
+import server.MATE.domain.question.dto.response.QuestionSummaryItem;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.global.config.ClockConfig;
+import server.MATE.global.config.JpaAuditingConfig;
+import server.MATE.global.config.QuerydslConfig;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({QuerydslConfig.class, ClockConfig.class, JpaAuditingConfig.class})
+class QuestionQueryRepositoryImplTest {
+
+    private static final Long TEST_ID = 10L;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private Question savedQuestion;
+
+    @BeforeEach
+    void setUp() {
+        savedQuestion = em.persistAndFlush(Question.builder()
+                .testId(TEST_ID)
+                .questionType(QuestionType.SUBJECTIVE)
+                .title("첫 번째 질문")
+                .description("설명")
+                .sequence(1L)
+                .build());
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("findQuestionByIdInTest: 삭제되지 않은 질문을 테스트 범위 안에서 조회한다")
+    void findQuestionByIdInTest_returnsQuestion() {
+        Optional<Question> result = questionRepository.findQuestionByIdInTest(savedQuestion.getId(), TEST_ID);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(savedQuestion.getId());
+    }
+
+    @Test
+    @DisplayName("findQuestionByIdInTest: 필수 인자가 없으면 빈 Optional을 반환한다")
+    void findQuestionByIdInTest_missingRequiredArgs_returnsEmpty() {
+        assertThat(questionRepository.findQuestionByIdInTest(null, TEST_ID)).isEmpty();
+        assertThat(questionRepository.findQuestionByIdInTest(savedQuestion.getId(), null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findQuestionByIdInTest: 삭제된 질문은 조회하지 않는다")
+    void findQuestionByIdInTest_deletedQuestion_returnsEmpty() {
+        em.getEntityManager()
+                .createQuery("update Question q set q.deletedAt = :now where q.id = :id")
+                .setParameter("now", LocalDateTime.now())
+                .setParameter("id", savedQuestion.getId())
+                .executeUpdate();
+        em.clear();
+
+        Optional<Question> result = questionRepository.findQuestionByIdInTest(savedQuestion.getId(), TEST_ID);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("countQuestionsInTest: 삭제되지 않은 질문 수만 반환한다")
+    void countQuestionsInTest_returnsActiveQuestionCount() {
+        em.persistAndFlush(Question.builder()
+                .testId(TEST_ID)
+                .questionType(QuestionType.OBJECTIVE)
+                .title("두 번째 질문")
+                .description("설명")
+                .sequence(2L)
+                .build());
+        Question deletedQuestion = em.persistAndFlush(Question.builder()
+                .testId(TEST_ID)
+                .questionType(QuestionType.SCALE)
+                .title("삭제된 질문")
+                .description("설명")
+                .sequence(3L)
+                .build());
+        em.getEntityManager()
+                .createQuery("update Question q set q.deletedAt = :now where q.id = :id")
+                .setParameter("now", LocalDateTime.now())
+                .setParameter("id", deletedQuestion.getId())
+                .executeUpdate();
+        em.clear();
+
+        long result = questionRepository.countQuestionsInTest(TEST_ID);
+
+        assertThat(result).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("countQuestionsInTest: testId가 없으면 0을 반환한다")
+    void countQuestionsInTest_missingTestId_returnsZero() {
+        assertThat(questionRepository.countQuestionsInTest(null)).isZero();
+    }
+
+    @Test
+    @DisplayName("findQuestionsInTest: sequence 오름차순으로 질문 목록을 반환한다")
+    void findQuestionsInTest_returnsQuestionsOrderedBySequence() {
+        em.persistAndFlush(Question.builder()
+                .testId(TEST_ID)
+                .questionType(QuestionType.OBJECTIVE)
+                .title("세 번째 질문")
+                .description("설명")
+                .sequence(3L)
+                .build());
+        em.persistAndFlush(Question.builder()
+                .testId(TEST_ID)
+                .questionType(QuestionType.SCALE)
+                .title("두 번째 질문")
+                .description("설명")
+                .sequence(2L)
+                .build());
+        em.clear();
+
+        List<Question> result = questionRepository.findQuestionsInTest(TEST_ID);
+
+        assertThat(result).extracting(Question::getSequence).containsExactly(1L, 2L, 3L);
+    }
+
+    @Test
+    @DisplayName("findQuestionsInTest: testId가 없으면 빈 리스트를 반환한다")
+    void findQuestionsInTest_missingTestId_returnsEmpty() {
+        assertThat(questionRepository.findQuestionsInTest(null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findAnswerQuestionTypesInTest: 질문 id와 유형 projection을 반환한다")
+    void findAnswerQuestionTypesInTest_returnsProjection() {
+        List<AnswerQuestionTypeView> result = questionRepository.findAnswerQuestionTypesInTest(TEST_ID);
+
+        assertThat(result).containsExactly(new AnswerQuestionTypeView(savedQuestion.getId(), QuestionType.SUBJECTIVE));
+    }
+
+    @Test
+    @DisplayName("findQuestionSummariesInTest: 질문 요약 projection을 sequence 순으로 반환한다")
+    void findQuestionSummariesInTest_returnsProjectionOrderedBySequence() {
+        em.persistAndFlush(Question.builder()
+                .testId(TEST_ID)
+                .questionType(QuestionType.OBJECTIVE)
+                .title("두 번째 질문")
+                .description("설명")
+                .sequence(2L)
+                .build());
+        em.clear();
+
+        List<QuestionSummaryItem> result = questionRepository.findQuestionSummariesInTest(TEST_ID);
+
+        assertThat(result).extracting(QuestionSummaryItem::sequence).containsExactly(1L, 2L);
+        assertThat(result).extracting(QuestionSummaryItem::title).containsExactly("첫 번째 질문", "두 번째 질문");
+    }
+
+    @Test
+    @DisplayName("projection 조회 메서드: testId가 없으면 빈 리스트를 반환한다")
+    void projectionQueries_missingTestId_returnsEmpty() {
+        assertThat(questionRepository.findAnswerQuestionTypesInTest(null)).isEmpty();
+        assertThat(questionRepository.findQuestionSummariesInTest(null)).isEmpty();
+    }
+}

--- a/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
+++ b/src/test/java/server/MATE/domain/question/service/QuestionServiceTest.java
@@ -131,7 +131,7 @@ class QuestionServiceTest {
         setQuestionId(scaleQuestion, 202L);
 
         given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
-        given(questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID))
+        given(questionRepository.findQuestionsInTest(TEST_ID))
                 .willReturn(List.of(scaleQuestion, objectiveQuestion));
         given(objectiveFetcher.fetch(List.of(objectiveQuestion))).willReturn(Map.of(
                 201L,
@@ -178,7 +178,7 @@ class QuestionServiceTest {
     @DisplayName("질문이 없는 테스트 조회는 빈 questions 배열을 반환한다")
     void returnsEmptyQuestionListWhenTestHasNoQuestions() {
         given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
-        given(questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID))
+        given(questionRepository.findQuestionsInTest(TEST_ID))
                 .willReturn(List.of());
 
         QuestionsDetailResponse response = questionService.getQuestionsDetails(TEST_ID);
@@ -202,7 +202,7 @@ class QuestionServiceTest {
         setQuestionId(objectiveQuestion, 201L);
 
         given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
-        given(questionRepository.findByIdAndTestIdAndDeletedAtIsNull(201L, TEST_ID))
+        given(questionRepository.findQuestionByIdInTest(201L, TEST_ID))
                 .willReturn(Optional.of(objectiveQuestion));
         given(objectiveFetcher.fetch(List.of(objectiveQuestion))).willReturn(Map.of(
                 201L,
@@ -235,7 +235,7 @@ class QuestionServiceTest {
         setTestPplCount(test, 12L);
 
         given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
-        given(questionRepository.findQuestionSummariesByTestId(TEST_ID)).willReturn(List.of(
+        given(questionRepository.findQuestionSummariesInTest(TEST_ID)).willReturn(List.of(
                 new QuestionSummaryItem(202L, 1L, "척도 질문", QuestionType.SCALE),
                 new QuestionSummaryItem(201L, 2L, "객관식 질문", QuestionType.OBJECTIVE)
         ));
@@ -257,7 +257,7 @@ class QuestionServiceTest {
         setTestStatus(test, TestStatus.IN_PROGRESS);
         setTestPplCount(test, 3L);
         given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
-        given(questionRepository.findQuestionSummariesByTestId(TEST_ID)).willReturn(List.of(
+        given(questionRepository.findQuestionSummariesInTest(TEST_ID)).willReturn(List.of(
                 new QuestionSummaryItem(301L, 1L, "진행 중 질문", QuestionType.SUBJECTIVE)
         ));
 
@@ -281,7 +281,7 @@ class QuestionServiceTest {
                 .extracting(ex -> ((BaseException) ex).getErrorCode())
                 .isEqualTo(BaseErrorCode.TEST_005);
 
-        verify(questionRepository, never()).findQuestionSummariesByTestId(TEST_ID);
+        verify(questionRepository, never()).findQuestionSummariesInTest(TEST_ID);
     }
 
     @Test
@@ -294,7 +294,7 @@ class QuestionServiceTest {
                 .extracting(ex -> ((BaseException) ex).getErrorCode())
                 .isEqualTo(BaseErrorCode.TEST_004);
 
-        verify(questionRepository, never()).findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID);
+        verify(questionRepository, never()).findQuestionsInTest(TEST_ID);
         verify(objectiveFetcher, never()).fetch(anyList());
         verify(scaleFetcher, never()).fetch(anyList());
     }
@@ -309,7 +309,7 @@ class QuestionServiceTest {
                 .extracting(ex -> ((BaseException) ex).getErrorCode())
                 .isEqualTo(BaseErrorCode.TEST_004);
 
-        verify(questionRepository, never()).findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID);
+        verify(questionRepository, never()).findQuestionsInTest(TEST_ID);
         verify(objectiveFetcher, never()).fetch(anyList());
         verify(scaleFetcher, never()).fetch(anyList());
     }
@@ -324,14 +324,14 @@ class QuestionServiceTest {
                 .extracting(ex -> ((BaseException) ex).getErrorCode())
                 .isEqualTo(BaseErrorCode.TEST_004);
 
-        verify(questionRepository, never()).findByIdAndTestIdAndDeletedAtIsNull(any(), any());
+        verify(questionRepository, never()).findQuestionByIdInTest(any(), any());
     }
 
     @Test
     @DisplayName("문항 상세 조회 대상 문항이 없으면 QUESTION_005 예외가 발생한다")
     void getQuestionDetailThrowsQuestion005WhenQuestionDoesNotExist() {
         given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
-        given(questionRepository.findByIdAndTestIdAndDeletedAtIsNull(201L, TEST_ID))
+        given(questionRepository.findQuestionByIdInTest(201L, TEST_ID))
                 .willReturn(Optional.empty());
 
         assertThatThrownBy(() -> questionService.getQuestionDetail(TEST_ID, 201L))
@@ -353,7 +353,7 @@ class QuestionServiceTest {
         setQuestionId(scaleQuestion, 202L);
 
         given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
-        given(questionRepository.findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID))
+        given(questionRepository.findQuestionsInTest(TEST_ID))
                 .willReturn(List.of(scaleQuestion));
         given(scaleFetcher.fetch(List.of(scaleQuestion))).willReturn(Map.of(
                 202L,
@@ -374,7 +374,7 @@ class QuestionServiceTest {
         QuestionsDetailResponse response = questionService.getQuestionsDetails(TEST_ID);
 
         assertThat(response.questions()).hasSize(1);
-        verify(questionRepository).findAllByTestIdAndDeletedAtIsNullOrderBySequenceAsc(TEST_ID);
+        verify(questionRepository).findQuestionsInTest(TEST_ID);
         verify(scaleFetcher).fetch(List.of(scaleQuestion));
     }
 

--- a/src/test/java/server/MATE/domain/report/service/ReportAggregateServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/ReportAggregateServiceTest.java
@@ -8,12 +8,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
+import server.MATE.domain.answer.entity.Answer;
 import server.MATE.domain.answer.repository.AnswerRepository;
+import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.repository.QuestionRepository;
 import server.MATE.domain.report.entity.Report;
 import server.MATE.domain.report.event.ReportAggregateService;
 import server.MATE.domain.report.repository.ReportRepository;
+import server.MATE.domain.report.service.ReportHandler;
 import server.MATE.domain.test.entity.ReportStatus;
 import server.MATE.domain.test.repository.TestRepository;
 
@@ -23,7 +26,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ReportAggregateServiceTest {
@@ -40,6 +45,9 @@ class ReportAggregateServiceTest {
     @Mock
     private TestRepository testRepository;
 
+    @Mock
+    private ReportHandler reportHandler;
+
     private ReportAggregateService reportAggregateService;
 
     private server.MATE.domain.test.entity.Test test;
@@ -47,12 +55,14 @@ class ReportAggregateServiceTest {
 
     @BeforeEach
     void setUp() {
+        given(reportHandler.supports()).willReturn(QuestionType.SUBJECTIVE);
+
         reportAggregateService = new ReportAggregateService(
                 questionRepository,
                 answerRepository,
                 reportRepository,
                 testRepository,
-                List.of()
+                List.of(reportHandler)
         );
 
         test = server.MATE.domain.test.entity.Test.builder()
@@ -65,6 +75,44 @@ class ReportAggregateServiceTest {
                 .closedAt(LocalDateTime.of(2099, 12, 31, 23, 59, 59))
                 .build();
         ReflectionTestUtils.setField(test, "id", TEST_ID);
+    }
+
+    @Test
+    @DisplayName("aggregate는 활성 질문 목록을 조회해 handler 결과로 리포트를 저장하고 집계를 완료 처리한다")
+    void aggregate_buildsReportsFromQuestionsAndAnswers() {
+        Question question = Question.builder()
+                .testId(TEST_ID)
+                .questionType(QuestionType.SUBJECTIVE)
+                .title("주관식 질문")
+                .description("설명")
+                .sequence(1L)
+                .build();
+        ReflectionTestUtils.setField(question, "id", 101L);
+
+        Answer answer = Answer.builder()
+                .participationId(501L)
+                .questionId(101L)
+                .questionType(QuestionType.SUBJECTIVE)
+                .answer(Map.of("text", "응답"))
+                .build();
+
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
+        given(questionRepository.countQuestionsInTest(TEST_ID)).willReturn(1L);
+        given(reportRepository.countByTestId(TEST_ID)).willReturn(0L);
+        given(questionRepository.findQuestionsInTest(TEST_ID)).willReturn(List.of(question));
+        given(answerRepository.findAllByQuestionIdInAndDeletedAtIsNull(List.of(101L))).willReturn(List.of(answer));
+        given(reportHandler.compute(List.of(question), Map.of(101L, List.of(answer))))
+                .willReturn(Map.of(101L, Map.of("texts", List.of("응답"))));
+        given(reportRepository.saveAll(any())).willAnswer(invocation -> invocation.getArgument(0));
+
+        List<Report> result = reportAggregateService.aggregate(TEST_ID);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getQuestionId()).isEqualTo(101L);
+        assertThat(result.getFirst().getResult()).isEqualTo(Map.of("texts", List.of("응답")));
+        assertThat(test.getReportStatus()).isEqualTo(ReportStatus.COMPLETED);
+        verify(questionRepository).findQuestionsInTest(TEST_ID);
+        verify(reportHandler).compute(List.of(question), Map.of(101L, List.of(answer)));
     }
 
     @Test

--- a/src/test/java/server/MATE/domain/report/service/ReportAggregateServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/ReportAggregateServiceTest.java
@@ -73,7 +73,7 @@ class ReportAggregateServiceTest {
         Report report1 = report(101L);
         Report report2 = report(102L);
 
-        given(questionRepository.countByTestIdAndDeletedAtIsNull(TEST_ID)).willReturn(2L);
+        given(questionRepository.countQuestionsInTest(TEST_ID)).willReturn(2L);
         given(reportRepository.countByTestId(TEST_ID)).willReturn(2L);
         given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
         given(reportRepository.findAllByTestId(TEST_ID)).willReturn(List.of(report1, report2));
@@ -91,7 +91,7 @@ class ReportAggregateServiceTest {
         Report report1 = report(101L);
         Report report2 = report(102L);
 
-        given(questionRepository.countByTestIdAndDeletedAtIsNull(TEST_ID)).willReturn(2L);
+        given(questionRepository.countQuestionsInTest(TEST_ID)).willReturn(2L);
         given(reportRepository.countByTestId(TEST_ID)).willReturn(2L);
         given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
         given(reportRepository.findAllByTestId(TEST_ID)).willReturn(List.of(report1, report2));
@@ -106,7 +106,7 @@ class ReportAggregateServiceTest {
     @Test
     @DisplayName("부분 생성된 리포트만 존재하면 FAILED로 복구하고 빈 리스트를 반환한다")
     void recover_whenReportsArePartiallyCreated_returnsEmptyListAndMarksFailed() {
-        given(questionRepository.countByTestIdAndDeletedAtIsNull(TEST_ID)).willReturn(3L);
+        given(questionRepository.countQuestionsInTest(TEST_ID)).willReturn(3L);
         given(reportRepository.countByTestId(TEST_ID)).willReturn(1L);
         given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
 
@@ -120,7 +120,7 @@ class ReportAggregateServiceTest {
     @Test
     @DisplayName("일반 예외이고 리포트가 없으면 FAILED로 복구하고 빈 리스트를 반환한다")
     void recover_whenGenericExceptionAndNoReportsExist_returnsEmptyListAndMarksFailed() {
-        given(questionRepository.countByTestIdAndDeletedAtIsNull(TEST_ID)).willReturn(2L);
+        given(questionRepository.countQuestionsInTest(TEST_ID)).willReturn(2L);
         given(reportRepository.countByTestId(TEST_ID)).willReturn(0L);
         given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
 

--- a/src/test/java/server/MATE/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/ReportServiceTest.java
@@ -69,14 +69,14 @@ class ReportServiceTest {
         ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.FAILED);
 
         given(testRepository.findActiveById(10L)).willReturn(Optional.of(test));
-        given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(0L);
+        given(questionRepository.countQuestionsInTest(10L)).willReturn(0L);
 
         ReportResponse response = reportService.getReport(10L, 1L, Role.USER);
 
         assertThat(response.testStatus()).isEqualTo(TestStatus.IN_PROGRESS);
         assertThat(response.reportStatus()).isEqualTo(ReportStatus.FAILED);
         assertThat(response.reports()).isEmpty();
-        verify(questionRepository, never()).findQuestionSummariesByTestId(10L);
+        verify(questionRepository, never()).findQuestionSummariesInTest(10L);
     }
 
     @Test
@@ -86,14 +86,14 @@ class ReportServiceTest {
         ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.FAILED);
 
         given(testRepository.findActiveById(10L)).willReturn(Optional.of(test));
-        given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(0L);
+        given(questionRepository.countQuestionsInTest(10L)).willReturn(0L);
 
         ReportResponse response = reportService.getReport(10L, 1L, Role.USER);
 
         assertThat(response.testStatus()).isEqualTo(TestStatus.REJECTED);
         assertThat(response.reportStatus()).isEqualTo(ReportStatus.FAILED);
         assertThat(response.reports()).isEmpty();
-        verify(questionRepository, never()).findQuestionSummariesByTestId(10L);
+        verify(questionRepository, never()).findQuestionSummariesInTest(10L);
     }
 
     @Test
@@ -103,7 +103,7 @@ class ReportServiceTest {
         ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.IN_PROGRESS);
 
         given(testRepository.findActiveById(10L)).willReturn(Optional.of(test));
-        given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(2L);
+        given(questionRepository.countQuestionsInTest(10L)).willReturn(2L);
 
         ReportResponse response = reportService.getReport(10L, 1L, Role.USER);
 
@@ -111,7 +111,7 @@ class ReportServiceTest {
         assertThat(response.reportStatus()).isEqualTo(ReportStatus.IN_PROGRESS);
         assertThat(response.questionCount()).isEqualTo(2);
         assertThat(response.reports()).isEmpty();
-        verify(questionRepository, never()).findQuestionSummariesByTestId(10L);
+        verify(questionRepository, never()).findQuestionSummariesInTest(10L);
     }
 
     @Test
@@ -127,9 +127,9 @@ class ReportServiceTest {
                 .build();
 
         given(testRepository.findActiveById(10L)).willReturn(Optional.of(test));
-        given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(1L);
+        given(questionRepository.countQuestionsInTest(10L)).willReturn(1L);
         given(reportRepository.findAllByTestId(10L)).willReturn(List.of(report));
-        given(questionRepository.findQuestionSummariesByTestId(10L)).willReturn(List.of(
+        given(questionRepository.findQuestionSummariesInTest(10L)).willReturn(List.of(
                 new QuestionSummaryItem(101L, 1L, "질문", server.MATE.domain.question.entity.QuestionType.SUBJECTIVE)
         ));
 
@@ -137,7 +137,7 @@ class ReportServiceTest {
 
         assertThat(response.reportStatus()).isEqualTo(ReportStatus.COMPLETED);
         assertThat(response.reports()).hasSize(1);
-        verify(questionRepository).findQuestionSummariesByTestId(10L);
+        verify(questionRepository).findQuestionSummariesInTest(10L);
     }
 
     @Test
@@ -153,9 +153,9 @@ class ReportServiceTest {
                 .build();
 
         given(testRepository.findActiveById(10L)).willReturn(Optional.of(test));
-        given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(2L);
+        given(questionRepository.countQuestionsInTest(10L)).willReturn(2L);
         given(reportRepository.findAllByTestId(10L)).willReturn(List.of(report));
-        given(questionRepository.findQuestionSummariesByTestId(10L)).willReturn(List.of(
+        given(questionRepository.findQuestionSummariesInTest(10L)).willReturn(List.of(
                 new QuestionSummaryItem(101L, 1L, "질문1", server.MATE.domain.question.entity.QuestionType.SUBJECTIVE),
                 new QuestionSummaryItem(102L, 2L, "질문2", server.MATE.domain.question.entity.QuestionType.SUBJECTIVE)
         ));
@@ -184,9 +184,9 @@ class ReportServiceTest {
                 .build();
 
         given(testRepository.findActiveById(10L)).willReturn(Optional.of(test));
-        given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(1L);
+        given(questionRepository.countQuestionsInTest(10L)).willReturn(1L);
         given(reportRepository.findAllByTestId(10L)).willReturn(List.of(activeReport, orphanReport));
-        given(questionRepository.findQuestionSummariesByTestId(10L)).willReturn(List.of(
+        given(questionRepository.findQuestionSummariesInTest(10L)).willReturn(List.of(
                 new QuestionSummaryItem(101L, 1L, "질문", server.MATE.domain.question.entity.QuestionType.SUBJECTIVE)
         ));
 
@@ -215,7 +215,7 @@ class ReportServiceTest {
         ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.PENDING);
 
         given(testRepository.findActiveById(10L)).willReturn(Optional.of(test));
-        given(questionRepository.countByTestIdAndDeletedAtIsNull(10L)).willReturn(0L);
+        given(questionRepository.countQuestionsInTest(10L)).willReturn(0L);
 
         ReportResponse response = reportService.getReport(10L, 999L, Role.ADMIN);
 

--- a/src/test/java/server/MATE/integration/DraftPaymentPublishEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/DraftPaymentPublishEndToEndIntegrationTest.java
@@ -174,7 +174,7 @@ class DraftPaymentPublishEndToEndIntegrationTest {
         assertThat(savedTest.getGoalPpl()).isEqualTo(5);
         assertThat(savedTest.getReward()).isEqualTo(300);
         assertThat(savedTest.getTestStatus()).isEqualTo(TestStatus.WAITING);
-        assertThat(questionRepository.countByTestIdAndDeletedAtIsNull(testId)).isEqualTo(1);
+        assertThat(questionRepository.countQuestionsInTest(testId)).isEqualTo(1);
 
         JsonNode questions = getQuestions(testId, makerToken);
         assertThat(questions).hasSize(1);
@@ -203,7 +203,7 @@ class DraftPaymentPublishEndToEndIntegrationTest {
 
         assertThat(secondTestId).isEqualTo(firstTestId);
         assertThat(testRepository.count()).isEqualTo(1);
-        assertThat(questionRepository.countByTestIdAndDeletedAtIsNull(firstTestId)).isEqualTo(1);
+        assertThat(questionRepository.countQuestionsInTest(firstTestId)).isEqualTo(1);
     }
 
     @Test
@@ -244,7 +244,7 @@ class DraftPaymentPublishEndToEndIntegrationTest {
         assertThat(testDraftRepository.findById(draftId)).isEmpty();
         assertThat(linkedPayment.getTestId()).isEqualTo(publishedTestId);
         assertThat(testRepository.count()).isEqualTo(1);
-        assertThat(questionRepository.countByTestIdAndDeletedAtIsNull(publishedTestId)).isEqualTo(1);
+        assertThat(questionRepository.countQuestionsInTest(publishedTestId)).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
## 📍 요약
- 질문 조회를 QueryDSL 구조로 분리하여 공통 조건을 조합하도록 구조를 수정

## 🔗 관련 이슈
- Closes #180 

## 📌 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- QuestionQueryRepositoryImpl에서 공통 조회 조건을 BooleanExpression 메서드로 분리함
- 질문 단건 조회, 질문 수 조회, 질문 목록 조회, 질문 요약 조회 등 질문 조회 로직을 QueryRepository 메서드 조합 방식으로 수정
- 테스트 ID, 삭제 여부 같은 조건을 조합해 조회할 수 있도록 구조를 개선
- QuestionQueryRepository 동작 검증 테스트와 관련 서비스/통합 테스트를 보완
- 답변 저장 경로와 리포트 집계 경로에 대한 후속 테스트를 추가

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew test --tests "server.MATE.domain.question.repository.QuestionQueryRepositoryImplTest" --tests "server.MATE.domain.question.service.QuestionServiceTest" --tests "server.MATE.domain.report.service.ReportAggregateServiceTest" --tests "server.MATE.domain.report.service.ReportServiceTest"
  - ./gradlew test --tests "server.MATE.integration.DraftPaymentPublishEndToEndIntegrationTest"
  - ./gradlew test --tests "server.MATE.domain.answer.service.AnswerServiceTest" --tests "server.MATE.domain.report.service.ReportAggregateServiceTest"