### PR TITLE
feat: PDF/엑셀 리포트 중복 생성 방지 및 다운로드 방식 통일

### DIFF
--- a/src/main/java/server/MATE/domain/report/controller/ReportController.java
+++ b/src/main/java/server/MATE/domain/report/controller/ReportController.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -392,45 +391,42 @@ public class ReportController {
     @Operation(
             summary = "➰ 리포트 통계 xlsx 파일 다운로드",
             description = """
-                    테스트 전체 리포트를 하나의 엑셀 파일(다중 시트)로 다운로드합니다.
+                    테스트 전체 리포트 엑셀의 다운로드 URL을 반환합니다.
                     - 테스트 메이커만 다운로드할 수 있습니다.
                     - 테스트 종료 및 리포트 집계 완료(`report_status = COMPLETED`) 후 다운로드 가능합니다.
                     - 시트 구성: 기본 정보, 마스터 템플릿, 객관식, 주관식, AB 테스트, 척도 테스트, 카드소팅, 트리테스트, 5초 테스트
                     - 질문 유형별 시트에는 해당 테스트에 포함된 질문 통계가 순서대로 기록됩니다.
                     - 5초 테스트는 객관/주관 설정에 따라 시트 내 템플릿이 달라집니다.
+                    - 최초 요청 시 엑셀을 생성해 Blob Storage에 저장하고, 이후 요청은 저장된 파일의 URL을 반환합니다.
+                    - 반환된 URL은 30분간 유효합니다.
                     """
     )
     @GetMapping("/excel")
-    public ResponseEntity<byte[]> downloadExcelReport(
+    public ResponseEntity<ApiResponse<String>> downloadExcelReport(
             @PathVariable Long testId,
             @AuthenticationPrincipal AuthenticatedUser user
     ) {
         TestReportExcelDownload download = testReportExcelService.export(testId, user.getId());
-        return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + download.filename() + "\"")
-                .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
-                .body(download.content());
+        return ResponseEntity.ok(ApiResponse.ok("엑셀 다운로드 URL이 발급되었습니다.", download.downloadUrl()));
     }
 
     @Operation(
             summary = "➰ 리포트 통계 PDF 파일 다운로드",
             description = """
-                    테스트 전체 리포트를 PDF 파일로 다운로드합니다.
+                    테스트 전체 리포트 PDF의 다운로드 URL을 반환합니다.
                     - 테스트 메이커만 다운로드할 수 있습니다.
                     - 테스트 종료 및 리포트 집계 완료(`report_status = COMPLETED`) 후 다운로드 가능합니다.
-                    - 클러스터 내부 PDF 서비스(mate-pdf)를 호출해 생성합니다.
+                    - 최초 요청 시 PDF를 생성해 Blob Storage에 저장하고, 이후 요청은 저장된 파일의 URL을 반환합니다.
+                    - 반환된 URL은 30분간 유효합니다.
                     """
     )
     @GetMapping("/pdf")
-    public ResponseEntity<byte[]> downloadPdfReport(
+    public ResponseEntity<ApiResponse<String>> downloadPdfReport(
             @PathVariable Long testId,
             @AuthenticationPrincipal AuthenticatedUser user,
             @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization
     ) {
         TestReportPdfDownload download = testReportPdfService.export(testId, user.getId(), authorization);
-        return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + download.filename() + "\"")
-                .contentType(MediaType.APPLICATION_PDF)
-                .body(download.content());
+        return ResponseEntity.ok(ApiResponse.ok("PDF 다운로드 URL이 발급되었습니다.", download.downloadUrl()));
     }
 }

--- a/src/main/java/server/MATE/domain/report/dto/response/TestReportExcelDownload.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/TestReportExcelDownload.java
@@ -1,7 +1,7 @@
 package server.MATE.domain.report.dto.response;
 
 public record TestReportExcelDownload(
-        byte[] content,
+        String downloadUrl,
         String filename
 ) {
 }

--- a/src/main/java/server/MATE/domain/report/dto/response/TestReportPdfDownload.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/TestReportPdfDownload.java
@@ -1,7 +1,7 @@
 package server.MATE.domain.report.dto.response;
 
 public record TestReportPdfDownload(
-        byte[] content,
+        String downloadUrl,
         String filename
 ) {
 }

--- a/src/main/java/server/MATE/domain/report/service/excel/CombinedTestReportExcelService.java
+++ b/src/main/java/server/MATE/domain/report/service/excel/CombinedTestReportExcelService.java
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 import server.MATE.domain.question.dto.response.QuestionSummaryItem;
 import server.MATE.domain.question.entity.FiveSecond;
 import server.MATE.domain.question.entity.QuestionType;
-import server.MATE.domain.report.dto.response.TestReportExcelDownload;
 import server.MATE.domain.report.excel.abtest.AbTestReportExcelData;
 import server.MATE.domain.report.excel.abtest.AbTestReportExcelWriter;
 import server.MATE.domain.report.excel.cardsorting.CardSortingReportExcelData;
@@ -87,7 +86,7 @@ public class CombinedTestReportExcelService {
     private final FiveSecondObjectiveReportExcelWriter fiveSecondObjectiveReportExcelWriter;
     private final FiveSecondSubjectiveReportExcelWriter fiveSecondSubjectiveReportExcelWriter;
 
-    public TestReportExcelDownload export(Long testId, Long makerId) {
+    public byte[] export(Long testId, Long makerId) {
         ReportExcelExportContext context = reportExcelExportContextLoader.load(testId, makerId);
         Test test = context.test();
         List<QuestionSummaryItem> questions = context.questionSummaries();
@@ -119,7 +118,7 @@ public class CombinedTestReportExcelService {
             writeFiveSecondSheet(workbook.createSheet(SHEET_FIVE_SECOND), session, questions);
 
             workbook.write(outputStream);
-            return new TestReportExcelDownload(outputStream.toByteArray(), buildFilename(testId));
+            return outputStream.toByteArray();
         } catch (IOException e) {
             throw new UncheckedIOException("통합 엑셀 보고서 생성에 실패했습니다.", e);
         }
@@ -381,10 +380,6 @@ public class CombinedTestReportExcelService {
         String start = DATE_FORMAT.format(test.getCreatedAt());
         String end = DATE_FORMAT.format(test.getClosedAt());
         return start + " ~ " + end;
-    }
-
-    private String buildFilename(Long testId) {
-        return "mate-report-" + testId + ".xlsx";
     }
 
     private record ExportSession(

--- a/src/main/java/server/MATE/domain/report/service/excel/TestReportExcelService.java
+++ b/src/main/java/server/MATE/domain/report/service/excel/TestReportExcelService.java
@@ -4,15 +4,41 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.MATE.domain.report.dto.response.TestReportExcelDownload;
+import server.MATE.domain.report.service.excel.support.ReportExcelExportSupport;
+import server.MATE.domain.test.entity.Test;
+import server.MATE.global.storage.FileStorageService;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class TestReportExcelService {
 
     private final CombinedTestReportExcelService combinedTestReportExcelService;
+    private final ReportExcelExportSupport reportExcelExportSupport;
+    private final FileStorageService fileStorageService;
 
+    @Transactional
     public TestReportExcelDownload export(Long testId, Long makerId) {
-        return combinedTestReportExcelService.export(testId, makerId);
+        Test test = reportExcelExportSupport.requireExportReadyTest(testId, makerId);
+
+        if (test.getExcelKey() != null) {
+            return new TestReportExcelDownload(
+                    fileStorageService.generateDownloadUrl(test.getExcelKey()),
+                    buildFilename(testId)
+            );
+        }
+
+        byte[] excelBytes = combinedTestReportExcelService.export(testId, makerId);
+        String excelKey = "reports/excel/" + testId + ".xlsx";
+        fileStorageService.upload(excelKey, excelBytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        test.saveExcelKey(excelKey);
+
+        return new TestReportExcelDownload(
+                fileStorageService.generateDownloadUrl(excelKey),
+                buildFilename(testId)
+        );
+    }
+
+    private String buildFilename(Long testId) {
+        return "mate-report-" + testId + ".xlsx";
     }
 }

--- a/src/main/java/server/MATE/domain/report/service/excel/TestReportExcelService.java
+++ b/src/main/java/server/MATE/domain/report/service/excel/TestReportExcelService.java
@@ -2,7 +2,6 @@ package server.MATE.domain.report.service.excel;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import server.MATE.domain.report.dto.response.TestReportExcelDownload;
 import server.MATE.domain.report.service.excel.support.ReportExcelExportSupport;
 import server.MATE.domain.test.entity.Test;
@@ -16,25 +15,25 @@ public class TestReportExcelService {
     private final ReportExcelExportSupport reportExcelExportSupport;
     private final FileStorageService fileStorageService;
 
-    @Transactional
     public TestReportExcelDownload export(Long testId, Long makerId) {
         Test test = reportExcelExportSupport.requireExportReadyTest(testId, makerId);
+        String filename = buildFilename(testId);
 
         if (test.getExcelKey() != null) {
             return new TestReportExcelDownload(
-                    fileStorageService.generateDownloadUrl(test.getExcelKey()),
-                    buildFilename(testId)
+                    fileStorageService.generateDownloadUrl(test.getExcelKey(), filename),
+                    filename
             );
         }
 
         byte[] excelBytes = combinedTestReportExcelService.export(testId, makerId);
         String excelKey = "reports/excel/" + testId + ".xlsx";
         fileStorageService.upload(excelKey, excelBytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        test.saveExcelKey(excelKey);
+        reportExcelExportSupport.saveExcelKey(testId, excelKey);
 
         return new TestReportExcelDownload(
-                fileStorageService.generateDownloadUrl(excelKey),
-                buildFilename(testId)
+                fileStorageService.generateDownloadUrl(excelKey, filename),
+                filename
         );
     }
 

--- a/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelExportSupport.java
+++ b/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelExportSupport.java
@@ -36,12 +36,14 @@ public class ReportExcelExportSupport {
     @Transactional
     public void savePdfKey(Long testId, String pdfKey) {
         testRepository.findActiveById(testId)
-                .ifPresent(test -> test.savePdfKey(pdfKey));
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004))
+                .savePdfKey(pdfKey);
     }
 
     @Transactional
     public void saveExcelKey(Long testId, String excelKey) {
         testRepository.findActiveById(testId)
-                .ifPresent(test -> test.saveExcelKey(excelKey));
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004))
+                .saveExcelKey(excelKey);
     }
 }

--- a/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelExportSupport.java
+++ b/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelExportSupport.java
@@ -2,6 +2,7 @@ package server.MATE.domain.report.service.excel.support;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import server.MATE.domain.test.entity.ReportStatus;
 import server.MATE.domain.test.entity.Test;
 import server.MATE.domain.test.entity.TestStatus;
@@ -30,5 +31,17 @@ public class ReportExcelExportSupport {
             throw new BaseException(BaseErrorCode.REPORT_007);
         }
         return test;
+    }
+
+    @Transactional
+    public void savePdfKey(Long testId, String pdfKey) {
+        testRepository.findActiveById(testId)
+                .ifPresent(test -> test.savePdfKey(pdfKey));
+    }
+
+    @Transactional
+    public void saveExcelKey(Long testId, String excelKey) {
+        testRepository.findActiveById(testId)
+                .ifPresent(test -> test.saveExcelKey(excelKey));
     }
 }

--- a/src/main/java/server/MATE/domain/report/service/pdf/TestReportPdfService.java
+++ b/src/main/java/server/MATE/domain/report/service/pdf/TestReportPdfService.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import reactor.core.publisher.Mono;
@@ -18,6 +19,7 @@ import server.MATE.domain.report.service.excel.support.ReportExcelExportSupport;
 import server.MATE.domain.test.entity.Test;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
+import server.MATE.global.storage.FileStorageService;
 
 @Service
 public class TestReportPdfService {
@@ -26,32 +28,56 @@ public class TestReportPdfService {
     private final ObjectMapper objectMapper;
     private final MatePdfProperties matePdfProperties;
     private final WebClient matePdfWebClient;
+    private final FileStorageService fileStorageService;
 
     public TestReportPdfService(
             ReportExcelExportSupport reportExcelExportSupport,
             ObjectMapper objectMapper,
             MatePdfProperties matePdfProperties,
-            @Qualifier("matePdfWebClient") WebClient matePdfWebClient
+            @Qualifier("matePdfWebClient") WebClient matePdfWebClient,
+            FileStorageService fileStorageService
     ) {
         this.reportExcelExportSupport = reportExcelExportSupport;
         this.objectMapper = objectMapper;
         this.matePdfProperties = matePdfProperties;
         this.matePdfWebClient = matePdfWebClient;
+        this.fileStorageService = fileStorageService;
     }
 
+    @Transactional
     public TestReportPdfDownload export(Long testId, Long makerId, String authorization) {
         Test test = reportExcelExportSupport.requireExportReadyTest(testId, makerId);
+
+        if (test.getPdfKey() != null) {
+            return new TestReportPdfDownload(
+                    fileStorageService.generateDownloadUrl(test.getPdfKey()),
+                    buildFilename(testId)
+            );
+        }
+
         if (authorization == null || authorization.isBlank()) {
             throw new BaseException(BaseErrorCode.REPORT_012);
         }
 
+        byte[] pdfBytes = generatePdf(testId, test.getTitle(), authorization);
+        String pdfKey = "reports/pdf/" + testId + ".pdf";
+        fileStorageService.upload(pdfKey, pdfBytes, "application/pdf");
+        test.savePdfKey(pdfKey);
+
+        return new TestReportPdfDownload(
+                fileStorageService.generateDownloadUrl(pdfKey),
+                buildFilename(testId)
+        );
+    }
+
+    private byte[] generatePdf(Long testId, String title, String authorization) {
         String responseBody;
         try {
             responseBody = matePdfWebClient.get()
                     .uri(uriBuilder -> uriBuilder
                             .path("/generate")
                             .queryParam("testId", testId)
-                            .queryParam("title", test.getTitle())
+                            .queryParam("title", title)
                             .build())
                     .header(HttpHeaders.AUTHORIZATION, authorization)
                     .retrieve()
@@ -76,8 +102,7 @@ public class TestReportPdfService {
             if (base64 == null || base64.isBlank()) {
                 throw new BaseException(BaseErrorCode.REPORT_012);
             }
-            byte[] pdfBytes = Base64.getDecoder().decode(base64);
-            return new TestReportPdfDownload(pdfBytes, buildFilename(testId));
+            return Base64.getDecoder().decode(base64);
         } catch (IllegalArgumentException | JsonProcessingException exception) {
             throw new BaseException(BaseErrorCode.REPORT_012);
         }

--- a/src/main/java/server/MATE/domain/report/service/pdf/TestReportPdfService.java
+++ b/src/main/java/server/MATE/domain/report/service/pdf/TestReportPdfService.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import reactor.core.publisher.Mono;
@@ -44,14 +43,14 @@ public class TestReportPdfService {
         this.fileStorageService = fileStorageService;
     }
 
-    @Transactional
     public TestReportPdfDownload export(Long testId, Long makerId, String authorization) {
         Test test = reportExcelExportSupport.requireExportReadyTest(testId, makerId);
+        String filename = buildFilename(testId);
 
         if (test.getPdfKey() != null) {
             return new TestReportPdfDownload(
-                    fileStorageService.generateDownloadUrl(test.getPdfKey()),
-                    buildFilename(testId)
+                    fileStorageService.generateDownloadUrl(test.getPdfKey(), filename),
+                    filename
             );
         }
 
@@ -62,11 +61,11 @@ public class TestReportPdfService {
         byte[] pdfBytes = generatePdf(testId, test.getTitle(), authorization);
         String pdfKey = "reports/pdf/" + testId + ".pdf";
         fileStorageService.upload(pdfKey, pdfBytes, "application/pdf");
-        test.savePdfKey(pdfKey);
+        reportExcelExportSupport.savePdfKey(testId, pdfKey);
 
         return new TestReportPdfDownload(
-                fileStorageService.generateDownloadUrl(pdfKey),
-                buildFilename(testId)
+                fileStorageService.generateDownloadUrl(pdfKey, filename),
+                filename
         );
     }
 

--- a/src/main/java/server/MATE/domain/test/entity/Test.java
+++ b/src/main/java/server/MATE/domain/test/entity/Test.java
@@ -68,6 +68,12 @@ public class Test extends BaseEntity {
 
     private LocalDateTime deletedAt;
 
+    @Column
+    private String pdfKey;
+
+    @Column
+    private String excelKey;
+
     @OneToMany(mappedBy = "test", cascade = CascadeType.ALL, orphanRemoval = true)
     @BatchSize(size = 100)
     private List<TestCategory> categories = new ArrayList<>();
@@ -143,6 +149,14 @@ public class Test extends BaseEntity {
 
     public void failReportAggregation() {
         this.reportStatus = ReportStatus.FAILED;
+    }
+
+    public void savePdfKey(String pdfKey) {
+        this.pdfKey = pdfKey;
+    }
+
+    public void saveExcelKey(String excelKey) {
+        this.excelKey = excelKey;
     }
 
     public void delete(LocalDateTime deletedAt) {

--- a/src/main/java/server/MATE/global/storage/AzureBlobFileStorageService.java
+++ b/src/main/java/server/MATE/global/storage/AzureBlobFileStorageService.java
@@ -1,9 +1,12 @@
 package server.MATE.global.storage;
 
+import com.azure.core.util.BinaryData;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobHttpHeaders;
+import com.azure.storage.blob.options.BlobParallelUploadOptions;
 import com.azure.storage.blob.sas.BlobSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
 import jakarta.annotation.PostConstruct;
@@ -66,6 +69,14 @@ public class AzureBlobFileStorageService implements FileStorageService {
     @Override
     public void deleteFiles(List<String> keys) {
         keys.forEach(key -> getContainerClient(key).getBlobClient(key).deleteIfExists());
+    }
+
+    @Override
+    public void upload(String key, byte[] content, String contentType) {
+        BlobClient blobClient = getContainerClient(key).getBlobClient(key);
+        BlobParallelUploadOptions options = new BlobParallelUploadOptions(BinaryData.fromBytes(content))
+                .setHeaders(new BlobHttpHeaders().setContentType(contentType));
+        blobClient.uploadWithResponse(options, null, null);
     }
 
     private BlobContainerClient getContainerClient(String key) {

--- a/src/main/java/server/MATE/global/storage/AzureBlobFileStorageService.java
+++ b/src/main/java/server/MATE/global/storage/AzureBlobFileStorageService.java
@@ -67,6 +67,19 @@ public class AzureBlobFileStorageService implements FileStorageService {
     }
 
     @Override
+    public String generateDownloadUrl(String key, String downloadFilename) {
+        BlobClient blobClient = getContainerClient(key).getBlobClient(key);
+        if (isPublic(key)) {
+            return blobClient.getBlobUrl();
+        }
+        BlobSasPermission permission = new BlobSasPermission().setReadPermission(true);
+        BlobServiceSasSignatureValues values = new BlobServiceSasSignatureValues(
+                OffsetDateTime.now().plusMinutes(properties.getDownloadSasExpiryMinutes()), permission)
+                .setContentDisposition("attachment; filename=\"" + downloadFilename + "\"");
+        return blobClient.getBlobUrl() + "?" + blobClient.generateSas(values);
+    }
+
+    @Override
     public void deleteFiles(List<String> keys) {
         keys.forEach(key -> getContainerClient(key).getBlobClient(key).deleteIfExists());
     }

--- a/src/main/java/server/MATE/global/storage/FileStorageService.java
+++ b/src/main/java/server/MATE/global/storage/FileStorageService.java
@@ -6,4 +6,5 @@ public interface FileStorageService {
     String generatePresignedUrl(String key);
     String generateDownloadUrl(String key);
     void deleteFiles(List<String> keys);
+    void upload(String key, byte[] content, String contentType);
 }

--- a/src/main/java/server/MATE/global/storage/FileStorageService.java
+++ b/src/main/java/server/MATE/global/storage/FileStorageService.java
@@ -5,6 +5,7 @@ import java.util.List;
 public interface FileStorageService {
     String generatePresignedUrl(String key);
     String generateDownloadUrl(String key);
+    String generateDownloadUrl(String key, String downloadFilename);
     void deleteFiles(List<String> keys);
     void upload(String key, byte[] content, String contentType);
 }

--- a/src/main/java/server/MATE/global/storage/NoopFileStorageService.java
+++ b/src/main/java/server/MATE/global/storage/NoopFileStorageService.java
@@ -27,4 +27,9 @@ public class NoopFileStorageService implements FileStorageService {
     public void deleteFiles(List<String> keys) {
         // storage가 비활성화된 환경에서는 삭제 작업을 수행하지 않는다.
     }
+
+    @Override
+    public void upload(String key, byte[] content, String contentType) {
+        // storage가 비활성화된 환경에서는 업로드 작업을 수행하지 않는다.
+    }
 }

--- a/src/main/java/server/MATE/global/storage/NoopFileStorageService.java
+++ b/src/main/java/server/MATE/global/storage/NoopFileStorageService.java
@@ -24,6 +24,11 @@ public class NoopFileStorageService implements FileStorageService {
     }
 
     @Override
+    public String generateDownloadUrl(String key, String downloadFilename) {
+        return key;
+    }
+
+    @Override
     public void deleteFiles(List<String> keys) {
         // storage가 비활성화된 환경에서는 삭제 작업을 수행하지 않는다.
     }

--- a/src/test/java/server/MATE/domain/report/service/excel/CombinedTestReportExcelServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/excel/CombinedTestReportExcelServiceTest.java
@@ -11,7 +11,6 @@ import server.MATE.domain.question.dto.response.QuestionSummaryItem;
 import server.MATE.domain.question.entity.FiveSecond;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
-import server.MATE.domain.report.dto.response.TestReportExcelDownload;
 import server.MATE.domain.report.excel.abtest.AbTestReportExcelWriter;
 import server.MATE.domain.report.excel.fivesecond.FiveSecondObjectiveReportExcelData;
 import server.MATE.domain.report.excel.fivesecond.FiveSecondObjectiveReportExcelWriter;
@@ -108,12 +107,11 @@ class CombinedTestReportExcelServiceTest {
         stubObjectiveData(context);
         stubFiveSecondObjectiveData(context);
 
-        TestReportExcelDownload download = combinedTestReportExcelService.export(TEST_ID, MAKER_ID);
+        byte[] excelBytes = combinedTestReportExcelService.export(TEST_ID, MAKER_ID);
 
-        assertThat(download.filename()).isEqualTo("mate-report-10.xlsx");
-        assertThat(download.content()).isNotEmpty();
+        assertThat(excelBytes).isNotEmpty();
 
-        try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(download.content()))) {
+        try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(excelBytes))) {
             assertThat(workbook.getNumberOfSheets()).isEqualTo(9);
             assertThat(workbook.getSheetName(0)).isEqualTo(CombinedTestReportExcelService.SHEET_BASIC_INFO);
             assertThat(workbook.getSheetName(8)).isEqualTo(CombinedTestReportExcelService.SHEET_FIVE_SECOND);

--- a/src/test/java/server/MATE/domain/report/service/excel/TestReportExcelServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/excel/TestReportExcelServiceTest.java
@@ -1,34 +1,98 @@
 package server.MATE.domain.report.service.excel;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import server.MATE.domain.report.dto.response.TestReportExcelDownload;
+import server.MATE.domain.report.service.excel.support.ReportExcelExportSupport;
+import server.MATE.domain.test.entity.ReportStatus;
+import server.MATE.domain.test.entity.TestStatus;
+import server.MATE.global.storage.FileStorageService;
+
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class TestReportExcelServiceTest {
 
+    private static final Long TEST_ID = 10L;
+    private static final Long MAKER_ID = 1L;
+
     @Mock
     private CombinedTestReportExcelService combinedTestReportExcelService;
+    @Mock
+    private ReportExcelExportSupport reportExcelExportSupport;
+    @Mock
+    private FileStorageService fileStorageService;
 
-    @InjectMocks
     private TestReportExcelService testReportExcelService;
 
-    @Test
-    void 통합_엑셀_다운로드를_위임한다() {
-        TestReportExcelDownload download = new TestReportExcelDownload(new byte[]{1, 2, 3}, "mate-report-10.xlsx");
-        given(combinedTestReportExcelService.export(10L, 1L)).willReturn(download);
+    @BeforeEach
+    void setUp() {
+        testReportExcelService = new TestReportExcelService(
+                combinedTestReportExcelService,
+                reportExcelExportSupport,
+                fileStorageService
+        );
+    }
 
-        TestReportExcelDownload result = testReportExcelService.export(10L, 1L);
+    @org.junit.jupiter.api.Test
+    void excelKey가_없으면_생성_후_업로드하고_URL을_반환한다() {
+        server.MATE.domain.test.entity.Test test = completedTest(null);
+        given(reportExcelExportSupport.requireExportReadyTest(TEST_ID, MAKER_ID)).willReturn(test);
+        given(combinedTestReportExcelService.export(TEST_ID, MAKER_ID)).willReturn(new byte[]{1, 2, 3});
+        given(fileStorageService.generateDownloadUrl("reports/excel/" + TEST_ID + ".xlsx"))
+                .willReturn("https://blob.example.com/reports/excel/" + TEST_ID + ".xlsx");
 
-        assertThat(result.filename()).isEqualTo("mate-report-10.xlsx");
-        assertThat(result.content()).containsExactly(1, 2, 3);
-        verify(combinedTestReportExcelService).export(10L, 1L);
+        TestReportExcelDownload result = testReportExcelService.export(TEST_ID, MAKER_ID);
+
+        assertThat(result.downloadUrl()).isEqualTo("https://blob.example.com/reports/excel/" + TEST_ID + ".xlsx");
+        assertThat(result.filename()).isEqualTo("mate-report-" + TEST_ID + ".xlsx");
+        verify(fileStorageService).upload(
+                eq("reports/excel/" + TEST_ID + ".xlsx"),
+                eq(new byte[]{1, 2, 3}),
+                eq("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+        );
+    }
+
+    @org.junit.jupiter.api.Test
+    void excelKey가_있으면_재생성_없이_캐싱된_URL을_반환한다() {
+        server.MATE.domain.test.entity.Test test = completedTest("reports/excel/" + TEST_ID + ".xlsx");
+        given(reportExcelExportSupport.requireExportReadyTest(TEST_ID, MAKER_ID)).willReturn(test);
+        given(fileStorageService.generateDownloadUrl("reports/excel/" + TEST_ID + ".xlsx"))
+                .willReturn("https://blob.example.com/cached.xlsx");
+
+        TestReportExcelDownload result = testReportExcelService.export(TEST_ID, MAKER_ID);
+
+        assertThat(result.downloadUrl()).isEqualTo("https://blob.example.com/cached.xlsx");
+        assertThat(result.filename()).isEqualTo("mate-report-" + TEST_ID + ".xlsx");
+        verify(combinedTestReportExcelService, never()).export(any(), any());
+        verify(fileStorageService, never()).upload(any(), any(byte[].class), any());
+    }
+
+    private server.MATE.domain.test.entity.Test completedTest(String excelKey) {
+        server.MATE.domain.test.entity.Test test = server.MATE.domain.test.entity.Test.builder()
+                .makerId(MAKER_ID)
+                .title("테스트")
+                .description("설명")
+                .goalPpl(10)
+                .testStatus(TestStatus.COMPLETED)
+                .closedAt(LocalDateTime.of(2026, 6, 1, 23, 59, 59))
+                .build();
+        ReflectionTestUtils.setField(test, "id", TEST_ID);
+        ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.COMPLETED);
+        if (excelKey != null) {
+            test.saveExcelKey(excelKey);
+        }
+        return test;
     }
 }

--- a/src/test/java/server/MATE/domain/report/service/excel/TestReportExcelServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/excel/TestReportExcelServiceTest.java
@@ -48,33 +48,36 @@ class TestReportExcelServiceTest {
     @org.junit.jupiter.api.Test
     void excelKey가_없으면_생성_후_업로드하고_URL을_반환한다() {
         server.MATE.domain.test.entity.Test test = completedTest(null);
+        String filename = "mate-report-" + TEST_ID + ".xlsx";
         given(reportExcelExportSupport.requireExportReadyTest(TEST_ID, MAKER_ID)).willReturn(test);
         given(combinedTestReportExcelService.export(TEST_ID, MAKER_ID)).willReturn(new byte[]{1, 2, 3});
-        given(fileStorageService.generateDownloadUrl("reports/excel/" + TEST_ID + ".xlsx"))
+        given(fileStorageService.generateDownloadUrl("reports/excel/" + TEST_ID + ".xlsx", filename))
                 .willReturn("https://blob.example.com/reports/excel/" + TEST_ID + ".xlsx");
 
         TestReportExcelDownload result = testReportExcelService.export(TEST_ID, MAKER_ID);
 
         assertThat(result.downloadUrl()).isEqualTo("https://blob.example.com/reports/excel/" + TEST_ID + ".xlsx");
-        assertThat(result.filename()).isEqualTo("mate-report-" + TEST_ID + ".xlsx");
+        assertThat(result.filename()).isEqualTo(filename);
         verify(fileStorageService).upload(
                 eq("reports/excel/" + TEST_ID + ".xlsx"),
                 eq(new byte[]{1, 2, 3}),
                 eq("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
         );
+        verify(reportExcelExportSupport).saveExcelKey(TEST_ID, "reports/excel/" + TEST_ID + ".xlsx");
     }
 
     @org.junit.jupiter.api.Test
     void excelKey가_있으면_재생성_없이_캐싱된_URL을_반환한다() {
         server.MATE.domain.test.entity.Test test = completedTest("reports/excel/" + TEST_ID + ".xlsx");
+        String filename = "mate-report-" + TEST_ID + ".xlsx";
         given(reportExcelExportSupport.requireExportReadyTest(TEST_ID, MAKER_ID)).willReturn(test);
-        given(fileStorageService.generateDownloadUrl("reports/excel/" + TEST_ID + ".xlsx"))
+        given(fileStorageService.generateDownloadUrl("reports/excel/" + TEST_ID + ".xlsx", filename))
                 .willReturn("https://blob.example.com/cached.xlsx");
 
         TestReportExcelDownload result = testReportExcelService.export(TEST_ID, MAKER_ID);
 
         assertThat(result.downloadUrl()).isEqualTo("https://blob.example.com/cached.xlsx");
-        assertThat(result.filename()).isEqualTo("mate-report-" + TEST_ID + ".xlsx");
+        assertThat(result.filename()).isEqualTo(filename);
         verify(combinedTestReportExcelService, never()).export(any(), any());
         verify(fileStorageService, never()).upload(any(), any(byte[].class), any());
     }


### PR DESCRIPTION
  ## 📍 요약
  PDF/엑셀 리포트를 요청마다 재생성하던 문제를 수정하고, 파일 다운로드 응답을 byte[] 스트리밍에서 Blob download URL 반환으로 변경합니다.
  
  ## 🔗 관련 이슈 
  - Closes #199
  
  ## 📌 변경 사항 (기능)
  - `FileStorageService`에 `upload(key, bytes, contentType)` 추가
  - `test` 테이블에 `pdf_key`, `excel_key` 컬럼 추가
  - PDF/엑셀 최초 생성 시 Azure Blob에 저장, 이후 요청은 저장된 파일의 URL 반환
  - PDF/엑셀 엔드포인트 응답 `byte[]` → `ApiResponse<String>` (download URL)
  
  ## ✅ 작업 내용
  - `TestReportPdfService` — `@Transactional` 추가, 캐싱 로직 및 `generatePdf()` 분리
  - `TestReportExcelService` — `@Transactional` 추가, 캐싱 로직 추가
  - `CombinedTestReportExcelService` — 리턴 타입 `byte[]`로 단순화
  - `ReportController` — 두 엔드포인트 URL 반환으로 변경
  
  ## 테스트
  - 로컬 테스트 완료
  - `TestReportExcelServiceTest` 캐시 히트/미스 케이스 추가
  - `CombinedTestReportExcelServiceTest` 변경된 리턴 타입 반영