### PR TITLE
fix: PDF 렌더링 전 Pretendard 폰트 로드 대기 추가

### DIFF
--- a/pdf-server/stats-report.html
+++ b/pdf-server/stats-report.html
@@ -975,6 +975,11 @@ body {
 
 
   // 렌더링 완료 마커 (pdf-server가 이걸 기다렸다가 PDF 생성)
+  try {
+    await document.fonts.ready;
+  } catch (e) {
+    console.error('[stats-report] 폰트 로드 중 오류 발생:', e);
+  }
   document.body.setAttribute('data-rendered', 'true');
   console.log('[stats-report] 렌더링 완료');
 })();


### PR DESCRIPTION
  ## 📍 요약
  - PDF 생성 시 Pretendard 폰트가 로드되기 전에 렌더링이 시작되어 기본 폰트로 출력되는 문제 수정
  
  ## 🔗 관련 이슈
  - Closes #213
  
  ## 📌 변경 사항
  - [x] 버그 수정
  
  ## ✅ 작업 내용
  - `document.fonts.ready` 대기 후 `data-rendered` 마커 설정하도록 수정
  
  ## 테스트
  - [ ] 로컬 테스트 완료
  - 테스트 방법:
    - pdf_key NULL 초기화 후 PDF 다운로드 API 호출하여 Pretendard 폰트 적용 확인