### PR TITLE
fix: mate 단독 변경 시 이미지 태그 미업데이트 버그 수정

### DIFF
--- a/.github/workflows/ci-acr.yml
+++ b/.github/workflows/ci-acr.yml
@@ -140,6 +140,7 @@ jobs:
   update-kustomization:
     needs: [changes, mate, pdf]
     if: >
+      always() &&
       github.event_name == 'push' &&
       github.actor != 'github-actions[bot]' &&
       (needs.mate.result == 'success' || needs.pdf.result == 'success')


### PR DESCRIPTION
  ## 📍 요약
  - pdf-server 외 파일만 변경 시 update-kustomization 잡이 skip되어 이미지 태그가 업데이트되지 않던 문제 수정
  
  ## 🔗 관련 이슈
  - Closes #193
  
  ## 📌 변경 사항
  - [x] 버그 수정
  
  ## ✅ 작업 내용
  - `update-kustomization` 잡 `if` 조건에 `always()` 추가
  - pdf 잡이 skipped 상태일 때 GitHub Actions가 dependent 잡을 자동 skip하는 동작 방지
  
  ## 테스트
  - [ ] 로컬 테스트 완료
  - 테스트 방법:
    - pdf-server 외 파일만 변경 후 push → update-kustomization 잡 정상 실행 및 kustomization.yaml 태그 업데이트 확인