### PR TITLE
fix: ci 배포 시 Pod Pending / 롤아웃 stuck 해결

### DIFF
--- a/deploy/apps/mate/deployment.yaml
+++ b/deploy/apps/mate/deployment.yaml
@@ -10,6 +10,11 @@ metadata:
 spec:
   replicas: 2
   revisionHistoryLimit: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: mate


### PR DESCRIPTION
## 📍 요약
- 2노드(worker + control) + required podAntiAffinity 환경에서 Rolling Update `maxSurge: 25%`로 새 Pod가 Pending 되며 롤아웃이 stuck 되던 문제를 `maxSurge: 0`, `maxUnavailable: 1`로 변경하여 해결

## 🔗 관련 이슈
- Closes #203

## 📌 변경 사항
- [ ] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [ ] 테스트
- [ ] 기타

## ✅ 작업 내용
- `deploy/apps/mate/deployment.yaml`에 RollingUpdate 전략 명시
  - `maxSurge: 0` — 배포 중 Pod를 3개까지 늘리지 않음 (2노드 anti-affinity 충돌 방지)
  - `maxUnavailable: 1` — 한 번에 1개씩 교체하여 최소 1 Pod Ready 유지
- `podAntiAffinity` (required) 및 PDB `minAvailable: 1`은 기존 설정 유지

### 원인
- `replicas: 2`, 기본 `maxSurge: 25%` → 배포 시 최대 3 Pod 시도
- 노드 2대(worker + control)에 mate Pod 1개씩 이미 배치 → anti-affinity 위반
- 새 Pod Pending → progress deadline 초과 → 롤아웃 stuck


## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - Argo sync 후 `kubectl rollout status deployment/mate -n mate --timeout=15m` → `successfully rolled out`
→ Pending stuck 문제가 재현 되지 않고 새 버전 2/2 반영됨
<img width="1528" height="228" alt="image" src="https://github.com/user-attachments/assets/053aab2b-30cb-4725-bc0e-3e07e4f134f0" />