### PR TITLE
feat: 테스트 마감일 기반 자동 종료 및 환불/리포트 생성 로직 구현

### DIFF
--- a/src/main/java/server/MATE/MateApplication.java
+++ b/src/main/java/server/MATE/MateApplication.java
@@ -3,7 +3,9 @@ package server.MATE;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
 @SpringBootApplication
 public class MateApplication {

--- a/src/main/java/server/MATE/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/server/MATE/domain/payment/repository/PaymentRepository.java
@@ -18,6 +18,8 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     Optional<Payment> findByDraftId(Long draftId);
 
+    Optional<Payment> findByTestId(Long testId);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""
             select p

--- a/src/main/java/server/MATE/domain/report/service/ReportService.java
+++ b/src/main/java/server/MATE/domain/report/service/ReportService.java
@@ -57,7 +57,7 @@ public class ReportService {
                 if (reportStatus != ReportStatus.COMPLETED) {
                     return new ReportResponse(
                             test.getTitle(),
-                            TestStatus.COMPLETED,
+                            test.getTestStatus(),
                             reportStatus,
                             questionCount,
                             test.getPplCount(),

--- a/src/main/java/server/MATE/domain/test/controller/TestController.java
+++ b/src/main/java/server/MATE/domain/test/controller/TestController.java
@@ -121,9 +121,9 @@ public class TestController {
             description = """
                     테스트 상태를 변경합니다.
 
-                    - `COMPLETED`: 메이커 본인만 가능, 현재 상태가 `IN_PROGRESS`일 때만 허용
-                    - `IN_PROGRESS`: 관리자만 가능 (테스트 승인)
-                    - `REJECTED`: 관리자만 가능 (테스트 반려)
+                    - `IN_PROGRESS`: 관리자만 가능 (테스트 승인), 현재 상태가 `WAITING`일 때만 허용
+                    - `REJECTED`: 관리자만 가능 (테스트 반려), 현재 상태가 `WAITING`일 때만 허용
+                    - `COMPLETED`: 마감일(closedAt) 경과 시 스케줄러가 자동 처리 (매일 00:00 KST)
                     """
     )
     @PatchMapping("/{testId}/status")

--- a/src/main/java/server/MATE/domain/test/repository/TestQueryRepository.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestQueryRepository.java
@@ -24,4 +24,6 @@ public interface TestQueryRepository {
     Optional<Test> findWithCategoriesById(Long id);
 
     Optional<Test> findByIdForUpdate(Long id);
+
+    List<Test> findExpiredInProgressTests(LocalDateTime now);
 }

--- a/src/main/java/server/MATE/domain/test/repository/TestQueryRepositoryImpl.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestQueryRepositoryImpl.java
@@ -188,4 +188,20 @@ public class TestQueryRepositoryImpl implements TestQueryRepository {
                         .fetchOne()
         );
     }
+
+    @Override
+    public List<Test> findExpiredInProgressTests(LocalDateTime now) {
+        if (now == null) {
+            return List.of();
+        }
+
+        return queryFactory
+                .selectFrom(test)
+                .where(
+                        test.testStatus.eq(TestStatus.IN_PROGRESS),
+                        test.closedAt.lt(now),
+                        notDeleted()
+                )
+                .fetch();
+    }
 }

--- a/src/main/java/server/MATE/domain/test/scheduler/TestAutoCloseScheduler.java
+++ b/src/main/java/server/MATE/domain/test/scheduler/TestAutoCloseScheduler.java
@@ -1,0 +1,21 @@
+package server.MATE.domain.test.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.test.service.TestAutoCloseService;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TestAutoCloseScheduler {
+
+    private final TestAutoCloseService testAutoCloseService;
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void autoCloseExpiredTests() {
+        log.info("테스트 자동 종료 스케줄러 실행");
+        testAutoCloseService.closeExpiredTests();
+    }
+}

--- a/src/main/java/server/MATE/domain/test/service/TestAutoCloseService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestAutoCloseService.java
@@ -1,0 +1,39 @@
+package server.MATE.domain.test.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.repository.TestRepository;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TestAutoCloseService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final TestRepository testRepository;
+    private final TestCloseProcessor testCloseProcessor;
+    private final Clock clock;
+
+    public void closeExpiredTests() {
+        LocalDateTime now = LocalDateTime.now(clock.withZone(KST));
+        List<Test> expiredTests = testRepository.findExpiredInProgressTests(now);
+
+        log.info("자동 종료 대상 테스트: {}개", expiredTests.size());
+
+        for (Test test : expiredTests) {
+            try {
+                testCloseProcessor.process(test.getId());
+            } catch (Exception e) {
+                log.error("테스트 {} 자동 종료 실패", test.getId(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/server/MATE/domain/test/service/TestCloseProcessor.java
+++ b/src/main/java/server/MATE/domain/test/service/TestCloseProcessor.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import server.MATE.domain.payment.repository.PaymentRepository;
 import server.MATE.domain.payment.service.MockPaymentService;
 import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.domain.test.event.TestCompleteEvent;
 import server.MATE.domain.test.repository.TestRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
@@ -27,8 +28,13 @@ public class TestCloseProcessor {
 
     @Transactional
     public void process(Long testId) {
-        Test test = testRepository.findActiveById(testId)
+        Test test = testRepository.findByIdForUpdate(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        if (test.getTestStatus() != TestStatus.IN_PROGRESS) {
+            log.warn("테스트 {} 처리 스킵 - 현재 상태: {}", testId, test.getTestStatus());
+            return;
+        }
 
         long threshold = (long) Math.ceil(test.getGoalPpl() * 0.2);
         test.complete();

--- a/src/main/java/server/MATE/domain/test/service/TestCloseProcessor.java
+++ b/src/main/java/server/MATE/domain/test/service/TestCloseProcessor.java
@@ -1,0 +1,51 @@
+package server.MATE.domain.test.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.payment.repository.PaymentRepository;
+import server.MATE.domain.payment.service.MockPaymentService;
+import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.event.TestCompleteEvent;
+import server.MATE.domain.test.repository.TestRepository;
+import server.MATE.global.common.exception.BaseErrorCode;
+import server.MATE.global.common.exception.BaseException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TestCloseProcessor {
+
+    private static final String REFUND_REASON = "테스트 응답 미달로 인한 자동 환불";
+
+    private final TestRepository testRepository;
+    private final PaymentRepository paymentRepository;
+    private final MockPaymentService mockPaymentService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void process(Long testId) {
+        Test test = testRepository.findActiveById(testId)
+                .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
+
+        long threshold = (long) Math.ceil(test.getGoalPpl() * 0.2);
+        test.complete();
+
+        if (test.getPplCount() < threshold) {
+            log.info("테스트 {} 응답 미달({}명 / 기준 {}명) - 환불 처리", testId, test.getPplCount(), threshold);
+            paymentRepository.findByTestId(testId).ifPresent(payment -> {
+                try {
+                    mockPaymentService.refundPayment(payment.getId(), payment.getMakerId(), REFUND_REASON);
+                } catch (Exception e) {
+                    log.error("테스트 {} 환불 처리 실패 - paymentId={}", testId, payment.getId(), e);
+                }
+            });
+        } else {
+            log.info("테스트 {} 리포트 집계 시작({}명 / 기준 {}명)", testId, test.getPplCount(), threshold);
+            test.startReportAggregation();
+            eventPublisher.publishEvent(new TestCompleteEvent(testId));
+        }
+    }
+}

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -81,15 +81,6 @@ public class TestService {
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
 
         switch (status) {
-            case COMPLETED -> {
-                if (!test.getMakerId().equals(userId)) {
-                    throw new BaseException(BaseErrorCode.COMMON_009);
-                }
-                if (test.getTestStatus() != TestStatus.IN_PROGRESS) {
-                    throw new BaseException(BaseErrorCode.TEST_007);
-                }
-                test.complete();
-            }
             case IN_PROGRESS -> {
                 if (role != Role.ADMIN) {
                     throw new BaseException(BaseErrorCode.COMMON_009);

--- a/src/test/java/server/MATE/domain/test/repository/TestQueryRepositoryImplTest.java
+++ b/src/test/java/server/MATE/domain/test/repository/TestQueryRepositoryImplTest.java
@@ -329,4 +329,70 @@ class TestQueryRepositoryImplTest {
     void findByIdForUpdate_nullId_returnsEmpty() {
         assertThat(testRepository.findByIdForUpdate(null)).isEmpty();
     }
+
+    @Test
+    @DisplayName("findExpiredInProgressTests: IN_PROGRESS 상태이고 closedAt이 지난 테스트를 반환한다")
+    void findExpiredInProgressTests_returnsExpiredTests() {
+        em.getEntityManager()
+                .createQuery("update Test t set t.closedAt = :past where t.id = :id")
+                .setParameter("past", LocalDateTime.now().minusDays(1))
+                .setParameter("id", savedTest.getId())
+                .executeUpdate();
+        em.clear();
+
+        List<server.MATE.domain.test.entity.Test> result =
+                testRepository.findExpiredInProgressTests(LocalDateTime.now());
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(savedTest.getId());
+    }
+
+    @Test
+    @DisplayName("findExpiredInProgressTests: closedAt이 지나지 않은 테스트는 포함하지 않는다")
+    void findExpiredInProgressTests_excludesNotExpiredTests() {
+        List<server.MATE.domain.test.entity.Test> result =
+                testRepository.findExpiredInProgressTests(LocalDateTime.now());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findExpiredInProgressTests: IN_PROGRESS가 아닌 테스트는 포함하지 않는다")
+    void findExpiredInProgressTests_excludesNonInProgressTests() {
+        em.getEntityManager()
+                .createQuery("update Test t set t.closedAt = :past, t.testStatus = :status where t.id = :id")
+                .setParameter("past", LocalDateTime.now().minusDays(1))
+                .setParameter("status", TestStatus.WAITING)
+                .setParameter("id", savedTest.getId())
+                .executeUpdate();
+        em.clear();
+
+        List<server.MATE.domain.test.entity.Test> result =
+                testRepository.findExpiredInProgressTests(LocalDateTime.now());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findExpiredInProgressTests: 삭제된 테스트는 포함하지 않는다")
+    void findExpiredInProgressTests_excludesDeletedTests() {
+        em.getEntityManager()
+                .createQuery("update Test t set t.closedAt = :past, t.deletedAt = :now where t.id = :id")
+                .setParameter("past", LocalDateTime.now().minusDays(1))
+                .setParameter("now", LocalDateTime.now())
+                .setParameter("id", savedTest.getId())
+                .executeUpdate();
+        em.clear();
+
+        List<server.MATE.domain.test.entity.Test> result =
+                testRepository.findExpiredInProgressTests(LocalDateTime.now());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findExpiredInProgressTests: now가 null이면 빈 리스트를 반환한다")
+    void findExpiredInProgressTests_nullNow_returnsEmpty() {
+        assertThat(testRepository.findExpiredInProgressTests(null)).isEmpty();
+    }
 }

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -217,36 +217,14 @@ class TestServiceTest {
     }
 
     @Test
-    void 메이커가_진행_중인_테스트를_종료한다() {
+    void COMPLETED_상태로_변경을_시도하면_예외가_발생한다() {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.IN_PROGRESS);
-        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
-
-        TestStatusUpdateResponse response = testService.updateTestStatus(TEST_ID, MAKER_ID, Role.USER, TestStatus.COMPLETED);
-
-        assertThat(response.testId()).isEqualTo(TEST_ID);
-        assertThat(response.testStatus()).isEqualTo(TestStatus.COMPLETED);
-    }
-
-    @Test
-    void 진행_중이_아닌_테스트를_종료하면_예외가_발생한다() {
-        ReflectionTestUtils.setField(test, "testStatus", TestStatus.WAITING);
         given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
 
         BaseException exception = Assertions.assertThrows(BaseException.class,
                 () -> testService.updateTestStatus(TEST_ID, MAKER_ID, Role.USER, TestStatus.COMPLETED));
 
-        assertThat(exception.getErrorCode()).isEqualTo(BaseErrorCode.TEST_007);
-    }
-
-    @Test
-    void 메이커가_아닌_사용자가_테스트를_종료하면_예외가_발생한다() {
-        ReflectionTestUtils.setField(test, "testStatus", TestStatus.IN_PROGRESS);
-        given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
-
-        BaseException exception = Assertions.assertThrows(BaseException.class,
-                () -> testService.updateTestStatus(TEST_ID, 999L, Role.USER, TestStatus.COMPLETED));
-
-        assertThat(exception.getErrorCode()).isEqualTo(BaseErrorCode.COMMON_009);
+        assertThat(exception.getErrorCode()).isEqualTo(BaseErrorCode.COMMON_002);
     }
 
     @Test


### PR DESCRIPTION
  ## 📍 요약
  - 테스트 마감일(closedAt) 경과 시 스케줄러가 자동으로 테스트 종료 처리
  - 응답자 수 기준으로 전액 환불 또는 리포트 생성 분기 처리
  
  ## 🔗 관련 이슈
  Closes #210
  
  ## 📌 변경 사항
  기능
  
  ## ✅ 작업 내용
  - 메이커의 수동 완료(PATCH /tests/{testId}/status → COMPLETED) 제거
  - 매일 00:00 KST 스케줄러 추가 (TestAutoCloseScheduler)
    - pplCount < goalPpl * 20% → 전액 환불, 리포트 생성 없이 COMPLETED
    - pplCount >= goalPpl * 20% → COMPLETED 후 리포트/PDF/Excel 생성
  - 각 테스트별 독립 트랜잭션 처리 (TestCloseProcessor 분리)
  
  ## 테스트
  로컬 빌드 및 단위 테스트 통과 확인