### PR TITLE
refactor: 테스트 참여 조회 조건을 QueryDSL BooleanExpression으로 조합하도록 수정

### DIFF
--- a/src/main/java/server/MATE/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/server/MATE/domain/answer/repository/AnswerRepository.java
@@ -13,8 +13,6 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
     List<Answer> findAllByQuestionIdInAndDeletedAtIsNull(List<Long> questionIds);
 
-    List<Answer> findAllByQuestionIdAndDeletedAtIsNullOrderByParticipationIdAsc(Long questionId);
-
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
             update Answer a

--- a/src/main/java/server/MATE/domain/answer/service/AnswerService.java
+++ b/src/main/java/server/MATE/domain/answer/service/AnswerService.java
@@ -82,7 +82,7 @@ public class AnswerService {
     }
 
     public MyAnswerResponse listMyAnswers(Long testerId) {
-        List<MyAnswerItem> answers = participationRepository.findMyAnswerItemsByTesterIdOrderByCreatedAtDesc(testerId)
+        List<MyAnswerItem> answers = participationRepository.findMyAnswerItemsByTesterId(testerId)
                 .stream()
                 .map(MyAnswerItem::from)
                 .toList();
@@ -102,7 +102,7 @@ public class AnswerService {
 
         test.validateCanParticipate();
 
-        if (participationRepository.existsByTestIdAndTesterIdAndDeletedAtIsNull(testId, testerId)) {
+        if (participationRepository.existsActiveParticipation(testId, testerId)) {
             throw new BaseException(BaseErrorCode.PARTICIPATION_003);
         }
 

--- a/src/main/java/server/MATE/domain/participation/repository/ParticipationQueryRepository.java
+++ b/src/main/java/server/MATE/domain/participation/repository/ParticipationQueryRepository.java
@@ -1,0 +1,17 @@
+package server.MATE.domain.participation.repository;
+
+import server.MATE.domain.answer.dto.response.MyAnswerItemView;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ParticipationQueryRepository {
+
+    boolean existsActiveParticipation(Long testId, Long testerId);
+
+    List<MyAnswerItemView> findMyAnswerItemsByTesterId(Long testerId);
+
+    long softDeleteByTestId(Long testId, LocalDateTime deletedAt);
+
+    long deleteByTestId(Long testId);
+}

--- a/src/main/java/server/MATE/domain/participation/repository/ParticipationQueryRepositoryImpl.java
+++ b/src/main/java/server/MATE/domain/participation/repository/ParticipationQueryRepositoryImpl.java
@@ -1,0 +1,98 @@
+package server.MATE.domain.participation.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import server.MATE.domain.answer.dto.response.MyAnswerItemView;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static server.MATE.domain.participation.entity.QParticipation.participation;
+import static server.MATE.domain.test.entity.QTest.test;
+
+@Repository
+@RequiredArgsConstructor
+public class ParticipationQueryRepositoryImpl implements ParticipationQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private static BooleanExpression participationNotDeleted() {
+        return participation.deletedAt.isNull();
+    }
+
+    private static BooleanExpression testNotDeleted() {
+        return test.deletedAt.isNull();
+    }
+
+    private static BooleanExpression testIdEq(Long testId) {
+        return participation.testId.eq(testId);
+    }
+
+    private static BooleanExpression testerIdEq(Long testerId) {
+        return participation.testerId.eq(testerId);
+    }
+
+    @Override
+    public boolean existsActiveParticipation(Long testId, Long testerId) {
+        if (testId == null || testerId == null) {
+            return false;
+        }
+
+        Integer found = queryFactory
+                .selectOne()
+                .from(participation)
+                .where(testIdEq(testId), testerIdEq(testerId), participationNotDeleted())
+                .fetchFirst();
+
+        return found != null;
+    }
+
+    @Override
+    public List<MyAnswerItemView> findMyAnswerItemsByTesterId(Long testerId) {
+        if (testerId == null) {
+            return List.of();
+        }
+
+        return queryFactory
+                .select(Projections.constructor(
+                        MyAnswerItemView.class,
+                        test.id,
+                        test.title,
+                        participation.createdAt,
+                        test.reward
+                ))
+                .from(participation)
+                .join(test).on(test.id.eq(participation.testId))
+                .where(testerIdEq(testerId), participationNotDeleted(), testNotDeleted())
+                .orderBy(participation.createdAt.desc())
+                .fetch();
+    }
+
+    @Override
+    public long softDeleteByTestId(Long testId, LocalDateTime deletedAt) {
+        if (testId == null || deletedAt == null) {
+            return 0L;
+        }
+
+        return queryFactory
+                .update(participation)
+                .set(participation.deletedAt, deletedAt)
+                .where(testIdEq(testId), participationNotDeleted())
+                .execute();
+    }
+
+    @Override
+    public long deleteByTestId(Long testId) {
+        if (testId == null) {
+            return 0L;
+        }
+
+        return queryFactory
+                .delete(participation)
+                .where(testIdEq(testId))
+                .execute();
+    }
+}

--- a/src/main/java/server/MATE/domain/participation/repository/ParticipationQueryRepositoryImpl.java
+++ b/src/main/java/server/MATE/domain/participation/repository/ParticipationQueryRepositoryImpl.java
@@ -3,6 +3,7 @@ package server.MATE.domain.participation.repository;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import server.MATE.domain.answer.dto.response.MyAnswerItemView;
@@ -18,6 +19,7 @@ import static server.MATE.domain.test.entity.QTest.test;
 public class ParticipationQueryRepositoryImpl implements ParticipationQueryRepository {
 
     private final JPAQueryFactory queryFactory;
+    private final EntityManager em;
 
     private static BooleanExpression participationNotDeleted() {
         return participation.deletedAt.isNull();
@@ -77,11 +79,14 @@ public class ParticipationQueryRepositoryImpl implements ParticipationQueryRepos
             return 0L;
         }
 
-        return queryFactory
+        em.flush();
+        long affected = queryFactory
                 .update(participation)
                 .set(participation.deletedAt, deletedAt)
                 .where(testIdEq(testId), participationNotDeleted())
                 .execute();
+        em.clear();
+        return affected;
     }
 
     @Override
@@ -90,9 +95,12 @@ public class ParticipationQueryRepositoryImpl implements ParticipationQueryRepos
             return 0L;
         }
 
-        return queryFactory
+        em.flush();
+        long affected = queryFactory
                 .delete(participation)
                 .where(testIdEq(testId))
                 .execute();
+        em.clear();
+        return affected;
     }
 }

--- a/src/main/java/server/MATE/domain/participation/repository/ParticipationRepository.java
+++ b/src/main/java/server/MATE/domain/participation/repository/ParticipationRepository.java
@@ -1,52 +1,7 @@
 package server.MATE.domain.participation.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import server.MATE.domain.answer.dto.response.MyAnswerItemView;
 import server.MATE.domain.participation.entity.Participation;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
-public interface ParticipationRepository extends JpaRepository<Participation, Long> {
-
-    boolean existsByTestIdAndTesterIdAndDeletedAtIsNull(Long testId, Long testerId);
-
-    List<Participation> findAllByTestIdAndDeletedAtIsNull(Long testId);
-
-    @Query("""
-            select new server.MATE.domain.answer.dto.response.MyAnswerItemView(
-                t.id,
-                t.title,
-                p.createdAt,
-                t.reward
-            )
-            from Participation p
-            join Test t on t.id = p.testId
-            where p.testerId = :testerId
-              and p.deletedAt is null
-              and t.deletedAt is null
-            order by p.createdAt desc
-            """)
-    List<MyAnswerItemView> findMyAnswerItemsByTesterIdOrderByCreatedAtDesc(@Param("testerId") Long testerId);
-
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("""
-            update Participation p
-            set p.deletedAt = :deletedAt
-            where p.testId = :testId
-              and p.deletedAt is null
-            """)
-    int softDeleteAllByTestId(@Param("testId") Long testId, @Param("deletedAt") LocalDateTime deletedAt);
-
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("""
-            delete
-            from Participation p
-            where p.testId = :testId
-            """)
-    int deleteAllByTestId(@Param("testId") Long testId);
+public interface ParticipationRepository extends JpaRepository<Participation, Long>, ParticipationQueryRepository {
 }

--- a/src/main/java/server/MATE/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/server/MATE/domain/payment/repository/PaymentRepository.java
@@ -14,8 +14,6 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     Optional<Payment> findByIdAndMakerId(Long id, Long makerId);
 
-    Optional<Payment> findByOrderNo(String orderNo);
-
     Optional<Payment> findByDraftId(Long draftId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/server/MATE/domain/report/repository/ReportRepository.java
+++ b/src/main/java/server/MATE/domain/report/repository/ReportRepository.java
@@ -21,23 +21,6 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     List<Report> findAllByTestId(@Param("testId") Long testId);
 
     @Query("""
-            select r
-            from Report r
-            where r.testId = :testId
-              and r.questionId = :questionId
-              and r.deletedAt is null
-            """)
-    Optional<Report> findByTestIdAndQuestionId(@Param("testId") Long testId, @Param("questionId") Long questionId);
-
-    @Query("""
-            select (count(r) > 0)
-            from Report r
-            where r.testId = :testId
-              and r.deletedAt is null
-            """)
-    boolean existsByTestId(@Param("testId") Long testId);
-
-    @Query("""
             select count(r)
             from Report r
             where r.testId = :testId

--- a/src/main/java/server/MATE/domain/test/service/TestDeleteService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestDeleteService.java
@@ -86,7 +86,7 @@ public class TestDeleteService {
         if (!questionIds.isEmpty()) {
             answerRepository.softDeleteAllByQuestionIds(questionIds, deletedAt);
         }
-        participationRepository.softDeleteAllByTestId(testId, deletedAt);
+        participationRepository.softDeleteByTestId(testId, deletedAt);
         questionRepository.softDeleteByTestId(testId, deletedAt);
         testRepository.softDeleteById(testId, deletedAt);
     }
@@ -112,7 +112,7 @@ public class TestDeleteService {
             questionRepository.deleteAllInBatch(questions);
         }
         testCategoryRepository.deleteAllByTestId(test.getId());
-        participationRepository.deleteAllByTestId(test.getId());
+        participationRepository.deleteByTestId(test.getId());
         paymentRepository.deleteAllByTestId(test.getId());
         testRepository.delete(test);
 

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -72,7 +72,7 @@ public class TestService {
     public TestDetailResponse getTest(Long testId, Long userId) {
         Test test = testRepository.findWithCategoriesById(testId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.TEST_004));
-        boolean hasResponded = participationRepository.existsByTestIdAndTesterIdAndDeletedAtIsNull(testId, userId);
+        boolean hasResponded = participationRepository.existsActiveParticipation(testId, userId);
         return TestDetailResponse.from(test, toImageUrls(test.getImageKeys()), hasResponded);
     }
 

--- a/src/test/java/server/MATE/domain/answer/service/AnswerServiceTest.java
+++ b/src/test/java/server/MATE/domain/answer/service/AnswerServiceTest.java
@@ -141,7 +141,7 @@ class AnswerServiceTest {
                 .build();
 
         given(testRepository.findByIdForUpdate(TEST_ID)).willReturn(Optional.of(test));
-        given(participationRepository.existsByTestIdAndTesterIdAndDeletedAtIsNull(TEST_ID, TESTER_ID)).willReturn(false);
+        given(participationRepository.existsActiveParticipation(TEST_ID, TESTER_ID)).willReturn(false);
         given(questionRepository.findAnswerQuestionTypesInTest(TEST_ID)).willReturn(List.of(
                 new AnswerQuestionTypeView(QUESTION_ID, QuestionType.SUBJECTIVE)
         ));

--- a/src/test/java/server/MATE/domain/participation/repository/ParticipationQueryRepositoryImplTest.java
+++ b/src/test/java/server/MATE/domain/participation/repository/ParticipationQueryRepositoryImplTest.java
@@ -1,0 +1,281 @@
+package server.MATE.domain.participation.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import server.MATE.domain.answer.dto.response.MyAnswerItemView;
+import server.MATE.domain.participation.entity.Participation;
+import server.MATE.domain.test.entity.TestStatus;
+import server.MATE.global.config.ClockConfig;
+import server.MATE.global.config.JpaAuditingConfig;
+import server.MATE.global.config.QuerydslConfig;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({QuerydslConfig.class, ClockConfig.class, JpaAuditingConfig.class})
+class ParticipationQueryRepositoryImplTest {
+
+    private static final Long TESTER_ID = 20L;
+    private static final Long OTHER_TESTER_ID = 21L;
+
+    @Autowired
+    private ParticipationRepository participationRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    @DisplayName("existsActiveParticipation: 삭제되지 않은 참여가 있으면 true를 반환한다")
+    void existsActiveParticipation_returnsTrue() {
+        server.MATE.domain.test.entity.Test test = persistTest("테스트 A");
+        em.persistAndFlush(Participation.builder()
+                .testId(test.getId())
+                .testerId(TESTER_ID)
+                .build());
+        em.clear();
+
+        boolean result = participationRepository.existsActiveParticipation(test.getId(), TESTER_ID);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("existsActiveParticipation: 삭제된 참여나 다른 testId testerId는 제외한다")
+    void existsActiveParticipation_excludesDeletedOrDifferentParticipation() {
+        server.MATE.domain.test.entity.Test test = persistTest("테스트 A");
+        server.MATE.domain.test.entity.Test otherTest = persistTest("테스트 B");
+        Participation deletedParticipation = em.persistAndFlush(Participation.builder()
+                .testId(test.getId())
+                .testerId(TESTER_ID)
+                .build());
+        em.persistAndFlush(Participation.builder()
+                .testId(otherTest.getId())
+                .testerId(TESTER_ID)
+                .build());
+        em.persistAndFlush(Participation.builder()
+                .testId(test.getId())
+                .testerId(OTHER_TESTER_ID)
+                .build());
+        markParticipationDeleted(deletedParticipation.getId(), LocalDateTime.now());
+        em.clear();
+
+        assertThat(participationRepository.existsActiveParticipation(test.getId(), TESTER_ID)).isFalse();
+        assertThat(participationRepository.existsActiveParticipation(test.getId(), OTHER_TESTER_ID)).isTrue();
+        assertThat(participationRepository.existsActiveParticipation(otherTest.getId(), TESTER_ID)).isTrue();
+    }
+
+    @Test
+    @DisplayName("existsActiveParticipation: 필수 인자가 없으면 false를 반환한다")
+    void existsActiveParticipation_missingRequiredArgs_returnsFalse() {
+        assertThat(participationRepository.existsActiveParticipation(null, TESTER_ID)).isFalse();
+        server.MATE.domain.test.entity.Test test = persistTest("테스트 A");
+        assertThat(participationRepository.existsActiveParticipation(test.getId(), null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("findMyAnswerItemsByTesterId: createdAt 내림차순으로 projection을 반환한다")
+    void findMyAnswerItemsByTesterId_returnsProjectionOrderedByCreatedAtDesc() {
+        server.MATE.domain.test.entity.Test firstTest = persistTest("첫 번째 테스트");
+        server.MATE.domain.test.entity.Test secondTest = persistTest("두 번째 테스트");
+
+        Participation olderParticipation = em.persistAndFlush(Participation.builder()
+                .testId(firstTest.getId())
+                .testerId(TESTER_ID)
+                .build());
+        Participation newerParticipation = em.persistAndFlush(Participation.builder()
+                .testId(secondTest.getId())
+                .testerId(TESTER_ID)
+                .build());
+
+        updateParticipationCreatedAt(olderParticipation.getId(), LocalDateTime.of(2026, 5, 1, 10, 0));
+        updateParticipationCreatedAt(newerParticipation.getId(), LocalDateTime.of(2026, 5, 2, 10, 0));
+        em.clear();
+
+        List<MyAnswerItemView> result = participationRepository.findMyAnswerItemsByTesterId(TESTER_ID);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(MyAnswerItemView::testId).containsExactly(secondTest.getId(), firstTest.getId());
+        assertThat(result).extracting(MyAnswerItemView::testName).containsExactly("두 번째 테스트", "첫 번째 테스트");
+        assertThat(result).extracting(MyAnswerItemView::reward).containsExactly(300, 300);
+    }
+
+    @Test
+    @DisplayName("findMyAnswerItemsByTesterId: 삭제된 participation과 삭제된 test는 제외한다")
+    void findMyAnswerItemsByTesterId_excludesDeletedData() {
+        server.MATE.domain.test.entity.Test activeTest = persistTest("활성 테스트");
+        server.MATE.domain.test.entity.Test deletedTest = persistTest("삭제 테스트");
+
+        Participation activeParticipation = em.persistAndFlush(Participation.builder()
+                .testId(activeTest.getId())
+                .testerId(TESTER_ID)
+                .build());
+        Participation deletedParticipation = em.persistAndFlush(Participation.builder()
+                .testId(activeTest.getId())
+                .testerId(OTHER_TESTER_ID)
+                .build());
+        Participation participationOnDeletedTest = em.persistAndFlush(Participation.builder()
+                .testId(deletedTest.getId())
+                .testerId(TESTER_ID)
+                .build());
+
+        updateParticipationCreatedAt(activeParticipation.getId(), LocalDateTime.of(2026, 5, 3, 10, 0));
+        updateParticipationCreatedAt(deletedParticipation.getId(), LocalDateTime.of(2026, 5, 4, 10, 0));
+        updateParticipationCreatedAt(participationOnDeletedTest.getId(), LocalDateTime.of(2026, 5, 5, 10, 0));
+        markParticipationDeleted(deletedParticipation.getId(), LocalDateTime.now());
+        markTestDeleted(deletedTest.getId(), LocalDateTime.now());
+        em.clear();
+
+        List<MyAnswerItemView> result = participationRepository.findMyAnswerItemsByTesterId(TESTER_ID);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().testId()).isEqualTo(activeTest.getId());
+        assertThat(result.getFirst().testName()).isEqualTo("활성 테스트");
+    }
+
+    @Test
+    @DisplayName("findMyAnswerItemsByTesterId: testerId가 없으면 빈 리스트를 반환한다")
+    void findMyAnswerItemsByTesterId_missingTesterId_returnsEmpty() {
+        assertThat(participationRepository.findMyAnswerItemsByTesterId(null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("softDeleteByTestId: 해당 테스트의 삭제되지 않은 참여만 논리삭제한다")
+    void softDeleteByTestId_updatesOnlyActiveParticipationsInTest() {
+        server.MATE.domain.test.entity.Test test = persistTest("테스트 A");
+        server.MATE.domain.test.entity.Test otherTest = persistTest("테스트 B");
+
+        Participation activeParticipation1 = em.persistAndFlush(Participation.builder()
+                .testId(test.getId())
+                .testerId(TESTER_ID)
+                .build());
+        Participation activeParticipation2 = em.persistAndFlush(Participation.builder()
+                .testId(test.getId())
+                .testerId(OTHER_TESTER_ID)
+                .build());
+        Participation alreadyDeletedParticipation = em.persistAndFlush(Participation.builder()
+                .testId(test.getId())
+                .testerId(30L)
+                .build());
+        Participation otherTestParticipation = em.persistAndFlush(Participation.builder()
+                .testId(otherTest.getId())
+                .testerId(TESTER_ID)
+                .build());
+
+        LocalDateTime deletedAt = LocalDateTime.of(2026, 6, 2, 12, 0);
+        markParticipationDeleted(alreadyDeletedParticipation.getId(), LocalDateTime.of(2026, 6, 1, 12, 0));
+        em.clear();
+
+        long updatedCount = participationRepository.softDeleteByTestId(test.getId(), deletedAt);
+        em.clear();
+
+        assertThat(updatedCount).isEqualTo(2L);
+        assertThat(findParticipationDeletedAt(activeParticipation1.getId())).isEqualTo(deletedAt);
+        assertThat(findParticipationDeletedAt(activeParticipation2.getId())).isEqualTo(deletedAt);
+        assertThat(findParticipationDeletedAt(alreadyDeletedParticipation.getId()))
+                .isEqualTo(LocalDateTime.of(2026, 6, 1, 12, 0));
+        assertThat(findParticipationDeletedAt(otherTestParticipation.getId())).isNull();
+    }
+
+    @Test
+    @DisplayName("softDeleteByTestId: 필수 인자가 없으면 0을 반환한다")
+    void softDeleteByTestId_missingRequiredArgs_returnsZero() {
+        assertThat(participationRepository.softDeleteByTestId(null, LocalDateTime.now())).isZero();
+        server.MATE.domain.test.entity.Test test = persistTest("테스트 A");
+        assertThat(participationRepository.softDeleteByTestId(test.getId(), null)).isZero();
+    }
+
+    @Test
+    @DisplayName("deleteByTestId: 해당 테스트의 참여만 모두 삭제한다")
+    void deleteByTestId_deletesParticipationsInTest() {
+        server.MATE.domain.test.entity.Test test = persistTest("테스트 A");
+        server.MATE.domain.test.entity.Test otherTest = persistTest("테스트 B");
+        em.persistAndFlush(Participation.builder()
+                .testId(test.getId())
+                .testerId(TESTER_ID)
+                .build());
+        em.persistAndFlush(Participation.builder()
+                .testId(test.getId())
+                .testerId(OTHER_TESTER_ID)
+                .build());
+        em.persistAndFlush(Participation.builder()
+                .testId(otherTest.getId())
+                .testerId(TESTER_ID)
+                .build());
+        em.clear();
+
+        long deletedCount = participationRepository.deleteByTestId(test.getId());
+        em.clear();
+
+        assertThat(deletedCount).isEqualTo(2L);
+        assertThat(countParticipationsByTestId(test.getId())).isZero();
+        assertThat(countParticipationsByTestId(otherTest.getId())).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("deleteByTestId: testId가 없으면 0을 반환한다")
+    void deleteByTestId_missingTestId_returnsZero() {
+        assertThat(participationRepository.deleteByTestId(null)).isZero();
+    }
+
+    private server.MATE.domain.test.entity.Test persistTest(String title) {
+        return em.persistAndFlush(
+                server.MATE.domain.test.entity.Test.builder()
+                        .makerId(1L)
+                        .title(title)
+                        .description("설명")
+                        .serviceName("서비스")
+                        .serviceDescription("서비스 설명")
+                        .goalPpl(10)
+                        .reward(300)
+                        .testStatus(TestStatus.IN_PROGRESS)
+                        .closedAt(LocalDateTime.now().plusDays(7))
+                        .build()
+        );
+    }
+
+    private void updateParticipationCreatedAt(Long participationId, LocalDateTime createdAt) {
+        em.getEntityManager()
+                .createNativeQuery("update participation set created_at = ? where id = ?")
+                .setParameter(1, createdAt)
+                .setParameter(2, participationId)
+                .executeUpdate();
+    }
+
+    private void markParticipationDeleted(Long participationId, LocalDateTime deletedAt) {
+        em.getEntityManager()
+                .createQuery("update Participation p set p.deletedAt = :deletedAt where p.id = :id")
+                .setParameter("deletedAt", deletedAt)
+                .setParameter("id", participationId)
+                .executeUpdate();
+    }
+
+    private void markTestDeleted(Long testId, LocalDateTime deletedAt) {
+        em.getEntityManager()
+                .createQuery("update Test t set t.deletedAt = :deletedAt where t.id = :id")
+                .setParameter("deletedAt", deletedAt)
+                .setParameter("id", testId)
+                .executeUpdate();
+    }
+
+    private LocalDateTime findParticipationDeletedAt(Long participationId) {
+        return em.getEntityManager()
+                .createQuery("select p.deletedAt from Participation p where p.id = :id", LocalDateTime.class)
+                .setParameter("id", participationId)
+                .getSingleResult();
+    }
+
+    private long countParticipationsByTestId(Long testId) {
+        Long count = em.getEntityManager()
+                .createQuery("select count(p) from Participation p where p.testId = :testId", Long.class)
+                .setParameter("testId", testId)
+                .getSingleResult();
+        return count == null ? 0L : count;
+    }
+}

--- a/src/test/java/server/MATE/domain/test/service/TestDeleteServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestDeleteServiceTest.java
@@ -125,7 +125,7 @@ class TestDeleteServiceTest {
 
         verify(reportRepository).softDeleteAllByTestId(eq(TEST_ID), any(LocalDateTime.class));
         verify(answerRepository).softDeleteAllByQuestionIds(eq(List.of(101L)), any(LocalDateTime.class));
-        verify(participationRepository).softDeleteAllByTestId(eq(TEST_ID), any(LocalDateTime.class));
+        verify(participationRepository).softDeleteByTestId(eq(TEST_ID), any(LocalDateTime.class));
         verify(questionRepository).softDeleteByTestId(eq(TEST_ID), any(LocalDateTime.class));
         verify(testCategoryRepository, never()).softDeleteAllByTestId(anyLong(), any(LocalDateTime.class));
         verify(testRepository).softDeleteById(eq(TEST_ID), any(LocalDateTime.class));
@@ -152,7 +152,7 @@ class TestDeleteServiceTest {
         verify(subjectiveRepository).deleteAllInBatch(anyList());
         verify(questionRepository).deleteAllInBatch(anyList());
         verify(testCategoryRepository).deleteAllByTestId(TEST_ID);
-        verify(participationRepository).deleteAllByTestId(TEST_ID);
+        verify(participationRepository).deleteByTestId(TEST_ID);
         verify(paymentRepository).deleteAllByTestId(TEST_ID);
         verify(testRepository).delete(test);
 

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -113,7 +113,7 @@ class TestServiceTest {
     void 테스트_상세_조회_시_상태와_응답_여부를_반환한다() {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.IN_PROGRESS);
         given(testRepository.findWithCategoriesById(TEST_ID)).willReturn(Optional.of(test));
-        given(participationRepository.existsByTestIdAndTesterIdAndDeletedAtIsNull(TEST_ID, MAKER_ID))
+        given(participationRepository.existsActiveParticipation(TEST_ID, MAKER_ID))
                 .willReturn(true);
 
         TestDetailResponse response = testService.getTest(TEST_ID, MAKER_ID);
@@ -127,7 +127,7 @@ class TestServiceTest {
     void 종료된_테스트_상세_조회_시_상태를_반환한다() {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.COMPLETED);
         given(testRepository.findWithCategoriesById(TEST_ID)).willReturn(Optional.of(test));
-        given(participationRepository.existsByTestIdAndTesterIdAndDeletedAtIsNull(TEST_ID, MAKER_ID))
+        given(participationRepository.existsActiveParticipation(TEST_ID, MAKER_ID))
                 .willReturn(false);
 
         TestDetailResponse response = testService.getTest(TEST_ID, MAKER_ID);


### PR DESCRIPTION
## 📍 요약
- 테스트 참여 조회를 QueryDSL 구조로 분리하여 공통 조건을 조합하도록 구조를 수정

## 🔗 관련 이슈
- Closes #212 

## 📌 변경 사항
- [ ] 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 설명해주세요 -->
- ParticipationRepository를 JpaRepository와 Custom Query Repository 구조로 분리
- ParticipationQueryRepositoryImpl에서 공통 조회 조건을 BooleanExpression 메서드로 분리함
- 테스트 ID, 삭제 여부 같은 조건을 조합해 조회할 수 있도록 구조를 개선

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew compileJava compileTestJava
  - ./gradlew test --tests "server.MATE.domain.participation.repository.ParticipationQueryRepositoryImplTest" --tests "server.MATE.domain.answer.service.AnswerServiceTest" --tests "server.MATE.domain.test.service.TestServiceTest" --tests "server.MATE.domain.test.service.TestDeleteServiceTest"
