### PR TITLE
feat: 리포트 조회 응답에 테스트 제목 필드 추가

### DIFF
--- a/src/main/java/server/MATE/domain/report/dto/response/ReportResponse.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/ReportResponse.java
@@ -8,6 +8,9 @@ import java.util.List;
 
 @Schema(description = "테스트 리포트 전체 조회 응답")
 public record ReportResponse(
+        @Schema(description = "테스트 제목", example = "MATE 사용성 테스트")
+        String title,
+
         @Schema(description = "테스트 상태 (IN_PROGRESS / COMPLETED)", example = "COMPLETED")
         TestStatus testStatus,
 

--- a/src/main/java/server/MATE/domain/report/service/ReportService.java
+++ b/src/main/java/server/MATE/domain/report/service/ReportService.java
@@ -44,6 +44,7 @@ public class ReportService {
             case WAITING, IN_PROGRESS, REJECTED -> {
                 // 완료 전 상태이므로 집계 결과 없이 현재 리포트 상태만 반환함
                 return new ReportResponse(
+                        test.getTitle(),
                         test.getTestStatus(),
                         reportStatus,
                         questionCount,
@@ -55,6 +56,7 @@ public class ReportService {
                 // 테스트는 종료됐지만 집계가 끝나지 않았으면 빈 결과를 반환함
                 if (reportStatus != ReportStatus.COMPLETED) {
                     return new ReportResponse(
+                            test.getTitle(),
                             TestStatus.COMPLETED,
                             reportStatus,
                             questionCount,
@@ -81,6 +83,7 @@ public class ReportService {
             log.error("테스트 {} 리포트 조회 중 활성 질문 리포트 누락 감지: questionCount={}, reportCount={}, missingQuestionIds={}",
                     testId, questionCount, aggregations.size(), missingQuestionIds);
             return new ReportResponse(
+                    test.getTitle(),
                     test.getTestStatus(),
                     ReportStatus.FAILED,
                     questionCount,
@@ -101,6 +104,7 @@ public class ReportService {
                 .toList();
 
         return new ReportResponse(
+                test.getTitle(),
                 TestStatus.COMPLETED,
                 ReportStatus.COMPLETED,
                 questionCount,


### PR DESCRIPTION
  ## 📍 요약
  리포트 조회 API 응답에 테스트 제목(title) 필드 추가
  
  ## 🔗 관련 이슈
  Closes #208
  
  ## 📌 변경 사항
  - [x] 기능
  
  ## ✅ 작업 내용
  - ReportResponse에 title 필드 추가
  - ReportService의 모든 ReportResponse 생성 시 test.getTitle() 포함
  
  ## 테스트
  로컬 서버 실행 후 Swagger에서 GET /api/v1/reports/{testId} 응답 확인