### PR TITLE
fix: PDF 다운로드 500 오류 수정

### DIFF
--- a/src/main/java/server/MATE/domain/report/config/MatePdfConfig.java
+++ b/src/main/java/server/MATE/domain/report/config/MatePdfConfig.java
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import reactor.netty.http.client.HttpClient;
@@ -13,15 +14,22 @@ import reactor.netty.http.client.HttpClient;
 @EnableConfigurationProperties(MatePdfProperties.class)
 public class MatePdfConfig {
 
+    private static final int MAX_IN_MEMORY_SIZE = 10 * 1024 * 1024; // 10MB
+
     @Bean
     @Qualifier("matePdfWebClient")
     public WebClient matePdfWebClient(WebClient.Builder builder, MatePdfProperties properties) {
         HttpClient httpClient = HttpClient.create()
                 .responseTimeout(properties.timeout());
 
+        ExchangeStrategies strategies = ExchangeStrategies.builder()
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(MAX_IN_MEMORY_SIZE))
+                .build();
+
         return builder
                 .baseUrl(properties.baseUrl())
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .exchangeStrategies(strategies)
                 .build();
     }
 }

--- a/src/main/java/server/MATE/domain/report/service/pdf/TestReportPdfService.java
+++ b/src/main/java/server/MATE/domain/report/service/pdf/TestReportPdfService.java
@@ -10,7 +10,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import reactor.core.publisher.Mono;
 import server.MATE.domain.report.config.MatePdfProperties;
@@ -46,17 +45,14 @@ public class TestReportPdfService {
             throw new BaseException(BaseErrorCode.REPORT_012);
         }
 
-        String uri = UriComponentsBuilder.fromPath("/generate")
-                .queryParam("testId", testId)
-                .queryParam("title", test.getTitle())
-                .build()
-                .encode()
-                .toUriString();
-
         String responseBody;
         try {
             responseBody = matePdfWebClient.get()
-                    .uri(uri)
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/generate")
+                            .queryParam("testId", testId)
+                            .queryParam("title", test.getTitle())
+                            .build())
                     .header(HttpHeaders.AUTHORIZATION, authorization)
                     .retrieve()
                     .onStatus(HttpStatusCode::isError, response -> response.bodyToMono(String.class)


### PR DESCRIPTION
  ## 📍 요약
  - PDF 응답 base64가 WebClient 기본 버퍼(256KB)를 초과해 발생하던 500 오류 수정
  
  ## 🔗 관련 이슈
  - Closes #193
  
  ## 📌 변경 사항
  - [x] 버그 수정
  
  ## ✅ 작업 내용
  - WebClient `ExchangeStrategies` 적용, maxInMemorySize 256KB → 10MB
  - `UriComponentsBuilder` 방식을 람다 URI 빌더로 교체해 한글 제목 이중 인코딩 방지
  
  ## 테스트