### PR TITLE
feat: 테스트 삭제 API 구현

### DIFF
--- a/src/main/java/server/MATE/domain/answer/entity/Answer.java
+++ b/src/main/java/server/MATE/domain/answer/entity/Answer.java
@@ -46,4 +46,8 @@ public class Answer extends BaseEntity {
         this.questionType = questionType;
         this.answer = answer;
     }
+
+    public void delete(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
 }

--- a/src/main/java/server/MATE/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/server/MATE/domain/answer/repository/AnswerRepository.java
@@ -1,8 +1,12 @@
 package server.MATE.domain.answer.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import server.MATE.domain.answer.entity.Answer;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
@@ -10,4 +14,22 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
     List<Answer> findAllByQuestionIdInAndDeletedAtIsNull(List<Long> questionIds);
 
     List<Answer> findAllByQuestionIdAndDeletedAtIsNullOrderByParticipationIdAsc(Long questionId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update Answer a
+            set a.deletedAt = :deletedAt
+            where a.questionId in :questionIds
+              and a.deletedAt is null
+            """)
+    int softDeleteAllByQuestionIds(@Param("questionIds") List<Long> questionIds,
+                                   @Param("deletedAt") LocalDateTime deletedAt);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete
+            from Answer a
+            where a.questionId in :questionIds
+            """)
+    int deleteAllByQuestionIds(@Param("questionIds") List<Long> questionIds);
 }

--- a/src/main/java/server/MATE/domain/participation/entity/Participation.java
+++ b/src/main/java/server/MATE/domain/participation/entity/Participation.java
@@ -36,4 +36,8 @@ public class Participation extends BaseEntity {
         this.testerId = testerId;
     }
 
+    public void delete(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+
 }

--- a/src/main/java/server/MATE/domain/participation/repository/ParticipationRepository.java
+++ b/src/main/java/server/MATE/domain/participation/repository/ParticipationRepository.java
@@ -1,17 +1,21 @@
 package server.MATE.domain.participation.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import server.MATE.domain.answer.dto.response.MyAnswerItemView;
 import server.MATE.domain.participation.entity.Participation;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
 
     boolean existsByTestIdAndTesterIdAndDeletedAtIsNull(Long testId, Long testerId);
+
+    List<Participation> findAllByTestIdAndDeletedAtIsNull(Long testId);
 
     @Query("""
             select new server.MATE.domain.answer.dto.response.MyAnswerItemView(
@@ -28,4 +32,21 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
             order by p.createdAt desc
             """)
     List<MyAnswerItemView> findMyAnswerItemsByTesterIdOrderByCreatedAtDesc(@Param("testerId") Long testerId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update Participation p
+            set p.deletedAt = :deletedAt
+            where p.testId = :testId
+              and p.deletedAt is null
+            """)
+    int softDeleteAllByTestId(@Param("testId") Long testId, @Param("deletedAt") LocalDateTime deletedAt);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete
+            from Participation p
+            where p.testId = :testId
+            """)
+    int deleteAllByTestId(@Param("testId") Long testId);
 }

--- a/src/main/java/server/MATE/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/server/MATE/domain/payment/repository/PaymentRepository.java
@@ -2,6 +2,7 @@ package server.MATE.domain.payment.repository;
 
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param;
@@ -24,4 +25,12 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
             where p.id = :id
             """)
     Optional<Payment> findByIdForUpdate(@Param("id") Long id);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete
+            from Payment p
+            where p.testId = :testId
+            """)
+    int deleteAllByTestId(@Param("testId") Long testId);
 }

--- a/src/main/java/server/MATE/domain/promotion/repository/PromotionRewardRepository.java
+++ b/src/main/java/server/MATE/domain/promotion/repository/PromotionRewardRepository.java
@@ -3,6 +3,7 @@ package server.MATE.domain.promotion.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import server.MATE.domain.promotion.entity.PromotionReward;
@@ -20,4 +21,12 @@ public interface PromotionRewardRepository extends JpaRepository<PromotionReward
             """)
     Long sumRewardAmountByTesterIdAndStatus(@Param("testerId") Long testerId,
                                             @Param("status") PromotionRewardStatus status);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete
+            from PromotionReward pr
+            where pr.testId = :testId
+            """)
+    int deleteAllByTestId(@Param("testId") Long testId);
 }

--- a/src/main/java/server/MATE/domain/question/entity/Question.java
+++ b/src/main/java/server/MATE/domain/question/entity/Question.java
@@ -49,4 +49,8 @@ public class Question extends BaseEntity {
         this.sequence = sequence == null ? 0L : sequence;
     }
 
+    public void delete(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+
 }

--- a/src/main/java/server/MATE/domain/question/repository/AbTestRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/AbTestRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface AbTestRepository extends JpaRepository<AbTest, Long> {
 
     List<AbTest> findAllByIdIn(Iterable<Long> ids);
+
+    List<AbTest> findAllByQuestion_IdIn(Iterable<Long> questionIds);
 }

--- a/src/main/java/server/MATE/domain/question/repository/CardSortingRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/CardSortingRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface CardSortingRepository extends JpaRepository<CardSorting, Long> {
 
     List<CardSorting> findAllByIdIn(Iterable<Long> ids);
+
+    List<CardSorting> findAllByQuestion_IdIn(Iterable<Long> questionIds);
 }

--- a/src/main/java/server/MATE/domain/question/repository/FiveSecondOptionRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/FiveSecondOptionRepository.java
@@ -1,0 +1,20 @@
+package server.MATE.domain.question.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import server.MATE.domain.question.entity.FiveSecondOption;
+
+import java.util.List;
+
+public interface FiveSecondOptionRepository extends JpaRepository<FiveSecondOption, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete
+            from FiveSecondOption fo
+            where fo.fiveSecond.id in :fiveSecondIds
+            """)
+    int deleteAllByFiveSecondIds(@Param("fiveSecondIds") List<Long> fiveSecondIds);
+}

--- a/src/main/java/server/MATE/domain/question/repository/FiveSecondRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/FiveSecondRepository.java
@@ -17,4 +17,7 @@ public interface FiveSecondRepository extends JpaRepository<FiveSecond, Long> {
     @EntityGraph(attributePaths = "options")
     @Query("SELECT f FROM FiveSecond f WHERE f.id = :id")
     Optional<FiveSecond> findWithOptionsById(@Param("id") Long id);
+
+    @EntityGraph(attributePaths = "options")
+    List<FiveSecond> findAllByQuestion_IdIn(Iterable<Long> questionIds);
 }

--- a/src/main/java/server/MATE/domain/question/repository/ObjectiveOptionRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/ObjectiveOptionRepository.java
@@ -1,0 +1,20 @@
+package server.MATE.domain.question.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import server.MATE.domain.question.entity.ObjectiveOption;
+
+import java.util.List;
+
+public interface ObjectiveOptionRepository extends JpaRepository<ObjectiveOption, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete
+            from ObjectiveOption oo
+            where oo.objective.id in :objectiveIds
+            """)
+    int deleteAllByObjectiveIds(@Param("objectiveIds") List<Long> objectiveIds);
+}

--- a/src/main/java/server/MATE/domain/question/repository/ObjectiveRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/ObjectiveRepository.java
@@ -17,4 +17,7 @@ public interface ObjectiveRepository extends JpaRepository<Objective, Long> {
     @EntityGraph(attributePaths = "options")
     @Query("SELECT o FROM Objective o WHERE o.id = :id")
     Optional<Objective> findWithOptionsById(@Param("id") Long id);
+
+    @EntityGraph(attributePaths = "options")
+    List<Objective> findAllByQuestion_IdIn(Iterable<Long> questionIds);
 }

--- a/src/main/java/server/MATE/domain/question/repository/QuestionQueryRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/QuestionQueryRepository.java
@@ -4,6 +4,7 @@ import server.MATE.domain.question.dto.response.AnswerQuestionTypeView;
 import server.MATE.domain.question.dto.response.QuestionSummaryItem;
 import server.MATE.domain.question.entity.Question;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,7 +16,11 @@ public interface QuestionQueryRepository {
 
     List<Question> findQuestionsInTest(Long testId);
 
+    List<Question> findQuestionsInTestIncludingDeleted(Long testId);
+
     List<AnswerQuestionTypeView> findAnswerQuestionTypesInTest(Long testId);
 
     List<QuestionSummaryItem> findQuestionSummariesInTest(Long testId);
+
+    long softDeleteByTestId(Long testId, LocalDateTime deletedAt);
 }

--- a/src/main/java/server/MATE/domain/question/repository/QuestionQueryRepositoryImpl.java
+++ b/src/main/java/server/MATE/domain/question/repository/QuestionQueryRepositoryImpl.java
@@ -11,6 +11,7 @@ import server.MATE.domain.question.entity.Question;
 
 import java.util.List;
 import java.util.Optional;
+import java.time.LocalDateTime;
 
 import static server.MATE.domain.question.entity.QQuestion.question;
 
@@ -78,6 +79,19 @@ public class QuestionQueryRepositoryImpl implements QuestionQueryRepository {
     }
 
     @Override
+    public List<Question> findQuestionsInTestIncludingDeleted(Long testId) {
+        if (testId == null) {
+            return List.of();
+        }
+
+        return queryFactory
+                .selectFrom(question)
+                .where(testIdEq(testId))
+                .orderBy(question.sequence.asc())
+                .fetch();
+    }
+
+    @Override
     public List<AnswerQuestionTypeView> findAnswerQuestionTypesInTest(Long testId) {
         if (testId == null) {
             return List.of();
@@ -112,5 +126,18 @@ public class QuestionQueryRepositoryImpl implements QuestionQueryRepository {
                 .where(testIdEq(testId), notDeleted())
                 .orderBy(question.sequence.asc())
                 .fetch();
+    }
+
+    @Override
+    public long softDeleteByTestId(Long testId, LocalDateTime deletedAt) {
+        if (testId == null || deletedAt == null) {
+            return 0L;
+        }
+
+        return queryFactory
+                .update(question)
+                .set(question.deletedAt, deletedAt)
+                .where(testIdEq(testId), notDeleted())
+                .execute();
     }
 }

--- a/src/main/java/server/MATE/domain/question/repository/ScaleRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/ScaleRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface ScaleRepository extends JpaRepository<Scale, Long> {
 
     List<Scale> findAllByIdIn(Iterable<Long> ids);
+
+    List<Scale> findAllByQuestion_IdIn(Iterable<Long> questionIds);
 }

--- a/src/main/java/server/MATE/domain/question/repository/SubjectiveRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/SubjectiveRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface SubjectiveRepository extends JpaRepository<Subjective, Long> {
 
     List<Subjective> findAllByIdIn(Iterable<Long> ids);
+
+    List<Subjective> findAllByQuestion_IdIn(Iterable<Long> questionIds);
 }

--- a/src/main/java/server/MATE/domain/question/repository/TreeTestRepository.java
+++ b/src/main/java/server/MATE/domain/question/repository/TreeTestRepository.java
@@ -1,7 +1,9 @@
 package server.MATE.domain.question.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import server.MATE.domain.question.entity.TreeTest;
 
 import java.util.List;
@@ -22,4 +24,12 @@ public interface TreeTestRepository extends JpaRepository<TreeTest, Long> {
             order by node.question.id asc, node.depth asc, node.sequence asc, node.id asc
             """)
     List<TreeTest> findAllByQuestionIdInOrderByQuestionAndTree(List<Long> questionIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete
+            from TreeTest node
+            where node.id = :id
+            """)
+    int deleteDirectById(@Param("id") Long id);
 }

--- a/src/main/java/server/MATE/domain/report/entity/Report.java
+++ b/src/main/java/server/MATE/domain/report/entity/Report.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import server.MATE.domain.question.entity.QuestionType;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 import server.MATE.global.common.entity.BaseEntity;
 
@@ -37,11 +38,17 @@ public class Report extends BaseEntity {
     @Column(nullable = false, columnDefinition = "jsonb")
     private Map<String, Object> result;
 
+    private LocalDateTime deletedAt;
+
     @Builder
     public Report(Long testId, Long questionId, QuestionType questionType, Map<String, Object> result) {
         this.testId = testId;
         this.questionId = questionId;
         this.questionType = questionType;
         this.result = result;
+    }
+
+    public void delete(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
     }
 }

--- a/src/main/java/server/MATE/domain/report/repository/ReportRepository.java
+++ b/src/main/java/server/MATE/domain/report/repository/ReportRepository.java
@@ -1,18 +1,64 @@
 package server.MATE.domain.report.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import server.MATE.domain.report.entity.Report;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
-    List<Report> findAllByTestId(Long testId);
+    @Query("""
+            select r
+            from Report r
+            where r.testId = :testId
+              and r.deletedAt is null
+            """)
+    List<Report> findAllByTestId(@Param("testId") Long testId);
 
-    Optional<Report> findByTestIdAndQuestionId(Long testId, Long questionId);
+    @Query("""
+            select r
+            from Report r
+            where r.testId = :testId
+              and r.questionId = :questionId
+              and r.deletedAt is null
+            """)
+    Optional<Report> findByTestIdAndQuestionId(@Param("testId") Long testId, @Param("questionId") Long questionId);
 
-    boolean existsByTestId(Long testId);
+    @Query("""
+            select (count(r) > 0)
+            from Report r
+            where r.testId = :testId
+              and r.deletedAt is null
+            """)
+    boolean existsByTestId(@Param("testId") Long testId);
 
-    long countByTestId(Long testId);
+    @Query("""
+            select count(r)
+            from Report r
+            where r.testId = :testId
+              and r.deletedAt is null
+            """)
+    long countByTestId(@Param("testId") Long testId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update Report r
+            set r.deletedAt = :deletedAt
+            where r.testId = :testId
+              and r.deletedAt is null
+            """)
+    int softDeleteAllByTestId(@Param("testId") Long testId, @Param("deletedAt") LocalDateTime deletedAt);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete
+            from Report r
+            where r.testId = :testId
+            """)
+    int deleteAllByTestId(@Param("testId") Long testId);
 }

--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -1,6 +1,7 @@
 package server.MATE.domain.test.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import server.MATE.domain.test.dto.request.TestDeleteMode;
 import server.MATE.domain.test.dto.response.LikedTestSummaryResponse;
 import server.MATE.domain.test.dto.response.MyTestSummaryResponse;
 import server.MATE.domain.test.dto.response.TestDetailResponse;
@@ -16,6 +18,7 @@ import server.MATE.domain.test.dto.request.TestStatusUpdateRequest;
 import server.MATE.domain.test.dto.response.TestStatusUpdateResponse;
 import server.MATE.domain.test.dto.response.TestSummaryListResponse;
 import server.MATE.domain.test.dto.response.TestSummaryResponse;
+import server.MATE.domain.test.service.TestDeleteService;
 import server.MATE.domain.test.service.TestService;
 import server.MATE.global.common.response.ApiResponse;
 import server.MATE.global.security.principal.AuthenticatedUser;
@@ -28,6 +31,7 @@ import server.MATE.global.security.principal.AuthenticatedUser;
 public class TestController {
 
     private final TestService testService;
+    private final TestDeleteService testDeleteService;
 
     @Operation(
             summary = "✔️ 테스트 목록 조회",
@@ -153,5 +157,39 @@ public class TestController {
     ) {
         TestLikeResponse response = testService.unlikeTest(testId, authenticatedUser.getId());
         return ResponseEntity.ok(ApiResponse.ok("테스트 찜을 취소했습니다.", response));
+    }
+
+    @Operation(
+            summary = "🔐️ 테스트 삭제",
+            description = """
+                    테스트를 soft 삭제 또는 hard 삭제합니다. 해당 api는 관리자 계정으로만 요청 가능합니다.
+                    - `mode=SOFT`: 테스트와 연관된 엔티티를 논리 삭제합니다.
+                      - soft delete 대상: `test`, `question`, `answer`, `participation`, `report`
+                      - 유지 대상: `test_like`, `payment`, `promotion_reward`, `test_category`
+                    
+                    - `mode=HARD`: 테스트와 연관된 엔티티를 모두 영구 삭제합니다. **요청 시, X-MATE-Hard-Delete-Key 헤더에 비밀키를 입력해주세요.**
+                      - hard delete 대상: `test`, `question`, `answer`, `participation`, `report`,
+                          `test_like`, `test_category`, `payment`, `promotion_reward`,
+                          `objective`, `objective_option`, `subjective`, `ab_test`, `scale`, `card_sorting`,
+                          `five_second`, `five_second_option`, `tree_test`
+                      - 또한, 테스트/질문에 사용된 이미지 파일도 blob storage에서 함께 영구 삭제됩니다.
+                    """
+
+    )
+    @DeleteMapping("/{testId}")
+    public ResponseEntity<ApiResponse<Void>> deleteTest(
+            @PathVariable Long testId,
+            @RequestParam TestDeleteMode mode,
+            @Parameter(description = "하드 삭제 검증 키. mode=HARD 일 때 필수입니다.")
+            @RequestHeader(value = "X-MATE-Hard-Delete-Key", required = false) String hardDeleteKey,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        testDeleteService.deleteTest(
+                testId,
+                authenticatedUser.getRole(),
+                mode,
+                hardDeleteKey
+        );
+        return ResponseEntity.ok(ApiResponse.ok("테스트를 삭제했습니다.", null));
     }
 }

--- a/src/main/java/server/MATE/domain/test/dto/request/TestDeleteMode.java
+++ b/src/main/java/server/MATE/domain/test/dto/request/TestDeleteMode.java
@@ -1,0 +1,6 @@
+package server.MATE.domain.test.dto.request;
+
+public enum TestDeleteMode {
+    SOFT,
+    HARD
+}

--- a/src/main/java/server/MATE/domain/test/entity/TestCategory.java
+++ b/src/main/java/server/MATE/domain/test/entity/TestCategory.java
@@ -32,4 +32,8 @@ public class TestCategory {
         this.test = test;
         this.category = category;
     }
+
+    public void delete(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
 }

--- a/src/main/java/server/MATE/domain/test/repository/TestCategoryRepository.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestCategoryRepository.java
@@ -1,0 +1,29 @@
+package server.MATE.domain.test.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import server.MATE.domain.test.entity.TestCategory;
+
+import java.time.LocalDateTime;
+
+public interface TestCategoryRepository extends JpaRepository<TestCategory, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update TestCategory tc
+            set tc.deletedAt = :deletedAt
+            where tc.test.id = :testId
+              and tc.deletedAt is null
+            """)
+    int softDeleteAllByTestId(@Param("testId") Long testId, @Param("deletedAt") LocalDateTime deletedAt);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete
+            from TestCategory tc
+            where tc.test.id = :testId
+            """)
+    int deleteAllByTestId(@Param("testId") Long testId);
+}

--- a/src/main/java/server/MATE/domain/test/repository/TestLikeRepository.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestLikeRepository.java
@@ -1,6 +1,7 @@
 package server.MATE.domain.test.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import server.MATE.domain.test.entity.TestLike;
@@ -22,4 +23,12 @@ public interface TestLikeRepository extends JpaRepository<TestLike, Long> {
               and tl.testId in :testIds
             """)
     List<Long> findLikedTestIds(@Param("userId") Long userId, @Param("testIds") Collection<Long> testIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete
+            from TestLike tl
+            where tl.testId = :testId
+            """)
+    int deleteAllByTestId(@Param("testId") Long testId);
 }

--- a/src/main/java/server/MATE/domain/test/repository/TestQueryRepository.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestQueryRepository.java
@@ -17,6 +17,10 @@ public interface TestQueryRepository {
 
     Optional<Test> findActiveById(Long id);
 
+    Optional<Test> findByIdIncludingDeleted(Long id);
+
+    long softDeleteById(Long id, LocalDateTime deletedAt);
+
     Optional<Test> findWithCategoriesById(Long id);
 
     Optional<Test> findByIdForUpdate(Long id);

--- a/src/main/java/server/MATE/domain/test/repository/TestQueryRepositoryImpl.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestQueryRepositoryImpl.java
@@ -130,6 +130,33 @@ public class TestQueryRepositoryImpl implements TestQueryRepository {
     }
 
     @Override
+    public Optional<Test> findByIdIncludingDeleted(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(test)
+                        .where(idEq(id))
+                        .fetchOne()
+        );
+    }
+
+    @Override
+    public long softDeleteById(Long id, LocalDateTime deletedAt) {
+        if (id == null || deletedAt == null) {
+            return 0L;
+        }
+
+        return queryFactory
+                .update(test)
+                .set(test.deletedAt, deletedAt)
+                .where(idEq(id), notDeleted())
+                .execute();
+    }
+
+    @Override
     public Optional<Test> findWithCategoriesById(Long id) {
         if (id == null) {
             return Optional.empty();

--- a/src/main/java/server/MATE/domain/test/service/TestDeleteService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestDeleteService.java
@@ -1,0 +1,278 @@
+package server.MATE.domain.test.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.answer.repository.AnswerRepository;
+import server.MATE.domain.participation.repository.ParticipationRepository;
+import server.MATE.domain.payment.repository.PaymentRepository;
+import server.MATE.domain.promotion.repository.PromotionRewardRepository;
+import server.MATE.domain.question.entity.*;
+import server.MATE.domain.question.repository.*;
+import server.MATE.domain.report.repository.ReportRepository;
+import server.MATE.domain.test.dto.request.TestDeleteMode;
+import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.repository.TestCategoryRepository;
+import server.MATE.domain.test.repository.TestLikeRepository;
+import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.domain.users.entity.Role;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+import server.MATE.global.security.config.AdminProperties;
+import server.MATE.global.storage.event.FileDeleteEvent;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TestDeleteService {
+
+    private final TestRepository testRepository;
+    private final AnswerRepository answerRepository;
+    private final QuestionRepository questionRepository;
+    private final ParticipationRepository participationRepository;
+    private final ReportRepository reportRepository;
+    private final PaymentRepository paymentRepository;
+    private final PromotionRewardRepository promotionRewardRepository;
+    private final TestCategoryRepository testCategoryRepository;
+    private final TestLikeRepository testLikeRepository;
+    private final ObjectiveRepository objectiveRepository;
+    private final ObjectiveOptionRepository objectiveOptionRepository;
+    private final SubjectiveRepository subjectiveRepository;
+    private final AbTestRepository abTestRepository;
+    private final ScaleRepository scaleRepository;
+    private final CardSortingRepository cardSortingRepository;
+    private final FiveSecondRepository fiveSecondRepository;
+    private final FiveSecondOptionRepository fiveSecondOptionRepository;
+    private final TreeTestRepository treeTestRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final AdminProperties adminProperties;
+    private final Clock clock;
+
+    public void deleteTest(Long testId, Role role, TestDeleteMode mode, String hardDeleteKey) {
+        validateAdmin(role);
+
+        if (mode == TestDeleteMode.HARD) {
+            Test test = testRepository.findByIdIncludingDeleted(testId)
+                    .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+            validateHardDeleteKey(hardDeleteKey);
+            hardDeleteTest(test);
+            return;
+        }
+
+        if (mode == TestDeleteMode.SOFT) {
+            testRepository.findActiveById(testId)
+                    .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+            softDeleteTest(testId);
+            return;
+        }
+
+        throw new BaseException(BaseErrorCode.COMMON_002);
+    }
+
+    private void softDeleteTest(Long testId) {
+        LocalDateTime deletedAt = LocalDateTime.now(clock);
+        List<Question> questions = questionRepository.findQuestionsInTest(testId);
+        List<Long> questionIds = questions.stream()
+                .map(Question::getId)
+                .toList();
+
+        reportRepository.softDeleteAllByTestId(testId, deletedAt);
+        if (!questionIds.isEmpty()) {
+            answerRepository.softDeleteAllByQuestionIds(questionIds, deletedAt);
+        }
+        participationRepository.softDeleteAllByTestId(testId, deletedAt);
+        questionRepository.softDeleteByTestId(testId, deletedAt);
+        testRepository.softDeleteById(testId, deletedAt);
+    }
+
+    private void hardDeleteTest(Test test) {
+        List<Question> questions = questionRepository.findQuestionsInTestIncludingDeleted(test.getId());
+        List<Long> questionIds = questions.stream()
+                .map(Question::getId)
+                .toList();
+
+        List<String> fileKeys = new ArrayList<>(test.getImageKeys());
+
+        promotionRewardRepository.deleteAllByTestId(test.getId());
+        if (!questionIds.isEmpty()) {
+            answerRepository.deleteAllByQuestionIds(questionIds);
+        }
+        reportRepository.deleteAllByTestId(test.getId());
+        testLikeRepository.deleteAllByTestId(test.getId());
+
+        deleteQuestionDetails(questions, fileKeys);
+
+        if (!questions.isEmpty()) {
+            questionRepository.deleteAllInBatch(questions);
+        }
+        testCategoryRepository.deleteAllByTestId(test.getId());
+        participationRepository.deleteAllByTestId(test.getId());
+        paymentRepository.deleteAllByTestId(test.getId());
+        testRepository.delete(test);
+
+        publishFileDeleteEvent(fileKeys);
+    }
+
+    private void deleteQuestionDetails(List<Question> questions, List<String> fileKeys) {
+        Map<QuestionType, List<Long>> questionIdsByType = questions.stream()
+                .collect(HashMap::new,
+                        (map, question) -> map.computeIfAbsent(question.getQuestionType(), key -> new ArrayList<>()).add(question.getId()),
+                        HashMap::putAll);
+
+        deleteObjectives(questionIdsByType.get(QuestionType.OBJECTIVE), fileKeys);
+        deleteSubjectives(questionIdsByType.get(QuestionType.SUBJECTIVE), fileKeys);
+        deleteAbTests(questionIdsByType.get(QuestionType.AB_TEST), fileKeys);
+        deleteScales(questionIdsByType.get(QuestionType.SCALE), fileKeys);
+        deleteCardSortings(questionIdsByType.get(QuestionType.CARD_SORTING));
+        deleteFiveSeconds(questionIdsByType.get(QuestionType.FIVE_SECOND), fileKeys);
+        deleteTreeTests(questionIdsByType.get(QuestionType.TREE_TEST));
+    }
+
+    private void deleteObjectives(List<Long> questionIds, List<String> fileKeys) {
+        if (questionIds == null || questionIds.isEmpty()) {
+            return;
+        }
+
+        List<Objective> objectives = objectiveRepository.findAllByQuestion_IdIn(questionIds);
+        if (objectives.isEmpty()) {
+            return;
+        }
+
+        objectives.stream()
+                .flatMap(objective -> objective.getOptions().stream())
+                .map(ObjectiveOption::getImageKey)
+                .forEach(fileKeys::add);
+
+        List<Long> objectiveIds = objectives.stream()
+                .map(Objective::getId)
+                .toList();
+
+        objectiveOptionRepository.deleteAllByObjectiveIds(objectiveIds);
+        objectiveRepository.deleteAllInBatch(objectives);
+    }
+
+    private void deleteSubjectives(List<Long> questionIds, List<String> fileKeys) {
+        if (questionIds == null || questionIds.isEmpty()) {
+            return;
+        }
+
+        List<Subjective> subjectives = subjectiveRepository.findAllByQuestion_IdIn(questionIds);
+        subjectives.stream()
+                .map(Subjective::getImageKey)
+                .forEach(fileKeys::add);
+
+        if (!subjectives.isEmpty()) {
+            subjectiveRepository.deleteAllInBatch(subjectives);
+        }
+    }
+
+    private void deleteAbTests(List<Long> questionIds, List<String> fileKeys) {
+        if (questionIds == null || questionIds.isEmpty()) {
+            return;
+        }
+
+        List<AbTest> abTests = abTestRepository.findAllByQuestion_IdIn(questionIds);
+        abTests.forEach(abTest -> {
+            fileKeys.add(abTest.getAImageKey());
+            fileKeys.add(abTest.getBImageKey());
+        });
+
+        if (!abTests.isEmpty()) {
+            abTestRepository.deleteAllInBatch(abTests);
+        }
+    }
+
+    private void deleteScales(List<Long> questionIds, List<String> fileKeys) {
+        if (questionIds == null || questionIds.isEmpty()) {
+            return;
+        }
+
+        List<Scale> scales = scaleRepository.findAllByQuestion_IdIn(questionIds);
+        scales.stream()
+                .map(Scale::getImageKey)
+                .forEach(fileKeys::add);
+
+        if (!scales.isEmpty()) {
+            scaleRepository.deleteAllInBatch(scales);
+        }
+    }
+
+    private void deleteCardSortings(List<Long> questionIds) {
+        if (questionIds == null || questionIds.isEmpty()) {
+            return;
+        }
+
+        List<CardSorting> cardSortings = cardSortingRepository.findAllByQuestion_IdIn(questionIds);
+        if (!cardSortings.isEmpty()) {
+            cardSortingRepository.deleteAllInBatch(cardSortings);
+        }
+    }
+
+    private void deleteFiveSeconds(List<Long> questionIds, List<String> fileKeys) {
+        if (questionIds == null || questionIds.isEmpty()) {
+            return;
+        }
+
+        List<FiveSecond> fiveSeconds = fiveSecondRepository.findAllByQuestion_IdIn(questionIds);
+        if (fiveSeconds.isEmpty()) {
+            return;
+        }
+
+        fiveSeconds.stream()
+                .map(FiveSecond::getImageKey)
+                .forEach(fileKeys::add);
+
+        List<Long> fiveSecondIds = fiveSeconds.stream()
+                .map(FiveSecond::getId)
+                .toList();
+
+        fiveSecondOptionRepository.deleteAllByFiveSecondIds(fiveSecondIds);
+        fiveSecondRepository.deleteAllInBatch(fiveSeconds);
+    }
+
+    private void deleteTreeTests(List<Long> questionIds) {
+        if (questionIds == null || questionIds.isEmpty()) {
+            return;
+        }
+
+        List<TreeTest> nodes = treeTestRepository.findAllByQuestionIdInOrderByQuestionAndTree(questionIds);
+        nodes.stream()
+                .sorted(Comparator.comparing((TreeTest node) -> node.getQuestion().getId())
+                        .thenComparing(TreeTest::getDepth, Comparator.reverseOrder())
+                        .thenComparing(TreeTest::getSequence)
+                        .thenComparing(TreeTest::getId))
+                .forEach(node -> treeTestRepository.deleteDirectById(node.getId()));
+    }
+
+    private void validateAdmin(Role role) {
+        if (role != Role.ADMIN) {
+            throw new BaseException(BaseErrorCode.COMMON_009);
+        }
+    }
+
+    private void validateHardDeleteKey(String hardDeleteKey) {
+        if (hardDeleteKey == null || hardDeleteKey.isBlank()) {
+            throw new BaseException(BaseErrorCode.TEST_009);
+        }
+        if (!hardDeleteKey.equals(adminProperties.hardDeleteKey())) {
+            throw new BaseException(BaseErrorCode.TEST_010);
+        }
+    }
+
+    private void publishFileDeleteEvent(List<String> fileKeys) {
+        List<String> keysToDelete = fileKeys.stream()
+                .filter(Objects::nonNull)
+                .filter(key -> !key.isBlank())
+                .distinct()
+                .toList();
+
+        if (!keysToDelete.isEmpty()) {
+            eventPublisher.publishEvent(new FileDeleteEvent(keysToDelete));
+        }
+    }
+}

--- a/src/main/java/server/MATE/domain/test/service/TestDeleteService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestDeleteService.java
@@ -25,6 +25,7 @@ import server.MATE.global.storage.event.FileDeleteEvent;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -120,9 +121,10 @@ public class TestDeleteService {
 
     private void deleteQuestionDetails(List<Question> questions, List<String> fileKeys) {
         Map<QuestionType, List<Long>> questionIdsByType = questions.stream()
-                .collect(HashMap::new,
-                        (map, question) -> map.computeIfAbsent(question.getQuestionType(), key -> new ArrayList<>()).add(question.getId()),
-                        HashMap::putAll);
+                .collect(Collectors.groupingBy(
+                        Question::getQuestionType,
+                        Collectors.mapping(Question::getId, Collectors.toList())
+                ));
 
         deleteObjectives(questionIdsByType.get(QuestionType.OBJECTIVE), fileKeys);
         deleteSubjectives(questionIdsByType.get(QuestionType.SUBJECTIVE), fileKeys);

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -4,21 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.MATE.domain.participation.repository.ParticipationRepository;
-import server.MATE.domain.test.dto.response.LikedTestSummaryItem;
-import server.MATE.domain.test.dto.response.LikedTestSummaryResponse;
-import server.MATE.domain.test.dto.response.MyTestSummaryItem;
-import server.MATE.domain.test.dto.response.MyTestSummaryResponse;
-import server.MATE.domain.test.dto.response.TestDetailResponse;
-import server.MATE.domain.test.dto.response.TestLikeResponse;
-import server.MATE.domain.test.dto.response.TestStatusUpdateResponse;
-import server.MATE.domain.users.entity.Role;
-import server.MATE.domain.test.dto.response.TestSummaryListResponse;
-import server.MATE.domain.test.dto.response.TestSummaryResponse;
+import server.MATE.domain.test.dto.response.*;
 import server.MATE.domain.test.entity.Test;
 import server.MATE.domain.test.entity.TestLike;
 import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.domain.test.repository.TestLikeRepository;
 import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.domain.users.entity.Role;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
 import server.MATE.global.storage.FileStorageService;
@@ -167,7 +159,6 @@ public class TestService {
                 .map(test -> TestSummaryResponse.from(test, likedTestIds.contains(test.getId()), toThumbnailUrl(test.getImageKeys())))
                 .toList();
     }
-
 
     private Set<Long> findLikedTestIds(Long userId, List<Test> tests) {
         if (tests.isEmpty()) {

--- a/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/server/MATE/global/common/exception/BaseErrorCode.java
@@ -44,6 +44,8 @@ public enum BaseErrorCode implements ErrorCode {
     TEST_006(HttpStatus.BAD_REQUEST, "TEST_006", "테스트가 종료된 후에 조회할 수 있습니다."),
     TEST_007(HttpStatus.BAD_REQUEST, "TEST_007", "현재 상태에서는 변경할 수 없습니다."),
     TEST_008(HttpStatus.BAD_REQUEST, "TEST_008", "테스트 마감 기한은 필수입니다."),
+    TEST_009(HttpStatus.BAD_REQUEST, "TEST_009", "하드 삭제 검증 키가 필요합니다."),
+    TEST_010(HttpStatus.FORBIDDEN, "TEST_010", "하드 삭제 검증 키가 올바르지 않습니다."),
 
     // Test Draft
     DRAFT_001(HttpStatus.NOT_FOUND, "DRAFT_001", "테스트 초안을 찾을 수 없습니다."),

--- a/src/main/java/server/MATE/global/security/config/AdminProperties.java
+++ b/src/main/java/server/MATE/global/security/config/AdminProperties.java
@@ -1,0 +1,9 @@
+package server.MATE.global.security.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "mate.admin")
+public record AdminProperties(
+        String hardDeleteKey
+) {
+}

--- a/src/main/java/server/MATE/global/security/config/SecurityConfig.java
+++ b/src/main/java/server/MATE/global/security/config/SecurityConfig.java
@@ -20,7 +20,7 @@ import server.MATE.global.security.handler.CustomAuthenticationEntryPoint;
 
 @Configuration
 @EnableWebSecurity
-@EnableConfigurationProperties(CorsProperties.class)
+@EnableConfigurationProperties({CorsProperties.class, AdminProperties.class})
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,8 @@ claude:
     min-response-threshold: 20
 
 mate:
+  admin:
+    hard-delete-key: hard-confirm
   pdf:
     base-url: http://localhost:3001
     timeout: 90s

--- a/src/test/java/server/MATE/domain/test/controller/TestControllerTest.java
+++ b/src/test/java/server/MATE/domain/test/controller/TestControllerTest.java
@@ -1,0 +1,102 @@
+package server.MATE.domain.test.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import server.MATE.domain.auth.jwt.TokenType;
+import server.MATE.domain.test.dto.request.TestDeleteMode;
+import server.MATE.domain.test.service.TestDeleteService;
+import server.MATE.domain.test.service.TestService;
+import server.MATE.domain.users.entity.Role;
+import server.MATE.global.common.exception.GlobalExceptionHandler;
+import server.MATE.global.discord.DiscordWebhookNotifier;
+import server.MATE.global.security.principal.AuthenticatedUser;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class TestControllerTest {
+
+    @Mock
+    private TestService testService;
+
+    @Mock
+    private TestDeleteService testDeleteService;
+
+    @Mock
+    private DiscordWebhookNotifier discordWebhookNotifier;
+
+    @InjectMocks
+    private TestController testController;
+
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(testController)
+                .setControllerAdvice(new GlobalExceptionHandler(discordWebhookNotifier))
+                .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("관리자 soft delete 요청을 정상 처리한다")
+    void deletesTestSoftSuccessfully() throws Exception {
+        mockMvc.perform(delete("/api/v1/tests/10")
+                        .with(authenticationPrincipal(1L, Role.ADMIN))
+                        .queryParam("mode", "SOFT"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("테스트를 삭제했습니다."));
+
+        verify(testDeleteService).deleteTest(10L, Role.ADMIN, TestDeleteMode.SOFT, null);
+    }
+
+    @Test
+    @DisplayName("관리자 hard delete 요청에 검증 키를 전달한다")
+    void deletesTestHardSuccessfully() throws Exception {
+        mockMvc.perform(delete("/api/v1/tests/10")
+                        .with(authenticationPrincipal(1L, Role.ADMIN))
+                        .queryParam("mode", "HARD")
+                        .header("X-MATE-Hard-Delete-Key", "hard-delete-key"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("테스트를 삭제했습니다."));
+
+        verify(testDeleteService).deleteTest(10L, Role.ADMIN, TestDeleteMode.HARD, "hard-delete-key");
+    }
+
+    private RequestPostProcessor authenticationPrincipal(Long userId, Role role) {
+        return request -> {
+            AuthenticatedUser principal = new AuthenticatedUser(userId, role, TokenType.ACCESS);
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(authentication);
+            SecurityContextHolder.setContext(context);
+            return request;
+        };
+    }
+}

--- a/src/test/java/server/MATE/domain/test/service/TestDeleteServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestDeleteServiceTest.java
@@ -1,0 +1,197 @@
+package server.MATE.domain.test.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+import server.MATE.domain.answer.repository.AnswerRepository;
+import server.MATE.domain.participation.repository.ParticipationRepository;
+import server.MATE.domain.payment.repository.PaymentRepository;
+import server.MATE.domain.promotion.repository.PromotionRewardRepository;
+import server.MATE.domain.question.entity.Question;
+import server.MATE.domain.question.entity.QuestionType;
+import server.MATE.domain.question.entity.Subjective;
+import server.MATE.domain.question.repository.*;
+import server.MATE.domain.report.repository.ReportRepository;
+import server.MATE.domain.test.dto.request.TestDeleteMode;
+import server.MATE.domain.test.entity.Category;
+import server.MATE.domain.test.repository.TestCategoryRepository;
+import server.MATE.domain.test.repository.TestLikeRepository;
+import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.domain.users.entity.Role;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+import server.MATE.global.security.config.AdminProperties;
+import server.MATE.global.storage.event.FileDeleteEvent;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TestDeleteServiceTest {
+
+    @Mock
+    private TestRepository testRepository;
+    @Mock
+    private AnswerRepository answerRepository;
+    @Mock
+    private QuestionRepository questionRepository;
+    @Mock
+    private ParticipationRepository participationRepository;
+    @Mock
+    private ReportRepository reportRepository;
+    @Mock
+    private PaymentRepository paymentRepository;
+    @Mock
+    private PromotionRewardRepository promotionRewardRepository;
+    @Mock
+    private TestCategoryRepository testCategoryRepository;
+    @Mock
+    private TestLikeRepository testLikeRepository;
+    @Mock
+    private ObjectiveRepository objectiveRepository;
+    @Mock
+    private ObjectiveOptionRepository objectiveOptionRepository;
+    @Mock
+    private SubjectiveRepository subjectiveRepository;
+    @Mock
+    private AbTestRepository abTestRepository;
+    @Mock
+    private ScaleRepository scaleRepository;
+    @Mock
+    private CardSortingRepository cardSortingRepository;
+    @Mock
+    private FiveSecondRepository fiveSecondRepository;
+    @Mock
+    private FiveSecondOptionRepository fiveSecondOptionRepository;
+    @Mock
+    private TreeTestRepository treeTestRepository;
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+    @Mock
+    private AdminProperties adminProperties;
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private TestDeleteService testDeleteService;
+
+    private server.MATE.domain.test.entity.Test test;
+    private static final Long TEST_ID = 10L;
+    private static final Long MAKER_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        test = server.MATE.domain.test.entity.Test.builder()
+                .makerId(MAKER_ID)
+                .title("기존 제목")
+                .description("기존 소개")
+                .serviceName("기존 서비스")
+                .serviceDescription("기존 서비스 소개")
+                .imageKeys(new ArrayList<>(List.of("old-key-1", "old-key-2")))
+                .closedAt(LocalDateTime.of(2099, 12, 31, 23, 59, 59))
+                .build();
+        ReflectionTestUtils.setField(test, "id", TEST_ID);
+        test.addCategories(List.of(Category.FOOD));
+        lenient().when(clock.instant()).thenReturn(Instant.parse("2026-05-30T00:00:00Z"));
+        lenient().when(clock.getZone()).thenReturn(ZoneId.of("Asia/Seoul"));
+        lenient().when(adminProperties.hardDeleteKey()).thenReturn("hard-delete-key");
+    }
+
+    @Test
+    void 관리자가_soft_delete를_수행하면_연관_엔티티를_논리삭제한다() {
+        Question question = createQuestion(101L, QuestionType.SUBJECTIVE);
+        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
+        given(questionRepository.findQuestionsInTest(TEST_ID)).willReturn(List.of(question));
+
+        testDeleteService.deleteTest(TEST_ID, Role.ADMIN, TestDeleteMode.SOFT, null);
+
+        verify(reportRepository).softDeleteAllByTestId(eq(TEST_ID), any(LocalDateTime.class));
+        verify(answerRepository).softDeleteAllByQuestionIds(eq(List.of(101L)), any(LocalDateTime.class));
+        verify(participationRepository).softDeleteAllByTestId(eq(TEST_ID), any(LocalDateTime.class));
+        verify(questionRepository).softDeleteByTestId(eq(TEST_ID), any(LocalDateTime.class));
+        verify(testCategoryRepository, never()).softDeleteAllByTestId(anyLong(), any(LocalDateTime.class));
+        verify(testRepository).softDeleteById(eq(TEST_ID), any(LocalDateTime.class));
+    }
+
+    @Test
+    void 관리자가_hard_delete를_수행하면_연관_데이터_삭제와_파일_삭제_이벤트를_발행한다() {
+        Question subjectiveQuestion = createQuestion(101L, QuestionType.SUBJECTIVE);
+        given(testRepository.findByIdIncludingDeleted(TEST_ID)).willReturn(Optional.of(test));
+        given(questionRepository.findQuestionsInTestIncludingDeleted(TEST_ID)).willReturn(List.of(subjectiveQuestion));
+
+        Subjective subjective = Subjective.builder()
+                .question(subjectiveQuestion)
+                .imageKey("question-image-key")
+                .build();
+        given(subjectiveRepository.findAllByQuestion_IdIn(List.of(101L))).willReturn(List.of(subjective));
+
+        testDeleteService.deleteTest(TEST_ID, Role.ADMIN, TestDeleteMode.HARD, "hard-delete-key");
+
+        verify(promotionRewardRepository).deleteAllByTestId(TEST_ID);
+        verify(answerRepository).deleteAllByQuestionIds(List.of(101L));
+        verify(reportRepository).deleteAllByTestId(TEST_ID);
+        verify(testLikeRepository).deleteAllByTestId(TEST_ID);
+        verify(subjectiveRepository).deleteAllInBatch(anyList());
+        verify(questionRepository).deleteAllInBatch(anyList());
+        verify(testCategoryRepository).deleteAllByTestId(TEST_ID);
+        verify(participationRepository).deleteAllByTestId(TEST_ID);
+        verify(paymentRepository).deleteAllByTestId(TEST_ID);
+        verify(testRepository).delete(test);
+
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(applicationEventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue()).isInstanceOf(FileDeleteEvent.class);
+        FileDeleteEvent fileDeleteEvent = (FileDeleteEvent) eventCaptor.getValue();
+        assertThat(fileDeleteEvent.fileKeys())
+                .contains("old-key-1", "old-key-2", "question-image-key");
+    }
+
+    @Test
+    void hard_delete_키가_없으면_예외가_발생한다() {
+        given(testRepository.findByIdIncludingDeleted(TEST_ID)).willReturn(Optional.of(test));
+
+        BaseException exception = Assertions.assertThrows(BaseException.class,
+                () -> testDeleteService.deleteTest(TEST_ID, Role.ADMIN, TestDeleteMode.HARD, null));
+
+        assertThat(exception.getErrorCode()).isEqualTo(BaseErrorCode.TEST_009);
+    }
+
+    @Test
+    void 관리자가_아니면_삭제할_수_없다() {
+        BaseException exception = Assertions.assertThrows(BaseException.class,
+                () -> testDeleteService.deleteTest(TEST_ID, Role.USER, TestDeleteMode.SOFT, null));
+
+        assertThat(exception.getErrorCode()).isEqualTo(BaseErrorCode.COMMON_009);
+        verifyNoInteractions(testRepository);
+    }
+
+    private Question createQuestion(Long id, QuestionType questionType) {
+        Question question = Question.builder()
+                .testId(TEST_ID)
+                .questionType(questionType)
+                .title("질문")
+                .description("설명")
+                .sequence(1L)
+                .build();
+        ReflectionTestUtils.setField(question, "id", id);
+        return question;
+    }
+}

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -28,6 +28,7 @@ import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.global.storage.FileStorageService;
 
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -80,6 +81,8 @@ class TestServiceTest {
         test.addCategories(List.of(Category.FOOD));
         lenient().when(fileStorageService.generateDownloadUrl(anyString())).thenReturn("https://example.com/url");
         lenient().when(clock.withZone(ZoneId.of("Asia/Seoul"))).thenReturn(Clock.system(ZoneId.of("Asia/Seoul")));
+        lenient().when(clock.instant()).thenReturn(Instant.parse("2026-05-30T00:00:00Z"));
+        lenient().when(clock.getZone()).thenReturn(ZoneId.of("Asia/Seoul"));
     }
 
     @Test
@@ -323,4 +326,5 @@ class TestServiceTest {
         ReflectionTestUtils.setField(listTest, "id", id);
         return listTest;
     }
+
 }

--- a/src/test/java/server/MATE/integration/TestDeleteIntegrationTest.java
+++ b/src/test/java/server/MATE/integration/TestDeleteIntegrationTest.java
@@ -1,0 +1,335 @@
+package server.MATE.integration;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import server.MATE.domain.answer.entity.Answer;
+import server.MATE.domain.answer.repository.AnswerRepository;
+import server.MATE.domain.auth.jwt.JwtProvider;
+import server.MATE.domain.auth.jwt.TokenType;
+import server.MATE.domain.participation.entity.Participation;
+import server.MATE.domain.participation.repository.ParticipationRepository;
+import server.MATE.domain.payment.entity.Payment;
+import server.MATE.domain.payment.entity.PayStatus;
+import server.MATE.domain.payment.repository.PaymentRepository;
+import server.MATE.domain.promotion.entity.PromotionReward;
+import server.MATE.domain.promotion.repository.PromotionRewardRepository;
+import server.MATE.domain.question.entity.*;
+import server.MATE.domain.question.repository.*;
+import server.MATE.domain.report.entity.Report;
+import server.MATE.domain.report.repository.ReportRepository;
+import server.MATE.domain.test.entity.*;
+import server.MATE.domain.test.repository.TestCategoryRepository;
+import server.MATE.domain.test.repository.TestLikeRepository;
+import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.domain.users.entity.Role;
+import server.MATE.domain.users.entity.Users;
+import server.MATE.domain.users.repository.UsersRepository;
+import server.MATE.global.storage.FileStorageService;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class TestDeleteIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private JwtProvider jwtProvider;
+    @Autowired
+    private UsersRepository usersRepository;
+    @Autowired
+    private TestRepository testRepository;
+    @Autowired
+    private QuestionRepository questionRepository;
+    @Autowired
+    private ObjectiveRepository objectiveRepository;
+    @Autowired
+    private FiveSecondRepository fiveSecondRepository;
+    @Autowired
+    private SubjectiveRepository subjectiveRepository;
+    @Autowired
+    private TreeTestRepository treeTestRepository;
+    @Autowired
+    private ParticipationRepository participationRepository;
+    @Autowired
+    private AnswerRepository answerRepository;
+    @Autowired
+    private ReportRepository reportRepository;
+    @Autowired
+    private PaymentRepository paymentRepository;
+    @Autowired
+    private PromotionRewardRepository promotionRewardRepository;
+    @Autowired
+    private TestLikeRepository testLikeRepository;
+    @Autowired
+    private TestCategoryRepository testCategoryRepository;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @MockitoBean
+    private FileStorageService fileStorageService;
+
+    @AfterEach
+    void tearDown() {
+        answerRepository.deleteAll();
+        promotionRewardRepository.deleteAll();
+        participationRepository.deleteAll();
+        treeTestRepository.deleteAll();
+        fiveSecondRepository.deleteAll();
+        objectiveRepository.deleteAll();
+        subjectiveRepository.deleteAll();
+        questionRepository.deleteAll();
+        reportRepository.deleteAll();
+        testLikeRepository.deleteAll();
+        testCategoryRepository.deleteAll();
+        paymentRepository.deleteAll();
+        testRepository.deleteAll();
+        usersRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("soft delete는 조회 대상만 논리 삭제하고 like, payment, promotion_reward는 유지한다")
+    void softDeleteMarksActiveDataOnly() throws Exception {
+        DeleteFixture fixture = createDeleteFixture();
+
+        mockMvc.perform(delete("/api/v1/tests/{testId}", fixture.test.getId())
+                        .header("Authorization", fixture.adminToken)
+                        .queryParam("mode", "SOFT"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/tests/{testId}", fixture.test.getId())
+                        .header("Authorization", fixture.adminToken))
+                .andExpect(status().isNotFound());
+
+        server.MATE.domain.test.entity.Test savedTest = testRepository.findById(fixture.test.getId()).orElseThrow();
+        Question savedObjectiveQuestion = questionRepository.findById(fixture.objectiveQuestion.getId()).orElseThrow();
+        Question savedTreeQuestion = questionRepository.findById(fixture.treeQuestion.getId()).orElseThrow();
+        Participation savedParticipation = participationRepository.findById(fixture.participation.getId()).orElseThrow();
+        Answer savedAnswer = answerRepository.findById(fixture.answer.getId()).orElseThrow();
+        Report savedReport = reportRepository.findById(fixture.report.getId()).orElseThrow();
+
+        assertThat(savedTest.getDeletedAt()).isNotNull();
+        assertThat(savedObjectiveQuestion.getDeletedAt()).isNotNull();
+        assertThat(savedTreeQuestion.getDeletedAt()).isNotNull();
+        assertThat(savedParticipation.getDeletedAt()).isNotNull();
+        assertThat(savedAnswer.getDeletedAt()).isNotNull();
+        assertThat(savedReport.getDeletedAt()).isNotNull();
+
+        assertThat(testCategoryRepository.findAll()).hasSize(1);
+        assertThat(testLikeRepository.findAll()).hasSize(1);
+        assertThat(paymentRepository.findAll()).hasSize(1);
+        assertThat(promotionRewardRepository.findAll()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("soft deleted test도 hard delete로 purge 가능하고 연관 데이터를 모두 제거한다")
+    void hardDeletePurgesSoftDeletedTest() throws Exception {
+        DeleteFixture fixture = createDeleteFixture();
+
+        mockMvc.perform(delete("/api/v1/tests/{testId}", fixture.test.getId())
+                        .header("Authorization", fixture.adminToken)
+                        .queryParam("mode", "SOFT"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(delete("/api/v1/tests/{testId}", fixture.test.getId())
+                        .header("Authorization", fixture.adminToken)
+                        .header("X-MATE-Hard-Delete-Key", "test-hard-delete-key")
+                        .queryParam("mode", "HARD"))
+                .andExpect(status().isOk());
+
+        assertThat(testRepository.findById(fixture.test.getId())).isEmpty();
+        assertThat(questionRepository.findById(fixture.objectiveQuestion.getId())).isEmpty();
+        assertThat(questionRepository.findById(fixture.fiveSecondQuestion.getId())).isEmpty();
+        assertThat(questionRepository.findById(fixture.treeQuestion.getId())).isEmpty();
+        assertThat(objectiveRepository.findById(fixture.objectiveQuestion.getId())).isEmpty();
+        assertThat(fiveSecondRepository.findById(fixture.fiveSecondQuestion.getId())).isEmpty();
+        assertThat(treeTestRepository.findAll()).isEmpty();
+        assertThat(answerRepository.findAll()).isEmpty();
+        assertThat(participationRepository.findAll()).isEmpty();
+        assertThat(reportRepository.findAll()).isEmpty();
+        assertThat(testLikeRepository.findAll()).isEmpty();
+        assertThat(paymentRepository.findAll()).isEmpty();
+        assertThat(promotionRewardRepository.findAll()).isEmpty();
+
+        verify(fileStorageService).deleteFiles(argThat(keys ->
+                keys.contains("test-image-key")
+                        && keys.contains("objective-image-key")
+                        && keys.contains("five-image-key")
+        ));
+    }
+
+    private DeleteFixture createDeleteFixture() {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        return tx.execute(status -> {
+            Users admin = usersRepository.save(Users.builder()
+                    .ci("admin-" + System.nanoTime())
+                    .name("admin")
+                    .role(Role.ADMIN)
+                    .build());
+            Users maker = usersRepository.save(Users.builder()
+                    .ci("maker-" + System.nanoTime())
+                    .name("maker")
+                    .build());
+            Users tester = usersRepository.save(Users.builder()
+                    .ci("tester-" + System.nanoTime())
+                    .name("tester")
+                    .build());
+
+            server.MATE.domain.test.entity.Test test = testRepository.save(server.MATE.domain.test.entity.Test.builder()
+                    .makerId(maker.getId())
+                    .title("삭제 대상 테스트")
+                    .description("설명")
+                    .serviceName("서비스")
+                    .serviceDescription("서비스 설명")
+                    .imageKeys(List.of("test-image-key"))
+                    .testStatus(TestStatus.IN_PROGRESS)
+                    .closedAt(LocalDateTime.of(2099, 12, 31, 23, 59, 59))
+                    .build());
+            test.addCategories(List.of(Category.FOOD));
+            testRepository.save(test);
+
+            Question objectiveQuestion = questionRepository.save(Question.builder()
+                    .testId(test.getId())
+                    .questionType(QuestionType.OBJECTIVE)
+                    .title("객관식 질문")
+                    .description("설명")
+                    .sequence(1L)
+                    .build());
+            Objective objective = Objective.builder()
+                    .question(questionRepository.getReferenceById(objectiveQuestion.getId()))
+                    .isDuplicate(false)
+                    .minSelect(1)
+                    .maxSelect(1)
+                    .isOther(false)
+                    .build();
+            objective.addOption(ObjectiveOption.builder()
+                    .objective(objective)
+                    .content("옵션 1")
+                    .imageKey("objective-image-key")
+                    .sequence(1)
+                    .isOtherOption(false)
+                    .build());
+            entityManager.persist(objective);
+
+            Question fiveSecondQuestion = questionRepository.save(Question.builder()
+                    .testId(test.getId())
+                    .questionType(QuestionType.FIVE_SECOND)
+                    .title("5초 질문")
+                    .description("설명")
+                    .sequence(2L)
+                    .build());
+            FiveSecond fiveSecond = FiveSecond.builder()
+                    .question(questionRepository.getReferenceById(fiveSecondQuestion.getId()))
+                    .imageKey("five-image-key")
+                    .imageRatio(ImageRatio.RATIO_9_16)
+                    .isObjective(true)
+                    .isDuplicate(false)
+                    .minSelect(1)
+                    .maxSelect(1)
+                    .isOther(false)
+                    .build();
+            fiveSecond.addOption(FiveSecondOption.builder()
+                    .fiveSecond(fiveSecond)
+                    .content("옵션 A")
+                    .sequence(1)
+                    .isOtherOption(false)
+                    .build());
+            entityManager.persist(fiveSecond);
+
+            Question treeQuestion = questionRepository.save(Question.builder()
+                    .testId(test.getId())
+                    .questionType(QuestionType.TREE_TEST)
+                    .title("트리 질문")
+                    .description("설명")
+                    .sequence(3L)
+                    .build());
+            Question treeQuestionRef = questionRepository.getReferenceById(treeQuestion.getId());
+            TreeTest root = TreeTest.create(treeQuestionRef, null, "root", 1);
+            entityManager.persist(root);
+            entityManager.persist(TreeTest.create(treeQuestionRef, root, "child", 1));
+            entityManager.flush();
+
+            Participation participation = participationRepository.save(Participation.builder()
+                    .testId(test.getId())
+                    .testerId(tester.getId())
+                    .build());
+
+            Answer answer = answerRepository.save(Answer.builder()
+                    .participationId(participation.getId())
+                    .questionId(objectiveQuestion.getId())
+                    .questionType(QuestionType.OBJECTIVE)
+                    .answer(Map.of("selectedOptionIds", List.of(1)))
+                    .build());
+
+            Report report = reportRepository.save(Report.builder()
+                    .testId(test.getId())
+                    .questionId(objectiveQuestion.getId())
+                    .questionType(QuestionType.OBJECTIVE)
+                    .result(Map.of("count", 1))
+                    .build());
+
+            paymentRepository.save(Payment.builder()
+                    .draftId(999L)
+                    .testId(test.getId())
+                    .makerId(maker.getId())
+                    .orderNo("order-" + System.nanoTime())
+                    .payStatus(PayStatus.PAY_SUCCEEDED)
+                    .goalPpl(10)
+                    .reward(300)
+                    .amount(3000)
+                    .isTestPayment(true)
+                    .build());
+
+            promotionRewardRepository.save(PromotionReward.builder()
+                    .participationId(participation.getId())
+                    .testId(test.getId())
+                    .testerId(tester.getId())
+                    .rewardAmount(300)
+                    .build());
+
+            testLikeRepository.save(TestLike.builder()
+                    .userId(tester.getId())
+                    .testId(test.getId())
+                    .build());
+
+            String adminToken = "Bearer " + jwtProvider.generateToken(admin.getId(), admin.getRole().name(), TokenType.ACCESS);
+            return new DeleteFixture(test, objectiveQuestion, fiveSecondQuestion, treeQuestion, participation, answer, report, adminToken);
+        });
+    }
+
+    private record DeleteFixture(
+            server.MATE.domain.test.entity.Test test,
+            Question objectiveQuestion,
+            Question fiveSecondQuestion,
+            Question treeQuestion,
+            Participation participation,
+            Answer answer,
+            Report report,
+            String adminToken
+    ) {
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -54,3 +54,7 @@ security:
     max-age-seconds: 3600
   token-encryption:
     key: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
+
+mate:
+  admin:
+    hard-delete-key: test-hard-delete-key


### PR DESCRIPTION
## 📍 요약
- 관리자용 테스트 soft/hard 삭제 API를 구현하고, 연관 데이터 정리 및 삭제 검증 로직을 구현함

## 🔗 관련 이슈
- Closes #201 

## 📌 변경 사항
- [x] 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- 해당 api는 관리자 권한을 가진 계정으로만 요청이 가능함. mode=`SOFT` 또는 `HARD`로 삭제 방식을 구분하여 각각 구현함.
  - hard delete 시 `X-MATE-Hard-Delete-Key` 헤더 검증을 추가함
- soft delete 시 `test`, `question`, `answer`, `participation`, `report`를 논리 삭제함
- hard delete 시 `test_like`, `test_category`, `payment`, `promotion_reward`, 질문 유형 엔티티(`objective`, `subjective`, `ab_test`, `scale`, `card_sorting`, `five_second`, `tree_test`)와 이미지 파일까지 함께 삭제함
- `TestDeleteService`를 삭제 책임을 전용 서비스로 하고, `TestService`는 조회/상태 변경/좋아요 책임만 갖도록 분리함

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `./gradlew test`
