### PR TITLE
fix: Azure Blob Storage CORS 설정 추가

### DIFF
--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -48,7 +48,6 @@ module "storage" {
   storage_account_name   = var.storage_account_name
   storage_container_name = var.storage_container_name
   blob_cors_allowed_origins = [
-    "http://localhost:5173",
     "https://mate.apps.tossmini.com",
     "https://mate.private-apps.tossmini.com",
     "https://developers-apps-in-toss.toss.im",

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -47,6 +47,13 @@ module "storage" {
   location               = var.location
   storage_account_name   = var.storage_account_name
   storage_container_name = var.storage_container_name
+  blob_cors_allowed_origins = [
+    "http://localhost:5173",
+    "https://mate.apps.tossmini.com",
+    "https://mate.private-apps.tossmini.com",
+    "https://developers-apps-in-toss.toss.im",
+    "https://apps-in-toss.toss.im",
+  ]
 }
 
 module "container_registry" {

--- a/infra/terraform/modules/storage/main.tf
+++ b/infra/terraform/modules/storage/main.tf
@@ -6,6 +6,18 @@ resource "azurerm_storage_account" "this" {
   account_replication_type = var.account_replication_type
 }
 
+resource "azurerm_storage_account_blob_service_properties" "this" {
+  storage_account_id = azurerm_storage_account.this.id
+
+  cors_rule {
+    allowed_headers    = ["*"]
+    allowed_methods    = ["GET", "PUT", "OPTIONS"]
+    allowed_origins    = var.blob_cors_allowed_origins
+    exposed_headers    = ["*"]
+    max_age_in_seconds = 86400
+  }
+}
+
 resource "azurerm_storage_container" "app" {
   name                  = var.storage_container_name
   storage_account_name  = azurerm_storage_account.this.name

--- a/infra/terraform/modules/storage/main.tf
+++ b/infra/terraform/modules/storage/main.tf
@@ -9,12 +9,15 @@ resource "azurerm_storage_account" "this" {
 resource "azurerm_storage_account_blob_service_properties" "this" {
   storage_account_id = azurerm_storage_account.this.id
 
-  cors_rule {
-    allowed_headers    = ["*"]
-    allowed_methods    = ["GET", "PUT", "OPTIONS"]
-    allowed_origins    = var.blob_cors_allowed_origins
-    exposed_headers    = ["*"]
-    max_age_in_seconds = 86400
+  dynamic "cors_rule" {
+    for_each = length(var.blob_cors_allowed_origins) > 0 ? [1] : []
+    content {
+      allowed_headers    = ["*"]
+      allowed_methods    = ["GET", "PUT", "OPTIONS"]
+      allowed_origins    = var.blob_cors_allowed_origins
+      exposed_headers    = ["*"]
+      max_age_in_seconds = 86400
+    }
   }
 }
 

--- a/infra/terraform/modules/storage/variables.tf
+++ b/infra/terraform/modules/storage/variables.tf
@@ -29,3 +29,9 @@ variable "account_replication_type" {
   type        = string
   default     = "LRS"
 }
+
+variable "blob_cors_allowed_origins" {
+  description = "CORS allowed origins for Blob Storage."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
  ## 📍 요약
  Azure Blob Storage CORS 미설정으로 프로덕션 이미지 업로드 실패
  
  ## 🔗 관련 이슈
  Closes #205
  
  ## 📌 변경 사항
  - [x] 버그 수정
  
  ## ✅ 작업 내용
  - modules/storage/main.tf에 azurerm_storage_account_blob_service_properties 리소스 추가
  - modules/storage/variables.tf에 blob_cors_allowed_origins 변수 추가
  - environments/prod/main.tf에 프로덕션 허용 origin 5개 전달

  ## 테스트
  terraform apply 후 이미지 업로드 정상 동작 확인 필요