### PR TITLE
fix: 결제 등록, 실행 간의 검증 정책 수정

### DIFF
--- a/src/main/java/server/MATE/domain/payment/service/PaymentPrepareService.java
+++ b/src/main/java/server/MATE/domain/payment/service/PaymentPrepareService.java
@@ -11,6 +11,7 @@ import server.MATE.domain.payment.policy.PaymentAmountCalculator;
 import server.MATE.domain.payment.repository.PaymentRepository;
 import server.MATE.domain.testdraft.entity.TestDraft;
 import server.MATE.domain.testdraft.repository.TestDraftRepository;
+import server.MATE.domain.testdraft.validator.TestDraftValidator;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
 
@@ -23,6 +24,7 @@ public class PaymentPrepareService {
     private final TestDraftRepository testDraftRepository;
     private final PaymentRepository paymentRepository;
     private final PaymentAmountCalculator paymentAmountCalculator;
+    private final TestDraftValidator testDraftValidator;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public PaymentPreparation prepare(Long draftId, Long makerId, boolean isTestPayment) {
@@ -31,7 +33,7 @@ public class PaymentPrepareService {
         if (!draft.getMakerId().equals(makerId)) {
             throw new BaseException(BaseErrorCode.DRAFT_002);
         }
-        draft.validateReadyForPayment();
+        testDraftValidator.validateForPayment(draft);
 
         int amount = paymentAmountCalculator.totalAmount(draft.getGoalPpl(), draft.getReward());
         Payment existingPayment = paymentRepository.findByDraftId(draftId).orElse(null);

--- a/src/main/java/server/MATE/domain/test/service/TestPublishService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestPublishService.java
@@ -1,8 +1,5 @@
 package server.MATE.domain.test.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -18,12 +15,12 @@ import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.domain.testdraft.entity.TestDraft;
 import server.MATE.domain.testdraft.repository.TestDraftRepository;
+import server.MATE.domain.testdraft.validator.TestDraftValidator;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
 import server.MATE.global.storage.event.FileCleanupEvent;
 
 import java.util.List;
-import java.util.Set;
 
 @Service
 @Transactional
@@ -35,8 +32,7 @@ public class TestPublishService {
     private final TestRepository testRepository;
     private final QuestionService questionService;
     private final ApplicationEventPublisher eventPublisher;
-    private final ObjectMapper objectMapper;
-    private final Validator validator;
+    private final TestDraftValidator testDraftValidator;
 
     public Long publish(Long paymentId) {
         Payment payment = paymentRepository.findByIdForUpdate(paymentId)
@@ -57,7 +53,7 @@ public class TestPublishService {
             throw new BaseException(BaseErrorCode.PAYMENT_003);
         }
 
-        draft.validateReadyForPublish();
+        QuestionCreateRequest questionCreateRequest = testDraftValidator.validateForPublish(draft);
         draft.markPublishing();
 
         Test test = testRepository.save(Test.builder()
@@ -80,7 +76,6 @@ public class TestPublishService {
             eventPublisher.publishEvent(new FileCleanupEvent(draft.getImageKeys()));
         }
 
-        QuestionCreateRequest questionCreateRequest = toQuestionCreateRequest(draft);
         questionService.createQuestions(test.getId(), draft.getMakerId(), questionCreateRequest);
 
         payment.linkTest(test.getId());
@@ -93,23 +88,5 @@ public class TestPublishService {
         return categoryNames.stream()
                 .map(Category::valueOf)
                 .toList();
-    }
-
-    private QuestionCreateRequest toQuestionCreateRequest(TestDraft draft) {
-        final QuestionCreateRequest questionCreateRequest;
-        try {
-            questionCreateRequest = objectMapper.convertValue(
-                    draft.getQuestionsPayload(),
-                    QuestionCreateRequest.class
-            );
-        } catch (IllegalArgumentException e) {
-            throw new BaseException(BaseErrorCode.DRAFT_004);
-        }
-
-        Set<ConstraintViolation<QuestionCreateRequest>> violations = validator.validate(questionCreateRequest);
-        if (!violations.isEmpty()) {
-            throw new BaseException(BaseErrorCode.DRAFT_004);
-        }
-        return questionCreateRequest;
     }
 }

--- a/src/main/java/server/MATE/domain/testdraft/entity/TestDraft.java
+++ b/src/main/java/server/MATE/domain/testdraft/entity/TestDraft.java
@@ -161,6 +161,9 @@ public class TestDraft extends BaseEntity {
         if (this.goalPpl == null || this.reward == null || this.closedAt == null) {
             throw new BaseException(BaseErrorCode.DRAFT_005);
         }
+        if (this.goalPpl <= 0 || this.reward < 0) {
+            throw new BaseException(BaseErrorCode.DRAFT_005);
+        }
     }
 
     public void validatePublishableFields() {

--- a/src/main/java/server/MATE/domain/testdraft/entity/TestDraft.java
+++ b/src/main/java/server/MATE/domain/testdraft/entity/TestDraft.java
@@ -151,37 +151,42 @@ public class TestDraft extends BaseEntity {
         this.status = TestDraftStatus.PUBLISH_FAILED;
     }
 
-    public void validateReadyForPayment() {
+    public void validatePaymentState() {
         if (this.status == TestDraftStatus.PUBLISHED || this.status == TestDraftStatus.PUBLISHING) {
             throw new BaseException(BaseErrorCode.DRAFT_003);
         }
+    }
+
+    public void validateAmountFields() {
         if (this.goalPpl == null || this.reward == null || this.closedAt == null) {
-            throw new BaseException(BaseErrorCode.PAYMENT_005);
+            throw new BaseException(BaseErrorCode.DRAFT_005);
         }
     }
 
-    public void validateReadyForPublish() {
-        if (this.publishedTestId != null && this.status == TestDraftStatus.PUBLISHED) {
-            return;
-        }
-        if (this.status != TestDraftStatus.PAYMENT_CREATED && this.status != TestDraftStatus.PUBLISH_FAILED) {
-            throw new BaseException(BaseErrorCode.DRAFT_004);
-        }
-        if (this.goalPpl == null || this.reward == null || this.closedAt == null) {
-            throw new BaseException(BaseErrorCode.DRAFT_004);
-        }
+    public void validatePublishableFields() {
         if (isBlank(this.title) || isBlank(this.description)) {
-            throw new BaseException(BaseErrorCode.DRAFT_004);
+            throw new BaseException(BaseErrorCode.DRAFT_006);
         }
         if (this.categories == null || this.categories.isEmpty()) {
-            throw new BaseException(BaseErrorCode.DRAFT_004);
+            throw new BaseException(BaseErrorCode.DRAFT_006);
         }
         boolean hasInvalidCategory = this.categories.stream()
                 .anyMatch(category -> !isValidCategory(category));
         if (hasInvalidCategory) {
-            throw new BaseException(BaseErrorCode.DRAFT_004);
+            throw new BaseException(BaseErrorCode.DRAFT_006);
         }
-        if (this.questionsPayload == null || !(this.questionsPayload.get("questions") instanceof List<?> questions) || questions.isEmpty()) {
+        if (this.questionsPayload == null
+                || !(this.questionsPayload.get("questions") instanceof List<?> questions)
+                || questions.isEmpty()) {
+            throw new BaseException(BaseErrorCode.DRAFT_006);
+        }
+    }
+
+    public void validatePublishState() {
+        if (this.publishedTestId != null && this.status == TestDraftStatus.PUBLISHED) {
+            return;
+        }
+        if (this.status != TestDraftStatus.PAYMENT_CREATED && this.status != TestDraftStatus.PUBLISH_FAILED) {
             throw new BaseException(BaseErrorCode.DRAFT_004);
         }
     }

--- a/src/main/java/server/MATE/domain/testdraft/entity/TestDraft.java
+++ b/src/main/java/server/MATE/domain/testdraft/entity/TestDraft.java
@@ -196,6 +196,9 @@ public class TestDraft extends BaseEntity {
     }
 
     private boolean isValidCategory(String category) {
+        if (category == null) {
+            return false;
+        }
         try {
             server.MATE.domain.test.entity.Category.valueOf(category);
             return true;

--- a/src/main/java/server/MATE/domain/testdraft/validator/TestDraftValidator.java
+++ b/src/main/java/server/MATE/domain/testdraft/validator/TestDraftValidator.java
@@ -1,0 +1,52 @@
+package server.MATE.domain.testdraft.validator;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.question.dto.request.QuestionCreateRequest;
+import server.MATE.domain.testdraft.entity.TestDraft;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class TestDraftValidator {
+
+    private final ObjectMapper objectMapper;
+    private final Validator validator;
+
+    public QuestionCreateRequest validateForPayment(TestDraft draft) {
+        draft.validatePaymentState();
+        draft.validateAmountFields();
+        draft.validatePublishableFields();
+        return resolveQuestionsPayload(draft);
+    }
+
+    public QuestionCreateRequest validateForPublish(TestDraft draft) {
+        draft.validatePublishState();
+        draft.validatePublishableFields();
+        return resolveQuestionsPayload(draft);
+    }
+
+    private QuestionCreateRequest resolveQuestionsPayload(TestDraft draft) {
+        final QuestionCreateRequest request;
+        try {
+            request = objectMapper.convertValue(
+                    draft.getQuestionsPayload(),
+                    QuestionCreateRequest.class
+            );
+        } catch (IllegalArgumentException e) {
+            throw new BaseException(BaseErrorCode.DRAFT_006);
+        }
+
+        Set<ConstraintViolation<QuestionCreateRequest>> violations = validator.validate(request);
+        if (!violations.isEmpty()) {
+            throw new BaseException(BaseErrorCode.DRAFT_006);
+        }
+        return request;
+    }
+}

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -50,6 +50,8 @@ public enum BaseErrorCode implements ErrorCode {
     DRAFT_002(HttpStatus.FORBIDDEN, "DRAFT_002", "테스트 초안에 접근할 권한이 없습니다."),
     DRAFT_003(HttpStatus.BAD_REQUEST, "DRAFT_003", "결제를 생성할 수 없는 테스트 초안입니다."),
     DRAFT_004(HttpStatus.BAD_REQUEST, "DRAFT_004", "게시할 수 없는 테스트 초안입니다."),
+    DRAFT_005(HttpStatus.BAD_REQUEST, "DRAFT_005", "결제 금액 산정에 필요한 정보가 부족합니다."),
+    DRAFT_006(HttpStatus.BAD_REQUEST, "DRAFT_006", "게시에 필요한 필수 정보가 부족합니다."),
 
     // Question
     QUESTION_001(HttpStatus.BAD_REQUEST, "QUESTION_001", "최소 선택 개수는 1 이상이어야 합니다."),
@@ -82,7 +84,7 @@ public enum BaseErrorCode implements ErrorCode {
     PAYMENT_002(HttpStatus.BAD_REQUEST, "PAYMENT_002", "결제를 생성할 수 없는 상태입니다."),
     PAYMENT_003(HttpStatus.BAD_REQUEST, "PAYMENT_003", "결제를 실행할 수 없는 상태입니다."),
     PAYMENT_004(HttpStatus.BAD_REQUEST, "PAYMENT_004", "환불할 수 없는 상태입니다."),
-    PAYMENT_005(HttpStatus.BAD_REQUEST, "PAYMENT_005", "결제 금액 계산에 필요한 값이 누락되었습니다."),
+
 
     // Report
     REPORT_001(HttpStatus.BAD_REQUEST, "REPORT_001", "엑셀 보고서는 질문 20개 이하 테스트만 지원합니다."),

--- a/src/test/java/server/MATE/domain/payment/service/PaymentPrepareServiceTest.java
+++ b/src/test/java/server/MATE/domain/payment/service/PaymentPrepareServiceTest.java
@@ -1,0 +1,175 @@
+package server.MATE.domain.payment.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import server.MATE.domain.payment.entity.Payment;
+import server.MATE.domain.payment.repository.PaymentRepository;
+import server.MATE.domain.payment.policy.PaymentAmountCalculator;
+import server.MATE.domain.testdraft.entity.TestDraft;
+import server.MATE.domain.testdraft.repository.TestDraftRepository;
+import server.MATE.domain.testdraft.validator.TestDraftValidator;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentPrepareServiceTest {
+
+    @Mock
+    private TestDraftRepository testDraftRepository;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private PaymentAmountCalculator paymentAmountCalculator;
+
+    @Mock
+    private TestDraftValidator testDraftValidator;
+
+    private PaymentPrepareService paymentPrepareService;
+
+    @BeforeEach
+    void setUp() {
+        paymentPrepareService = new PaymentPrepareService(
+                testDraftRepository,
+                paymentRepository,
+                paymentAmountCalculator,
+                testDraftValidator
+        );
+    }
+
+    @Test
+    @DisplayName("금액 산정 필수값이 부족하면 결제 등록을 중단하고 DRAFT_005를 전파한다")
+    void throwsDraft005WhenAmountFieldsMissing() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .build();
+        ReflectionTestUtils.setField(draft, "id", 10L);
+
+        given(testDraftRepository.findById(10L)).willReturn(Optional.of(draft));
+        given(testDraftValidator.validateForPayment(draft))
+                .willThrow(new BaseException(BaseErrorCode.DRAFT_005));
+
+        assertThatThrownBy(() -> paymentPrepareService.prepare(10L, 1L, true))
+                .isInstanceOf(BaseException.class)
+                .extracting(ex -> ((BaseException) ex).getErrorCode())
+                .isEqualTo(BaseErrorCode.DRAFT_005);
+
+        verify(paymentAmountCalculator, never()).totalAmount(anyInt(), anyInt());
+        verify(paymentRepository, never()).save(any(Payment.class));
+    }
+
+    @Test
+    @DisplayName("게시 필수값이 부족하면 결제 등록을 중단하고 DRAFT_006을 전파한다")
+    void throwsDraft006WhenPublishableFieldsMissing() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .goalPpl(5)
+                .reward(300)
+                .closedAt(LocalDateTime.now().plusDays(3))
+                .build();
+        ReflectionTestUtils.setField(draft, "id", 10L);
+
+        given(testDraftRepository.findById(10L)).willReturn(Optional.of(draft));
+        given(testDraftValidator.validateForPayment(draft))
+                .willThrow(new BaseException(BaseErrorCode.DRAFT_006));
+
+        assertThatThrownBy(() -> paymentPrepareService.prepare(10L, 1L, true))
+                .isInstanceOf(BaseException.class)
+                .extracting(ex -> ((BaseException) ex).getErrorCode())
+                .isEqualTo(BaseErrorCode.DRAFT_006);
+
+        verify(paymentAmountCalculator, never()).totalAmount(anyInt(), anyInt());
+        verify(paymentRepository, never()).save(any(Payment.class));
+    }
+
+    @Test
+    @DisplayName("질문 payload 구조가 잘못되면 결제 등록을 중단하고 payment를 생성하지 않는다")
+    void blocksPaymentCreationWhenQuestionPayloadMalformed() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .title("제목")
+                .description("설명")
+                .categories(List.of("FOOD"))
+                .goalPpl(5)
+                .reward(300)
+                .closedAt(LocalDateTime.now().plusDays(3))
+                .questionsPayload(Map.of("questions", "not-a-list"))
+                .build();
+        ReflectionTestUtils.setField(draft, "id", 10L);
+
+        given(testDraftRepository.findById(10L)).willReturn(Optional.of(draft));
+        given(testDraftValidator.validateForPayment(draft))
+                .willThrow(new BaseException(BaseErrorCode.DRAFT_006));
+
+        assertThatThrownBy(() -> paymentPrepareService.prepare(10L, 1L, true))
+                .isInstanceOf(BaseException.class)
+                .extracting(ex -> ((BaseException) ex).getErrorCode())
+                .isEqualTo(BaseErrorCode.DRAFT_006);
+
+        verify(paymentAmountCalculator, never()).totalAmount(anyInt(), anyInt());
+        verify(paymentRepository, never()).findByDraftId(anyLong());
+        verify(paymentRepository, never()).save(any(Payment.class));
+    }
+
+    @Test
+    @DisplayName("정상 초안이면 validator를 거친 뒤 결제 준비 정보를 반환한다")
+    void preparesPaymentWhenDraftIsValid() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .title("제목")
+                .description("설명")
+                .categories(List.of("FOOD"))
+                .goalPpl(5)
+                .reward(300)
+                .closedAt(LocalDateTime.now().plusDays(3))
+                .questionsPayload(Map.of("questions", List.of(
+                        Map.of("type", "SUBJECTIVE", "title", "질문 제목", "description", "질문 설명")
+                )))
+                .build();
+        ReflectionTestUtils.setField(draft, "id", 10L);
+
+        Payment savedPayment = Payment.builder()
+                .draftId(10L)
+                .makerId(1L)
+                .orderNo("temp-order")
+                .goalPpl(5)
+                .reward(300)
+                .amount(1500)
+                .isTestPayment(true)
+                .build();
+        ReflectionTestUtils.setField(savedPayment, "id", 20L);
+
+        given(testDraftRepository.findById(10L)).willReturn(Optional.of(draft));
+        given(paymentAmountCalculator.totalAmount(5, 300)).willReturn(1500);
+        given(paymentRepository.findByDraftId(10L)).willReturn(Optional.empty());
+        given(paymentRepository.save(any(Payment.class))).willReturn(savedPayment);
+
+        PaymentPrepareService.PaymentPreparation result = paymentPrepareService.prepare(10L, 1L, true);
+
+        assertThat(result.paymentId()).isEqualTo(20L);
+        assertThat(result.draftId()).isEqualTo(10L);
+        assertThat(result.amount()).isEqualTo(1500);
+        assertThat(result.orderNo()).startsWith("d-10-");
+        verify(testDraftValidator).validateForPayment(draft);
+    }
+}

--- a/src/test/java/server/MATE/domain/test/service/TestPublishServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestPublishServiceTest.java
@@ -1,7 +1,5 @@
 package server.MATE.domain.test.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.validation.Validation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +19,9 @@ import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.domain.testdraft.entity.TestDraft;
 import server.MATE.domain.testdraft.entity.TestDraftStatus;
 import server.MATE.domain.testdraft.repository.TestDraftRepository;
+import server.MATE.domain.testdraft.validator.TestDraftValidator;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -52,6 +53,9 @@ class TestPublishServiceTest {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
+    @Mock
+    private TestDraftValidator testDraftValidator;
+
     private TestPublishService testPublishService;
 
     @BeforeEach
@@ -62,8 +66,7 @@ class TestPublishServiceTest {
                 testRepository,
                 questionService,
                 eventPublisher,
-                new ObjectMapper().findAndRegisterModules(),
-                Validation.buildDefaultValidatorFactory().getValidator()
+                testDraftValidator
         );
     }
 
@@ -109,6 +112,8 @@ class TestPublishServiceTest {
 
         given(paymentRepository.findByIdForUpdate(20L)).willReturn(Optional.of(payment));
         given(testDraftRepository.findByIdForUpdate(10L)).willReturn(Optional.of(draft));
+        given(testDraftValidator.validateForPublish(any(TestDraft.class)))
+                .willReturn(new QuestionCreateRequest(List.of()));
         given(testRepository.save(any(server.MATE.domain.test.entity.Test.class))).willAnswer(invocation -> {
             server.MATE.domain.test.entity.Test saved = invocation.getArgument(0);
             ReflectionTestUtils.setField(saved, "id", 99L);
@@ -157,59 +162,17 @@ class TestPublishServiceTest {
     }
 
     @Test
-    @DisplayName("유효하지 않은 카테고리가 포함된 draft는 publish 단계에서 DRAFT_004 예외가 발생한다")
-    void throwsDraft004WhenDraftContainsInvalidCategory() {
+    @DisplayName("TestDraftValidator가 DRAFT_006을 던지면 publish 단계에서 그대로 전파된다")
+    void throwsDraft006WhenTestDraftValidatorFails() {
         TestDraft draft = TestDraft.builder()
                 .makerId(1L)
                 .title("테스트 제목")
                 .description("테스트 설명")
-                .serviceName("서비스명")
-                .serviceDescription("서비스 설명")
-                .categories(List.of("INVALID_CATEGORY"))
-                .goalPpl(100)
-                .reward(300)
-                .questionsPayload(Map.of(
-                        "questions", List.of(
-                                Map.of("type", "SUBJECTIVE", "title", "질문 제목", "description", "질문 설명")
-                        )
-                ))
-                .status(TestDraftStatus.PAYMENT_CREATED)
-                .build();
-        ReflectionTestUtils.setField(draft, "id", 10L);
-
-        Payment payment = Payment.builder()
-                .draftId(10L)
-                .makerId(1L)
-                .payStatus(PayStatus.PAY_SUCCEEDED)
-                .goalPpl(100)
-                .reward(300)
-                .amount(30000)
-                .build();
-        ReflectionTestUtils.setField(payment, "id", 20L);
-
-        given(paymentRepository.findByIdForUpdate(20L)).willReturn(Optional.of(payment));
-        given(testDraftRepository.findByIdForUpdate(10L)).willReturn(Optional.of(draft));
-
-        assertThatThrownBy(() -> testPublishService.publish(20L))
-                .isInstanceOf(server.MATE.global.common.exception.BaseException.class)
-                .hasMessageContaining("게시할 수 없는 테스트 초안입니다.");
-    }
-
-    @Test
-    @DisplayName("질문 payload가 QuestionCreateRequest로 변환되거나 검증되지 못하면 DRAFT_004 예외가 발생한다")
-    void throwsDraft004WhenQuestionPayloadIsInvalid() {
-        TestDraft draft = TestDraft.builder()
-                .makerId(1L)
-                .title("테스트 제목")
-                .description("테스트 설명")
-                .serviceName("서비스명")
-                .serviceDescription("서비스 설명")
                 .categories(List.of("DAILY"))
                 .goalPpl(100)
                 .reward(300)
-                .questionsPayload(Map.of(
-                        "questions", "invalid-payload"
-                ))
+                .closedAt(LocalDateTime.parse("2099-05-31T23:59:59"))
+                .questionsPayload(Map.of("questions", List.of(Map.of("type", "SUBJECTIVE", "title", "질문"))))
                 .status(TestDraftStatus.PAYMENT_CREATED)
                 .build();
         ReflectionTestUtils.setField(draft, "id", 10L);
@@ -226,9 +189,11 @@ class TestPublishServiceTest {
 
         given(paymentRepository.findByIdForUpdate(20L)).willReturn(Optional.of(payment));
         given(testDraftRepository.findByIdForUpdate(10L)).willReturn(Optional.of(draft));
+        given(testDraftValidator.validateForPublish(any(TestDraft.class)))
+                .willThrow(new BaseException(BaseErrorCode.DRAFT_006));
 
         assertThatThrownBy(() -> testPublishService.publish(20L))
-                .isInstanceOf(server.MATE.global.common.exception.BaseException.class)
-                .hasMessageContaining("게시할 수 없는 테스트 초안입니다.");
+                .isInstanceOf(BaseException.class)
+                .hasMessageContaining("게시에 필요한 필수 정보가 부족합니다.");
     }
 }

--- a/src/test/java/server/MATE/domain/testdraft/entity/TestDraftValidationTest.java
+++ b/src/test/java/server/MATE/domain/testdraft/entity/TestDraftValidationTest.java
@@ -1,0 +1,212 @@
+package server.MATE.domain.testdraft.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TestDraftValidationTest {
+
+    @Test
+    @DisplayName("PUBLISHED 상태에서 validatePaymentState 호출 시 DRAFT_003")
+    void validatePaymentState_published_throwsDraft003() {
+        TestDraft draft = TestDraft.builder().makerId(1L).status(TestDraftStatus.PUBLISHED).build();
+
+        BaseException ex = assertThrows(BaseException.class, draft::validatePaymentState);
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_003);
+    }
+
+    @Test
+    @DisplayName("PUBLISHING 상태에서 validatePaymentState 호출 시 DRAFT_003")
+    void validatePaymentState_publishing_throwsDraft003() {
+        TestDraft draft = TestDraft.builder().makerId(1L).status(TestDraftStatus.PUBLISHING).build();
+
+        BaseException ex = assertThrows(BaseException.class, draft::validatePaymentState);
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_003);
+    }
+
+   @Test
+    @DisplayName("goalPpl 없으면 DRAFT_005")
+    void validateAmountFields_missingGoalPpl_throwsDraft005() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .reward(300)
+                .closedAt(LocalDateTime.now().plusDays(10))
+                .build();
+
+        BaseException ex = assertThrows(BaseException.class, draft::validateAmountFields);
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_005);
+    }
+
+    @Test
+    @DisplayName("reward 없으면 DRAFT_005")
+    void validateAmountFields_missingReward_throwsDraft005() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .goalPpl(5)
+                .closedAt(LocalDateTime.now().plusDays(10))
+                .build();
+
+        BaseException ex = assertThrows(BaseException.class, draft::validateAmountFields);
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_005);
+    }
+
+    @Test
+    @DisplayName("closedAt 없으면 DRAFT_005")
+    void validateAmountFields_missingClosedAt_throwsDraft005() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .goalPpl(5)
+                .reward(300)
+                .build();
+
+        BaseException ex = assertThrows(BaseException.class, draft::validateAmountFields);
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_005);
+    }
+
+    @Test
+    @DisplayName("title이 blank이면 DRAFT_006")
+    void validatePublishableFields_blankTitle_throwsDraft006() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .goalPpl(5).reward(300).closedAt(LocalDateTime.now().plusDays(10))
+                .title("  ")
+                .description("설명")
+                .categories(List.of("FOOD"))
+                .questionsPayload(Map.of("questions", List.of(Map.of("type", "SUBJECTIVE"))))
+                .build();
+
+        BaseException ex = assertThrows(BaseException.class, draft::validatePublishableFields);
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_006);
+    }
+
+    @Test
+    @DisplayName("description이 blank이면 DRAFT_006")
+    void validatePublishableFields_blankDescription_throwsDraft006() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .goalPpl(5).reward(300).closedAt(LocalDateTime.now().plusDays(10))
+                .title("제목")
+                .description("")
+                .categories(List.of("FOOD"))
+                .questionsPayload(Map.of("questions", List.of(Map.of("type", "SUBJECTIVE"))))
+                .build();
+
+        BaseException ex = assertThrows(BaseException.class, draft::validatePublishableFields);
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_006);
+    }
+
+    @Test
+    @DisplayName("categories가 비어있으면 DRAFT_006")
+    void validatePublishableFields_emptyCategories_throwsDraft006() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .goalPpl(5).reward(300).closedAt(LocalDateTime.now().plusDays(10))
+                .title("제목").description("설명")
+                .categories(List.of())
+                .questionsPayload(Map.of("questions", List.of(Map.of("type", "SUBJECTIVE"))))
+                .build();
+
+        BaseException ex = assertThrows(BaseException.class, draft::validatePublishableFields);
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_006);
+    }
+
+    @Test
+    @DisplayName("categories에 유효하지 않은 enum 값이 있으면 DRAFT_006")
+    void validatePublishableFields_invalidCategory_throwsDraft006() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .goalPpl(5).reward(300).closedAt(LocalDateTime.now().plusDays(10))
+                .title("제목").description("설명")
+                .categories(List.of("INVALID_CATEGORY"))
+                .questionsPayload(Map.of("questions", List.of(Map.of("type", "SUBJECTIVE"))))
+                .build();
+
+        BaseException ex = assertThrows(BaseException.class, draft::validatePublishableFields);
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_006);
+    }
+
+    @Test
+    @DisplayName("questionsPayload가 null이면 DRAFT_006")
+    void validatePublishableFields_nullQuestionsPayload_throwsDraft006() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .goalPpl(5).reward(300).closedAt(LocalDateTime.now().plusDays(10))
+                .title("제목").description("설명")
+                .categories(List.of("FOOD"))
+                .build();
+
+        BaseException ex = assertThrows(BaseException.class, draft::validatePublishableFields);
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_006);
+    }
+
+    @Test
+    @DisplayName("questionsPayload의 questions 리스트가 비어있으면 DRAFT_006")
+    void validatePublishableFields_emptyQuestions_throwsDraft006() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .goalPpl(5).reward(300).closedAt(LocalDateTime.now().plusDays(10))
+                .title("제목").description("설명")
+                .categories(List.of("FOOD"))
+                .questionsPayload(Map.of("questions", List.of()))
+                .build();
+
+        BaseException ex = assertThrows(BaseException.class, draft::validatePublishableFields);
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_006);
+    }
+
+    @Test
+    @DisplayName("게시 필수 필드를 모두 충족하면 예외 없음")
+    void validatePublishableFields_allFieldsValid_doesNotThrow() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .status(TestDraftStatus.DRAFT)
+                .goalPpl(5).reward(300).closedAt(LocalDateTime.now().plusDays(10))
+                .title("제목").description("설명")
+                .categories(List.of("FOOD"))
+                .questionsPayload(Map.of("questions", List.of(Map.of("type", "SUBJECTIVE"))))
+                .build();
+
+        assertThatCode(draft::validatePublishableFields).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("PAYMENT_CREATED 상태이면 예외 없음")
+    void validatePublishState_paymentCreated_doesNotThrow() {
+        TestDraft draft = TestDraft.builder().makerId(1L).status(TestDraftStatus.PAYMENT_CREATED).build();
+        assertThatCode(draft::validatePublishState).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("PUBLISH_FAILED 상태이면 예외 없음")
+    void validatePublishState_publishFailed_doesNotThrow() {
+        TestDraft draft = TestDraft.builder().makerId(1L).status(TestDraftStatus.PUBLISH_FAILED).build();
+        assertThatCode(draft::validatePublishState).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("DRAFT 상태이면 DRAFT_004")
+    void validatePublishState_draftStatus_throwsDraft004() {
+        TestDraft draft = TestDraft.builder().makerId(1L).status(TestDraftStatus.DRAFT).build();
+
+        BaseException ex = assertThrows(BaseException.class, draft::validatePublishState);
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_004);
+    }
+
+    @Test
+    @DisplayName("PAYMENT_FAILED 상태이면 DRAFT_004")
+    void validatePublishState_paymentFailed_throwsDraft004() {
+        TestDraft draft = TestDraft.builder().makerId(1L).status(TestDraftStatus.PAYMENT_FAILED).build();
+
+        BaseException ex = assertThrows(BaseException.class, draft::validatePublishState);
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_004);
+    }
+}

--- a/src/test/java/server/MATE/domain/testdraft/entity/TestDraftValidationTest.java
+++ b/src/test/java/server/MATE/domain/testdraft/entity/TestDraftValidationTest.java
@@ -74,6 +74,34 @@ class TestDraftValidationTest {
     }
 
     @Test
+    @DisplayName("goalPpl이 0 이하이면 DRAFT_005")
+    void validateAmountFields_nonPositiveGoalPpl_throwsDraft005() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .goalPpl(0)
+                .reward(300)
+                .closedAt(LocalDateTime.now().plusDays(10))
+                .build();
+
+        BaseException ex = assertThrows(BaseException.class, draft::validateAmountFields);
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_005);
+    }
+
+    @Test
+    @DisplayName("reward가 음수이면 DRAFT_005")
+    void validateAmountFields_negativeReward_throwsDraft005() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .goalPpl(5)
+                .reward(-1)
+                .closedAt(LocalDateTime.now().plusDays(10))
+                .build();
+
+        BaseException ex = assertThrows(BaseException.class, draft::validateAmountFields);
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_005);
+    }
+
+    @Test
     @DisplayName("title이 blank이면 DRAFT_006")
     void validatePublishableFields_blankTitle_throwsDraft006() {
         TestDraft draft = TestDraft.builder()

--- a/src/test/java/server/MATE/domain/testdraft/entity/TestDraftValidationTest.java
+++ b/src/test/java/server/MATE/domain/testdraft/entity/TestDraftValidationTest.java
@@ -6,6 +6,7 @@ import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -127,6 +128,21 @@ class TestDraftValidationTest {
                 .goalPpl(5).reward(300).closedAt(LocalDateTime.now().plusDays(10))
                 .title("제목").description("설명")
                 .categories(List.of("INVALID_CATEGORY"))
+                .questionsPayload(Map.of("questions", List.of(Map.of("type", "SUBJECTIVE"))))
+                .build();
+
+        BaseException ex = assertThrows(BaseException.class, draft::validatePublishableFields);
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_006);
+    }
+
+    @Test
+    @DisplayName("categories에 null 요소가 있으면 DRAFT_006")
+    void validatePublishableFields_nullCategory_throwsDraft006() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .goalPpl(5).reward(300).closedAt(LocalDateTime.now().plusDays(10))
+                .title("제목").description("설명")
+                .categories(Arrays.asList("FOOD", null))
                 .questionsPayload(Map.of("questions", List.of(Map.of("type", "SUBJECTIVE"))))
                 .build();
 

--- a/src/test/java/server/MATE/domain/testdraft/validator/TestDraftValidatorTest.java
+++ b/src/test/java/server/MATE/domain/testdraft/validator/TestDraftValidatorTest.java
@@ -1,0 +1,90 @@
+package server.MATE.domain.testdraft.validator;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import server.MATE.domain.question.dto.request.QuestionCreateRequest;
+import server.MATE.domain.testdraft.entity.TestDraft;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TestDraftValidatorTest {
+
+    private TestDraftValidator testDraftValidator;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        testDraftValidator = new TestDraftValidator(objectMapper, validator);
+    }
+
+    @Test
+    @DisplayName("결제 등록 검증은 금액/게시 필수값과 questionsPayload를 함께 검증한다")
+    void validateForPayment_validPayload_returnsRequest() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .goalPpl(5)
+                .reward(300)
+                .closedAt(java.time.LocalDateTime.now().plusDays(3))
+                .title("제목")
+                .description("설명")
+                .categories(List.of("FOOD"))
+                .questionsPayload(Map.of("questions", List.of(
+                        Map.of("type", "SUBJECTIVE",
+                               "title", "어떤 점이 불편했나요?",
+                               "description", "자유롭게 작성해주세요.")
+                )))
+                .build();
+
+        QuestionCreateRequest result = testDraftValidator.validateForPayment(draft);
+
+        assertThat(result).isNotNull();
+        assertThat(result.questions()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("게시 검증에서 questions 값이 List가 아니면 DRAFT_006")
+    void validateForPublish_questionsNotList_throwsDraft006() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .status(server.MATE.domain.testdraft.entity.TestDraftStatus.PAYMENT_CREATED)
+                .title("제목")
+                .description("설명")
+                .categories(List.of("FOOD"))
+                .questionsPayload(Map.of("questions", "invalid_string_not_a_list"))
+                .build();
+
+        BaseException ex = assertThrows(BaseException.class,
+                () -> testDraftValidator.validateForPublish(draft));
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_006);
+    }
+
+    @Test
+    @DisplayName("게시 검증에서 상태가 PAYMENT_CREATED가 아니면 DRAFT_004")
+    void validateForPublish_invalidState_throwsDraft004() {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .status(server.MATE.domain.testdraft.entity.TestDraftStatus.DRAFT)
+                .title("제목")
+                .description("설명")
+                .categories(List.of("FOOD"))
+                .questionsPayload(Map.of("questions", List.of(
+                        Map.of("type", "SUBJECTIVE", "title", "질문 제목", "description", "질문 설명")
+                )))
+                .build();
+
+        BaseException ex = assertThrows(BaseException.class,
+                () -> testDraftValidator.validateForPublish(draft));
+        assertThat(ex.getErrorCode()).isEqualTo(BaseErrorCode.DRAFT_004);
+    }
+}

--- a/src/test/java/server/MATE/integration/DraftPaymentPublishEndToEndIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/DraftPaymentPublishEndToEndIntegrationTest.java
@@ -35,11 +35,14 @@ import server.MATE.domain.question.service.QuestionService;
 import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.domain.test.repository.TestLikeRepository;
 import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.domain.testdraft.entity.TestDraft;
 import server.MATE.domain.testdraft.entity.TestDraftStatus;
 import server.MATE.domain.testdraft.repository.TestDraftRepository;
 import server.MATE.domain.users.entity.Users;
 import server.MATE.domain.users.repository.UsersRepository;
 import server.MATE.global.storage.FileStorageService;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -258,16 +261,16 @@ class DraftPaymentPublishEndToEndIntegrationTest {
 
         Long draftId = createDraft(makerToken);
 
-        JsonNode error = createPaymentExpectingError(draftId, makerToken, 400, "PAYMENT_005");
+        JsonNode error = createPaymentExpectingError(draftId, makerToken, 400, "DRAFT_005");
 
-        assertThat(error.path("message").asText()).isEqualTo("결제 금액 계산에 필요한 값이 누락되었습니다.");
+        assertThat(error.path("message").asText()).isEqualTo("결제 금액 산정에 필요한 정보가 부족합니다.");
         assertThat(paymentRepository.findByDraftId(draftId)).isEmpty();
         assertThat(testDraftRepository.findById(draftId).orElseThrow().getStatus()).isEqualTo(TestDraftStatus.DRAFT);
     }
 
     @Test
-    @DisplayName("게시 필수 정보가 없는 draft는 결제 성공 후에도 publish가 차단되고 draft는 PUBLISH_FAILED로 남는다")
-    void marksDraftAsPublishFailedWhenPublishValidationFails() throws Exception {
+    @DisplayName("goalPpl/reward/closedAt은 있지만 title/categories/questions 없으면 결제 등록이 차단된다")
+    void blocksPaymentCreationWhenPublishFieldsMissing() throws Exception {
         Users maker = usersRepository.save(Users.builder()
                 .ci("maker-" + System.nanoTime())
                 .name("maker")
@@ -283,16 +286,76 @@ class DraftPaymentPublishEndToEndIntegrationTest {
                 }
                 """);
 
-        Long paymentId = createPayment(draftId, makerToken);
-        JsonNode error = executePaymentExpectingError(paymentId, makerToken, 400, "DRAFT_004");
+        JsonNode error = createPaymentExpectingError(draftId, makerToken, 400, "DRAFT_006");
+        assertThat(error.path("message").asText()).isEqualTo("게시에 필요한 필수 정보가 부족합니다.");
+        assertThat(paymentRepository.findByDraftId(draftId)).isEmpty();
+        assertThat(testDraftRepository.findById(draftId).orElseThrow().getStatus()).isEqualTo(TestDraftStatus.DRAFT);
+    }
 
-        assertThat(error.path("message").asText()).isEqualTo("게시할 수 없는 테스트 초안입니다.");
-        var draft = testDraftRepository.findById(draftId).orElseThrow();
-        var payment = paymentRepository.findById(paymentId).orElseThrow();
-        assertThat(draft.getStatus()).isEqualTo(TestDraftStatus.PUBLISH_FAILED);
-        assertThat(draft.getPublishedTestId()).isNull();
-        assertThat(payment.getPayStatus()).isEqualTo(PayStatus.PAY_SUCCEEDED);
-        assertThat(payment.getTestId()).isNull();
+    @Test
+    @DisplayName("questions 배열 원소가 객체가 아니면 결제 등록이 차단된다")
+    void blocksPaymentCreationWhenQuestionsPayloadMalformed() throws Exception {
+        Users maker = usersRepository.save(Users.builder()
+                .ci("maker-" + System.nanoTime())
+                .name("maker")
+                .build());
+        String makerToken = bearerToken(maker);
+
+        Long draftId = createDraft(makerToken);
+        updateDraft(draftId, makerToken, """
+                {
+                  "title": "신규 테스트",
+                  "description": "테스트 소개",
+                  "categories": ["FOOD"],
+                  "goalPpl": 5,
+                  "reward": 300,
+                  "closedAt": "2099-05-31",
+                  "questionsPayload": {
+                    "questions": ["not-an-object"]
+                  }
+                }
+                """);
+
+        JsonNode error = createPaymentExpectingError(draftId, makerToken, 400, "DRAFT_006");
+        assertThat(error.path("message").asText()).isEqualTo("게시에 필요한 필수 정보가 부족합니다.");
+        assertThat(paymentRepository.findByDraftId(draftId)).isEmpty();
+        assertThat(testDraftRepository.findById(draftId).orElseThrow().getStatus()).isEqualTo(TestDraftStatus.DRAFT);
+    }
+
+    @Test
+    @DisplayName("결제 등록 후 draft가 훼손되면 결제 실행 시 publish 직전 검증에서 차단된다")
+    void blocksPublishWhenDraftBecomesInvalidAfterPaymentCreation() throws Exception {
+        Users maker = usersRepository.save(Users.builder()
+                .ci("maker-" + System.nanoTime())
+                .name("maker")
+                .build());
+        String makerToken = bearerToken(maker);
+
+        Long draftId = createDraft(makerToken);
+        updateDraft(draftId, makerToken, draftPayload());
+        Long paymentId = createPayment(draftId, makerToken);
+
+        TestDraft invalidatedDraft = testDraftRepository.findById(draftId).orElseThrow();
+        invalidatedDraft.update(
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of("INVALID_CATEGORY"),
+                null,
+                null,
+                null,
+                null
+        );
+        testDraftRepository.saveAndFlush(invalidatedDraft);
+
+        JsonNode error = executePaymentExpectingError(paymentId, makerToken, 400, "DRAFT_006");
+
+        assertThat(error.path("message").asText()).isEqualTo("게시에 필요한 필수 정보가 부족합니다.");
+        assertThat(testDraftRepository.findById(draftId).orElseThrow().getStatus()).isEqualTo(TestDraftStatus.PUBLISH_FAILED);
+        assertThat(paymentRepository.findById(paymentId).orElseThrow().getPayStatus()).isEqualTo(PayStatus.PAY_SUCCEEDED);
+        assertThat(paymentRepository.findById(paymentId).orElseThrow().getTestId()).isNull();
         assertThat(testRepository.count()).isZero();
         assertThat(questionRepository.count()).isZero();
     }


### PR DESCRIPTION
## 📍 요약
- 결제 등록과 결제 실행 전 검증 정책을 분리하고, 결제 등록에서 선검증하되 publish 직전에도 최종 검증이 수행되도록 구조를 개선함

## 🔗 관련 이슈
- Closes #189 

## 📌 변경 사항
- [x] 기능
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- TestDraft 검증을 결제 등록 상태, 금액 필드, 게시 필수 필드, 게시 가능 상태 검증으로 분리
- TestDraftValidator에 validateForPayment, validateForPublish를 추가해 결제 등록, 결제 실행 단계별 검증 진입점을 분리
- PaymentPrepareService는 결제 등록 전 테스트 draft 선검증을 수행하도록 수정
- TestPublishService는 결제 실행 후 publish 직전에 최종 검증을 다시 수행하도록 수정
- 결제 등록 실패(DRAFT_005, DRAFT_006, malformed payload)와 publish 직전 차단 시나리오 테스트를 추가 및 보완

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew test --tests server.MATE.domain.payment.service.PaymentPrepareServiceTest --tests server.MATE.domain.testdraft.entity.TestDraftValidationTest --tests server.MATE.domain.testdraft.validator.TestDraftValidatorTest --tests server.MATE.domain.test.service.TestPublishServiceTest --tests server.MATE.integration.DraftPaymentPublishEndToEndIntegrationTest
