### PR TITLE
feat: PDF 리포트 다운로드 응답을 URL에서 binary로 변경

### DIFF
--- a/src/main/java/server/MATE/domain/report/controller/ReportController.java
+++ b/src/main/java/server/MATE/domain/report/controller/ReportController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -427,9 +428,12 @@ public class ReportController {
             @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization
     ) {
         TestReportPdfDownload download = testReportPdfService.export(testId, user.getId(), authorization);
+        ContentDisposition contentDisposition = ContentDisposition.attachment()
+                .filename(download.filename(), java.nio.charset.StandardCharsets.UTF_8)
+                .build();
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_PDF)
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + download.filename() + "\"")
+                .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString())
                 .body(download.data());
     }
 }

--- a/src/main/java/server/MATE/domain/report/controller/ReportController.java
+++ b/src/main/java/server/MATE/domain/report/controller/ReportController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -413,20 +414,22 @@ public class ReportController {
     @Operation(
             summary = "➰ 리포트 통계 PDF 파일 다운로드",
             description = """
-                    테스트 전체 리포트 PDF의 다운로드 URL을 반환합니다.
+                    테스트 전체 리포트 PDF 파일을 binary로 반환합니다.
                     - 테스트 메이커만 다운로드할 수 있습니다.
                     - 테스트 종료 및 리포트 집계 완료(`report_status = COMPLETED`) 후 다운로드 가능합니다.
-                    - 최초 요청 시 PDF를 생성해 Blob Storage에 저장하고, 이후 요청은 저장된 파일의 URL을 반환합니다.
-                    - 반환된 URL은 30분간 유효합니다.
+                    - 최초 요청 시 PDF를 생성해 Blob Storage에 저장하고, 이후 요청은 저장된 파일을 binary로 반환합니다.
                     """
     )
     @GetMapping("/pdf")
-    public ResponseEntity<ApiResponse<String>> downloadPdfReport(
+    public ResponseEntity<byte[]> downloadPdfReport(
             @PathVariable Long testId,
             @AuthenticationPrincipal AuthenticatedUser user,
             @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization
     ) {
         TestReportPdfDownload download = testReportPdfService.export(testId, user.getId(), authorization);
-        return ResponseEntity.ok(ApiResponse.ok("PDF 다운로드 URL이 발급되었습니다.", download.downloadUrl()));
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_PDF)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + download.filename() + "\"")
+                .body(download.data());
     }
 }

--- a/src/main/java/server/MATE/domain/report/dto/response/TestReportExcelDownload.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/TestReportExcelDownload.java
@@ -1,7 +1,6 @@
 package server.MATE.domain.report.dto.response;
 
 public record TestReportExcelDownload(
-        String downloadUrl,
-        String filename
+        String downloadUrl
 ) {
 }

--- a/src/main/java/server/MATE/domain/report/dto/response/TestReportPdfDownload.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/TestReportPdfDownload.java
@@ -1,7 +1,7 @@
 package server.MATE.domain.report.dto.response;
 
 public record TestReportPdfDownload(
-        String downloadUrl,
+        byte[] data,
         String filename
 ) {
 }

--- a/src/main/java/server/MATE/domain/report/service/excel/TestReportExcelService.java
+++ b/src/main/java/server/MATE/domain/report/service/excel/TestReportExcelService.java
@@ -21,8 +21,7 @@ public class TestReportExcelService {
 
         if (test.getExcelKey() != null) {
             return new TestReportExcelDownload(
-                    fileStorageService.generateDownloadUrl(test.getExcelKey(), filename),
-                    filename
+                    fileStorageService.generateDownloadUrl(test.getExcelKey(), filename)
             );
         }
 
@@ -32,8 +31,7 @@ public class TestReportExcelService {
         reportExcelExportSupport.saveExcelKey(testId, excelKey);
 
         return new TestReportExcelDownload(
-                fileStorageService.generateDownloadUrl(excelKey, filename),
-                filename
+                fileStorageService.generateDownloadUrl(excelKey, filename)
         );
     }
 

--- a/src/main/java/server/MATE/domain/report/service/pdf/TestReportPdfService.java
+++ b/src/main/java/server/MATE/domain/report/service/pdf/TestReportPdfService.java
@@ -48,10 +48,7 @@ public class TestReportPdfService {
         String filename = buildFilename(testId);
 
         if (test.getPdfKey() != null) {
-            return new TestReportPdfDownload(
-                    fileStorageService.generateDownloadUrl(test.getPdfKey(), filename),
-                    filename
-            );
+            return new TestReportPdfDownload(fileStorageService.download(test.getPdfKey()), filename);
         }
 
         if (authorization == null || authorization.isBlank()) {
@@ -63,10 +60,7 @@ public class TestReportPdfService {
         fileStorageService.upload(pdfKey, pdfBytes, "application/pdf");
         reportExcelExportSupport.savePdfKey(testId, pdfKey);
 
-        return new TestReportPdfDownload(
-                fileStorageService.generateDownloadUrl(pdfKey, filename),
-                filename
-        );
+        return new TestReportPdfDownload(pdfBytes, filename);
     }
 
     private byte[] generatePdf(Long testId, String title, String authorization) {

--- a/src/main/java/server/MATE/global/storage/AzureBlobFileStorageService.java
+++ b/src/main/java/server/MATE/global/storage/AzureBlobFileStorageService.java
@@ -92,6 +92,12 @@ public class AzureBlobFileStorageService implements FileStorageService {
         blobClient.uploadWithResponse(options, null, null);
     }
 
+    @Override
+    public byte[] download(String key) {
+        BlobClient blobClient = getContainerClient(key).getBlobClient(key);
+        return blobClient.downloadContent().toBytes();
+    }
+
     private BlobContainerClient getContainerClient(String key) {
         return isPublic(key) ? publicContainerClient : privateContainerClient;
     }

--- a/src/main/java/server/MATE/global/storage/FileStorageService.java
+++ b/src/main/java/server/MATE/global/storage/FileStorageService.java
@@ -8,4 +8,5 @@ public interface FileStorageService {
     String generateDownloadUrl(String key, String downloadFilename);
     void deleteFiles(List<String> keys);
     void upload(String key, byte[] content, String contentType);
+    byte[] download(String key);
 }

--- a/src/main/java/server/MATE/global/storage/NoopFileStorageService.java
+++ b/src/main/java/server/MATE/global/storage/NoopFileStorageService.java
@@ -37,4 +37,9 @@ public class NoopFileStorageService implements FileStorageService {
     public void upload(String key, byte[] content, String contentType) {
         // storage가 비활성화된 환경에서는 업로드 작업을 수행하지 않는다.
     }
+
+    @Override
+    public byte[] download(String key) {
+        return new byte[0];
+    }
 }

--- a/src/test/java/server/MATE/domain/report/service/excel/TestReportExcelServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/excel/TestReportExcelServiceTest.java
@@ -45,7 +45,7 @@ class TestReportExcelServiceTest {
         );
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void excelKey가_없으면_생성_후_업로드하고_URL을_반환한다() {
         server.MATE.domain.test.entity.Test test = completedTest(null);
         String filename = "mate-report-" + TEST_ID + ".xlsx";
@@ -66,7 +66,7 @@ class TestReportExcelServiceTest {
         verify(reportExcelExportSupport).saveExcelKey(TEST_ID, "reports/excel/" + TEST_ID + ".xlsx");
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void excelKey가_있으면_재생성_없이_캐싱된_URL을_반환한다() {
         server.MATE.domain.test.entity.Test test = completedTest("reports/excel/" + TEST_ID + ".xlsx");
         String filename = "mate-report-" + TEST_ID + ".xlsx";

--- a/src/test/java/server/MATE/domain/report/service/excel/TestReportExcelServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/excel/TestReportExcelServiceTest.java
@@ -57,7 +57,6 @@ class TestReportExcelServiceTest {
         TestReportExcelDownload result = testReportExcelService.export(TEST_ID, MAKER_ID);
 
         assertThat(result.downloadUrl()).isEqualTo("https://blob.example.com/reports/excel/" + TEST_ID + ".xlsx");
-        assertThat(result.filename()).isEqualTo(filename);
         verify(fileStorageService).upload(
                 eq("reports/excel/" + TEST_ID + ".xlsx"),
                 eq(new byte[]{1, 2, 3}),
@@ -77,7 +76,6 @@ class TestReportExcelServiceTest {
         TestReportExcelDownload result = testReportExcelService.export(TEST_ID, MAKER_ID);
 
         assertThat(result.downloadUrl()).isEqualTo("https://blob.example.com/cached.xlsx");
-        assertThat(result.filename()).isEqualTo(filename);
         verify(combinedTestReportExcelService, never()).export(any(), any());
         verify(fileStorageService, never()).upload(any(), any(byte[].class), any());
     }

--- a/src/test/java/server/MATE/domain/report/service/pdf/TestReportPdfServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/pdf/TestReportPdfServiceTest.java
@@ -1,0 +1,88 @@
+package server.MATE.domain.report.service.pdf;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import server.MATE.domain.report.config.MatePdfProperties;
+import server.MATE.domain.report.dto.response.TestReportPdfDownload;
+import server.MATE.domain.report.service.excel.support.ReportExcelExportSupport;
+import server.MATE.domain.test.entity.ReportStatus;
+import server.MATE.domain.test.entity.TestStatus;
+import server.MATE.global.storage.FileStorageService;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TestReportPdfServiceTest {
+
+    private static final Long TEST_ID = 10L;
+    private static final Long MAKER_ID = 1L;
+    private static final String AUTHORIZATION = "Bearer token";
+
+    @Mock
+    private ReportExcelExportSupport reportExcelExportSupport;
+    @Mock
+    private FileStorageService fileStorageService;
+    @Mock
+    private WebClient matePdfWebClient;
+    @Mock
+    private MatePdfProperties matePdfProperties;
+
+    private TestReportPdfService testReportPdfService;
+
+    @BeforeEach
+    void setUp() {
+        testReportPdfService = new TestReportPdfService(
+                reportExcelExportSupport,
+                new ObjectMapper(),
+                matePdfProperties,
+                matePdfWebClient,
+                fileStorageService
+        );
+    }
+
+    @Test
+    void pdfKey가_있으면_재생성_없이_캐싱된_bytes를_반환한다() {
+        String pdfKey = "reports/pdf/" + TEST_ID + ".pdf";
+        server.MATE.domain.test.entity.Test test = completedTest(pdfKey);
+        byte[] cachedBytes = new byte[]{1, 2, 3};
+        given(reportExcelExportSupport.requireExportReadyTest(TEST_ID, MAKER_ID)).willReturn(test);
+        given(fileStorageService.download(pdfKey)).willReturn(cachedBytes);
+
+        TestReportPdfDownload result = testReportPdfService.export(TEST_ID, MAKER_ID, AUTHORIZATION);
+
+        assertThat(result.data()).isEqualTo(cachedBytes);
+        assertThat(result.filename()).isEqualTo("mate-report-" + TEST_ID + ".pdf");
+        verify(fileStorageService, never()).upload(any(), any(byte[].class), any());
+        verify(matePdfWebClient, never()).get();
+    }
+
+    private server.MATE.domain.test.entity.Test completedTest(String pdfKey) {
+        server.MATE.domain.test.entity.Test test = server.MATE.domain.test.entity.Test.builder()
+                .makerId(MAKER_ID)
+                .title("테스트")
+                .description("설명")
+                .goalPpl(10)
+                .testStatus(TestStatus.COMPLETED)
+                .closedAt(LocalDateTime.of(2026, 6, 1, 23, 59, 59))
+                .build();
+        ReflectionTestUtils.setField(test, "id", TEST_ID);
+        ReflectionTestUtils.setField(test, "reportStatus", ReportStatus.COMPLETED);
+        if (pdfKey != null) {
+            test.savePdfKey(pdfKey);
+        }
+        return test;
+    }
+}


### PR DESCRIPTION
  ## 📍 요약
  - PDF 리포트 다운로드 API 응답을 Azure Blob SAS URL에서 binary(byte[]) 직접 응답으로 변경 (엑셀은 URL 방식 유지)

  ## 🔗 관련 이슈
  - Closes #218

  ## 📌 변경 사항
  - [x] 기능
  - [ ] 버그 수정
  - [ ] 리팩토링
  - [ ] 문서
  - [x] 테스트
  - [ ] 기타

  ## ✅ 작업 내용
  - `FileStorageService` / `AzureBlobFileStorageService` / `NoopFileStorageService` - `download(key)` 메서드 추가
  - `TestReportPdfDownload` - `downloadUrl` → `byte[] data`로 변경
  - `TestReportPdfService` - 캐시 히트 시 Blob에서 bytes 반환, 미스 시 생성 후 업로드 + bytes 반환
  - `ReportController` - PDF 엔드포인트 `ResponseEntity<byte[]>` + `Content-Type`, `Content-Disposition` 헤더 설정
  - `TestReportPdfServiceTest` 신규 추가 (캐시 히트 케이스 검증)

  ## 테스트
  - [x] 로컬 테스트 완료
  - 테스트 방법:
    - `./gradlew test`