### PR TITLE
fix: Azure Blob Storage CORS 설정 추가

### DIFF
--- a/infra/terraform/modules/storage/main.tf
+++ b/infra/terraform/modules/storage/main.tf
@@ -4,19 +4,17 @@ resource "azurerm_storage_account" "this" {
   location                 = var.location
   account_tier             = var.account_tier
   account_replication_type = var.account_replication_type
-}
 
-resource "azurerm_storage_account_blob_service_properties" "this" {
-  storage_account_id = azurerm_storage_account.this.id
-
-  dynamic "cors_rule" {
-    for_each = length(var.blob_cors_allowed_origins) > 0 ? [1] : []
-    content {
-      allowed_headers    = ["*"]
-      allowed_methods    = ["GET", "PUT", "OPTIONS"]
-      allowed_origins    = var.blob_cors_allowed_origins
-      exposed_headers    = ["*"]
-      max_age_in_seconds = 86400
+  blob_properties {
+    dynamic "cors_rule" {
+      for_each = length(var.blob_cors_allowed_origins) > 0 ? [1] : []
+      content {
+        allowed_headers    = ["*"]
+        allowed_methods    = ["GET", "PUT", "OPTIONS"]
+        allowed_origins    = var.blob_cors_allowed_origins
+        exposed_headers    = ["*"]
+        max_age_in_seconds = 86400
+      }
     }
   }
 }


### PR DESCRIPTION
  ## 📍 요약
  Azure Blob Storage CORS 미설정으로 프로덕션 이미지 업로드 실패
  
  ## 🔗 관련 이슈
  Closes #205
  
  ## 📌 변경 사항
  버그 수정
  
  ## ✅ 작업 내용
  - modules/storage/main.tf에 blob_properties.cors_rule 추가 (azurerm v4 호환)
  - modules/storage/variables.tf에 blob_cors_allowed_origins 변수 추가
  - environments/prod/main.tf에 프로덕션 허용 origin 4개 전달
  
  ## 테스트
  terraform apply 후 이미지 업로드 정상 동작 확인 필요