### PR TITLE
fix: 엑셀 다운로드 응답 방식을 URL에서 바이너리로 변경

### DIFF
--- a/src/main/java/server/MATE/domain/report/controller/ReportController.java
+++ b/src/main/java/server/MATE/domain/report/controller/ReportController.java
@@ -393,23 +393,28 @@ public class ReportController {
     @Operation(
             summary = "➰ 리포트 통계 xlsx 파일 다운로드",
             description = """
-                    테스트 전체 리포트 엑셀의 다운로드 URL을 반환합니다.
+                    테스트 전체 리포트 엑셀 파일을 binary로 반환합니다.
                     - 테스트 메이커만 다운로드할 수 있습니다.
                     - 테스트 종료 및 리포트 집계 완료(`report_status = COMPLETED`) 후 다운로드 가능합니다.
                     - 시트 구성: 기본 정보, 마스터 템플릿, 객관식, 주관식, AB 테스트, 척도 테스트, 카드소팅, 트리테스트, 5초 테스트
                     - 질문 유형별 시트에는 해당 테스트에 포함된 질문 통계가 순서대로 기록됩니다.
                     - 5초 테스트는 객관/주관 설정에 따라 시트 내 템플릿이 달라집니다.
-                    - 최초 요청 시 엑셀을 생성해 Blob Storage에 저장하고, 이후 요청은 저장된 파일의 URL을 반환합니다.
-                    - 반환된 URL은 30분간 유효합니다.
+                    - 최초 요청 시 엑셀을 생성해 Blob Storage에 저장하고, 이후 요청은 저장된 파일을 binary로 반환합니다.
                     """
     )
     @GetMapping("/excel")
-    public ResponseEntity<ApiResponse<String>> downloadExcelReport(
+    public ResponseEntity<byte[]> downloadExcelReport(
             @PathVariable Long testId,
             @AuthenticationPrincipal AuthenticatedUser user
     ) {
         TestReportExcelDownload download = testReportExcelService.export(testId, user.getId());
-        return ResponseEntity.ok(ApiResponse.ok("엑셀 다운로드 URL이 발급되었습니다.", download.downloadUrl()));
+        ContentDisposition contentDisposition = ContentDisposition.attachment()
+                .filename(download.filename(), java.nio.charset.StandardCharsets.UTF_8)
+                .build();
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString())
+                .body(download.data());
     }
 
     @Operation(

--- a/src/main/java/server/MATE/domain/report/dto/response/TestReportExcelDownload.java
+++ b/src/main/java/server/MATE/domain/report/dto/response/TestReportExcelDownload.java
@@ -1,6 +1,7 @@
 package server.MATE.domain.report.dto.response;
 
 public record TestReportExcelDownload(
-        String downloadUrl
+        byte[] data,
+        String filename
 ) {
 }

--- a/src/main/java/server/MATE/domain/report/service/excel/TestReportExcelService.java
+++ b/src/main/java/server/MATE/domain/report/service/excel/TestReportExcelService.java
@@ -20,9 +20,7 @@ public class TestReportExcelService {
         String filename = buildFilename(testId);
 
         if (test.getExcelKey() != null) {
-            return new TestReportExcelDownload(
-                    fileStorageService.generateDownloadUrl(test.getExcelKey(), filename)
-            );
+            return new TestReportExcelDownload(fileStorageService.download(test.getExcelKey()), filename);
         }
 
         byte[] excelBytes = combinedTestReportExcelService.export(testId, makerId);
@@ -30,9 +28,7 @@ public class TestReportExcelService {
         fileStorageService.upload(excelKey, excelBytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         reportExcelExportSupport.saveExcelKey(testId, excelKey);
 
-        return new TestReportExcelDownload(
-                fileStorageService.generateDownloadUrl(excelKey, filename)
-        );
+        return new TestReportExcelDownload(excelBytes, filename);
     }
 
     private String buildFilename(Long testId) {

--- a/src/test/java/server/MATE/domain/report/service/excel/TestReportExcelServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/excel/TestReportExcelServiceTest.java
@@ -46,36 +46,36 @@ class TestReportExcelServiceTest {
     }
 
     @Test
-    void excelKey가_없으면_생성_후_업로드하고_URL을_반환한다() {
+    void excelKey가_없으면_생성_후_업로드하고_바이너리를_반환한다() {
         server.MATE.domain.test.entity.Test test = completedTest(null);
-        String filename = "mate-report-" + TEST_ID + ".xlsx";
+        byte[] excelBytes = {1, 2, 3};
         given(reportExcelExportSupport.requireExportReadyTest(TEST_ID, MAKER_ID)).willReturn(test);
-        given(combinedTestReportExcelService.export(TEST_ID, MAKER_ID)).willReturn(new byte[]{1, 2, 3});
-        given(fileStorageService.generateDownloadUrl("reports/excel/" + TEST_ID + ".xlsx", filename))
-                .willReturn("https://blob.example.com/reports/excel/" + TEST_ID + ".xlsx");
+        given(combinedTestReportExcelService.export(TEST_ID, MAKER_ID)).willReturn(excelBytes);
 
         TestReportExcelDownload result = testReportExcelService.export(TEST_ID, MAKER_ID);
 
-        assertThat(result.downloadUrl()).isEqualTo("https://blob.example.com/reports/excel/" + TEST_ID + ".xlsx");
+        assertThat(result.data()).isEqualTo(excelBytes);
+        assertThat(result.filename()).isEqualTo("mate-report-" + TEST_ID + ".xlsx");
         verify(fileStorageService).upload(
                 eq("reports/excel/" + TEST_ID + ".xlsx"),
-                eq(new byte[]{1, 2, 3}),
+                eq(excelBytes),
                 eq("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
         );
         verify(reportExcelExportSupport).saveExcelKey(TEST_ID, "reports/excel/" + TEST_ID + ".xlsx");
     }
 
     @Test
-    void excelKey가_있으면_재생성_없이_캐싱된_URL을_반환한다() {
-        server.MATE.domain.test.entity.Test test = completedTest("reports/excel/" + TEST_ID + ".xlsx");
-        String filename = "mate-report-" + TEST_ID + ".xlsx";
+    void excelKey가_있으면_재생성_없이_저장된_파일을_바이너리로_반환한다() {
+        String excelKey = "reports/excel/" + TEST_ID + ".xlsx";
+        server.MATE.domain.test.entity.Test test = completedTest(excelKey);
+        byte[] cachedBytes = {4, 5, 6};
         given(reportExcelExportSupport.requireExportReadyTest(TEST_ID, MAKER_ID)).willReturn(test);
-        given(fileStorageService.generateDownloadUrl("reports/excel/" + TEST_ID + ".xlsx", filename))
-                .willReturn("https://blob.example.com/cached.xlsx");
+        given(fileStorageService.download(excelKey)).willReturn(cachedBytes);
 
         TestReportExcelDownload result = testReportExcelService.export(TEST_ID, MAKER_ID);
 
-        assertThat(result.downloadUrl()).isEqualTo("https://blob.example.com/cached.xlsx");
+        assertThat(result.data()).isEqualTo(cachedBytes);
+        assertThat(result.filename()).isEqualTo("mate-report-" + TEST_ID + ".xlsx");
         verify(combinedTestReportExcelService, never()).export(any(), any());
         verify(fileStorageService, never()).upload(any(), any(byte[].class), any());
     }


### PR DESCRIPTION
  ## 📍 요약
  프론트엔드 요청에 따라 엑셀 다운로드 API를 URL 반환에서 바이너리 응답으로 변경

  ## 🔗 관련 이슈 
  - Closes #220

  ## 📌 변경 사항 
  - [x] 버그수정

  ## ✅ 작업 내용
  - `TestReportExcelDownload` DTO를 `downloadUrl` → `data(byte[]) + filename` 구조로 변경
  - `TestReportExcelService` 캐시 히트 시 `generateDownloadUrl` 대신 `download()` 반환, 최초 생성 시 생성된 bytes 직접 반환
  - `ReportController` 엑셀 엔드포인트 반환 타입 `ApiResponse<String>` → `byte[]`, Content-Disposition 헤더 추가
  - `TestReportExcelServiceTest` 테스트 수정

  ## 테스트
  - [x] 로컬 테스트 완료 (단위 테스트)