### PR TITLE
fix: 객관식 Excel 추출 시 옵션 ID 불일치로 인한 "알 수 없는 선지" 오류 수정 및 쿼리 최적화     

### DIFF
--- a/infra/terraform/environments/prod/terraform.tfvars
+++ b/infra/terraform/environments/prod/terraform.tfvars
@@ -42,7 +42,7 @@ kubernetes_vm_ssh_public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHCcRTcz5A5n
 kubernetes_control_vm_name   = "mate-k8s-control"
 kubernetes_worker_vm_name    = "mate-k8s-worker"
 
-kubernetes_control_vm_size = "Standard_D2s_v3"
+kubernetes_control_vm_size = "Standard_B2s_v2"
 kubernetes_worker_vm_size  = "Standard_B2ls_v2"
 
 # NSG: SSH(22) — 출발지 Any (*). 보안상 이후 수정

--- a/infra/terraform/environments/prod/variables.tf
+++ b/infra/terraform/environments/prod/variables.tf
@@ -245,7 +245,7 @@ variable "kubernetes_worker_vm_name" {
 variable "kubernetes_control_vm_size" {
   description = "Control VM SKU."
   type        = string
-  default     = "Standard_D2s_v3"
+  default     = "Standard_B2s_v2"
 }
 
 variable "kubernetes_worker_vm_size" {

--- a/src/main/java/server/MATE/domain/report/service/excel/preparer/FiveSecondReportExcelService.java
+++ b/src/main/java/server/MATE/domain/report/service/excel/preparer/FiveSecondReportExcelService.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.MATE.domain.answer.entity.Answer;
 import server.MATE.domain.question.entity.FiveSecond;
-import server.MATE.domain.question.entity.FiveSecondOption;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.report.excel.fivesecond.FiveSecondObjectiveReportExcelData;
@@ -18,11 +17,8 @@ import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
 
 import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -39,23 +35,14 @@ public class FiveSecondReportExcelService {
         }
         Map<String, Object> reportResult = context.requireReportResult(questionId, QuestionType.OBJECTIVE);
 
-        List<FiveSecondOption> options = fiveSecond.getOptions().stream()
-                .sorted(Comparator.comparingInt(FiveSecondOption::getSequence))
-                .toList();
-        Map<Long, String> optionContentById = options.stream()
-                .collect(Collectors.toMap(
-                        FiveSecondOption::getId,
-                        FiveSecondOption::getContent,
-                        (a, b) -> a,
-                        LinkedHashMap::new
-                ));
+        Map<Long, String> optionContentById = ReportExcelResultMapper.buildOptionContentFromReport(reportResult);
 
         List<Answer> answers = context.answers(questionId);
         return new FiveSecondObjectiveReportExcelData(
                 String.format("Q%02d", question.getSequence()),
                 question.getTitle(),
                 buildObjectiveRespondentRows(answers, optionContentById),
-                ReportExcelResultMapper.toFiveSecondOptionStats(options, reportResult),
+                ReportExcelResultMapper.toFiveSecondOptionStats(reportResult),
                 answers.size()
         );
     }

--- a/src/main/java/server/MATE/domain/report/service/excel/preparer/ObjectiveReportExcelService.java
+++ b/src/main/java/server/MATE/domain/report/service/excel/preparer/ObjectiveReportExcelService.java
@@ -4,11 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.MATE.domain.answer.entity.Answer;
-import server.MATE.domain.question.entity.Objective;
-import server.MATE.domain.question.entity.ObjectiveOption;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
-import server.MATE.domain.report.excel.objective.ObjectiveOptionStatRow;
 import server.MATE.domain.report.excel.objective.ObjectiveReportExcelData;
 import server.MATE.domain.report.excel.objective.ObjectiveRespondentRow;
 import server.MATE.domain.report.service.excel.support.ReportExcelExportContext;
@@ -17,11 +14,8 @@ import server.MATE.domain.report.service.handler.ReportHandlerUtils;
 import server.MATE.global.common.exception.BaseErrorCode;
 
 import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -34,16 +28,11 @@ public class ObjectiveReportExcelService {
         );
         Map<String, Object> reportResult = context.requireReportResult(questionId, QuestionType.OBJECTIVE);
 
-        Objective objective = context.requireObjective(questionId);
-        List<ObjectiveOption> options = objective.getOptions().stream()
-                .sorted(Comparator.comparingInt(ObjectiveOption::getSequence))
-                .toList();
-        Map<Long, String> optionContentById = options.stream()
-                .collect(Collectors.toMap(ObjectiveOption::getId, ObjectiveOption::getContent, (a, b) -> a, LinkedHashMap::new));
+        Map<Long, String> optionContentById = ReportExcelResultMapper.buildOptionContentFromReport(reportResult);
 
         List<Answer> answers = context.answers(questionId);
         List<ObjectiveRespondentRow> respondents = buildRespondentRows(answers, optionContentById);
-        List<ObjectiveOptionStatRow> optionStats = ReportExcelResultMapper.toObjectiveOptionStats(options, reportResult);
+        var optionStats = ReportExcelResultMapper.toObjectiveOptionStats(reportResult);
 
         return new ObjectiveReportExcelData(
                 String.format("Q%02d", question.getSequence()),

--- a/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelExportContext.java
+++ b/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelExportContext.java
@@ -4,7 +4,6 @@ import server.MATE.domain.answer.entity.Answer;
 import server.MATE.domain.question.dto.response.QuestionSummaryItem;
 import server.MATE.domain.question.entity.CardSorting;
 import server.MATE.domain.question.entity.FiveSecond;
-import server.MATE.domain.question.entity.Objective;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.entity.Scale;
@@ -29,7 +28,6 @@ public final class ReportExcelExportContext {
     private final Map<Long, Question> questionById;
     private final Map<Long, Map<String, Object>> reportResultByQuestionId;
     private final Map<Long, List<Answer>> answersByQuestionId;
-    private final Map<Long, Objective> objectiveByQuestionId;
     private final Map<Long, FiveSecond> fiveSecondByQuestionId;
     private final Map<Long, Scale> scaleByQuestionId;
     private final Map<Long, CardSorting> cardSortingByQuestionId;
@@ -42,7 +40,6 @@ public final class ReportExcelExportContext {
             Map<Long, Question> questionById,
             Map<Long, Map<String, Object>> reportResultByQuestionId,
             Map<Long, List<Answer>> answersByQuestionId,
-            Map<Long, Objective> objectiveByQuestionId,
             Map<Long, FiveSecond> fiveSecondByQuestionId,
             Map<Long, Scale> scaleByQuestionId,
             Map<Long, CardSorting> cardSortingByQuestionId,
@@ -54,7 +51,6 @@ public final class ReportExcelExportContext {
         this.questionById = Map.copyOf(questionById);
         this.reportResultByQuestionId = Map.copyOf(reportResultByQuestionId);
         this.answersByQuestionId = Map.copyOf(answersByQuestionId);
-        this.objectiveByQuestionId = Map.copyOf(objectiveByQuestionId);
         this.fiveSecondByQuestionId = Map.copyOf(fiveSecondByQuestionId);
         this.scaleByQuestionId = Map.copyOf(scaleByQuestionId);
         this.cardSortingByQuestionId = Map.copyOf(cardSortingByQuestionId);
@@ -103,14 +99,6 @@ public final class ReportExcelExportContext {
         return answersByQuestionId.getOrDefault(questionId, List.of());
     }
 
-    public Objective requireObjective(Long questionId) {
-        Objective objective = objectiveByQuestionId.get(questionId);
-        if (objective == null) {
-            throw new BaseException(BaseErrorCode.QUESTION_005);
-        }
-        return objective;
-    }
-
     public FiveSecond requireFiveSecond(Long questionId) {
         FiveSecond fiveSecond = fiveSecondByQuestionId.get(questionId);
         if (fiveSecond == null) {
@@ -150,7 +138,6 @@ public final class ReportExcelExportContext {
         private Map<Long, Question> questionById = Map.of();
         private Map<Long, Map<String, Object>> reportResultByQuestionId = Map.of();
         private Map<Long, List<Answer>> answersByQuestionId = Map.of();
-        private Map<Long, Objective> objectiveByQuestionId = Map.of();
         private Map<Long, FiveSecond> fiveSecondByQuestionId = Map.of();
         private Map<Long, Scale> scaleByQuestionId = Map.of();
         private Map<Long, CardSorting> cardSortingByQuestionId = Map.of();
@@ -186,11 +173,6 @@ public final class ReportExcelExportContext {
             return this;
         }
 
-        public Builder objectiveByQuestionId(Map<Long, Objective> objectiveByQuestionId) {
-            this.objectiveByQuestionId = objectiveByQuestionId;
-            return this;
-        }
-
         public Builder fiveSecondByQuestionId(Map<Long, FiveSecond> fiveSecondByQuestionId) {
             this.fiveSecondByQuestionId = fiveSecondByQuestionId;
             return this;
@@ -219,7 +201,6 @@ public final class ReportExcelExportContext {
                     questionById,
                     reportResultByQuestionId,
                     answersByQuestionId,
-                    objectiveByQuestionId,
                     fiveSecondByQuestionId,
                     scaleByQuestionId,
                     cardSortingByQuestionId,

--- a/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelExportContextLoader.java
+++ b/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelExportContextLoader.java
@@ -7,14 +7,13 @@ import server.MATE.domain.answer.repository.AnswerRepository;
 import server.MATE.domain.question.dto.response.QuestionSummaryItem;
 import server.MATE.domain.question.entity.CardSorting;
 import server.MATE.domain.question.entity.FiveSecond;
-import server.MATE.domain.question.entity.Objective;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.question.entity.Scale;
 import server.MATE.domain.question.entity.TreeTest;
 import server.MATE.domain.question.repository.CardSortingRepository;
 import server.MATE.domain.question.repository.FiveSecondRepository;
-import server.MATE.domain.question.repository.ObjectiveRepository;
+
 import server.MATE.domain.question.repository.QuestionRepository;
 import server.MATE.domain.question.repository.ScaleRepository;
 import server.MATE.domain.question.repository.TreeTestRepository;
@@ -38,7 +37,6 @@ public class ReportExcelExportContextLoader {
     private final QuestionRepository questionRepository;
     private final ReportRepository reportRepository;
     private final AnswerRepository answerRepository;
-    private final ObjectiveRepository objectiveRepository;
     private final FiveSecondRepository fiveSecondRepository;
     private final ScaleRepository scaleRepository;
     private final CardSortingRepository cardSortingRepository;
@@ -77,12 +75,8 @@ public class ReportExcelExportContextLoader {
                         Collectors.mapping(QuestionSummaryItem::questionId, Collectors.toList())
                 ));
 
-        Map<Long, Objective> objectiveByQuestionId = objectiveRepository
-                .findAllByIdIn(questionIdsByType.getOrDefault(QuestionType.OBJECTIVE, List.of()))
-                .stream()
-                .collect(Collectors.toMap(Objective::getId, Function.identity()));
         Map<Long, FiveSecond> fiveSecondByQuestionId = fiveSecondRepository
-                .findAllByIdIn(questionIdsByType.getOrDefault(QuestionType.FIVE_SECOND, List.of()))
+                .findAllById(questionIdsByType.getOrDefault(QuestionType.FIVE_SECOND, List.of()))
                 .stream()
                 .collect(Collectors.toMap(FiveSecond::getId, Function.identity()));
         Map<Long, Scale> scaleByQuestionId = scaleRepository
@@ -106,7 +100,6 @@ public class ReportExcelExportContextLoader {
                 .questionById(questionById)
                 .reportResultByQuestionId(reportResultByQuestionId)
                 .answersByQuestionId(answersByQuestionId)
-                .objectiveByQuestionId(objectiveByQuestionId)
                 .fiveSecondByQuestionId(fiveSecondByQuestionId)
                 .scaleByQuestionId(scaleByQuestionId)
                 .cardSortingByQuestionId(cardSortingByQuestionId)

--- a/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelExportContextLoader.java
+++ b/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelExportContextLoader.java
@@ -75,10 +75,11 @@ public class ReportExcelExportContextLoader {
                         Collectors.mapping(QuestionSummaryItem::questionId, Collectors.toList())
                 ));
 
-        Map<Long, FiveSecond> fiveSecondByQuestionId = fiveSecondRepository
-                .findAllById(questionIdsByType.getOrDefault(QuestionType.FIVE_SECOND, List.of()))
-                .stream()
-                .collect(Collectors.toMap(FiveSecond::getId, Function.identity()));
+        List<Long> fiveSecondIds = questionIdsByType.getOrDefault(QuestionType.FIVE_SECOND, List.of());
+        Map<Long, FiveSecond> fiveSecondByQuestionId = fiveSecondIds.isEmpty()
+                ? Map.of()
+                : fiveSecondRepository.findAllById(fiveSecondIds).stream()
+                        .collect(Collectors.toMap(FiveSecond::getId, Function.identity()));
         Map<Long, Scale> scaleByQuestionId = scaleRepository
                 .findAllByIdIn(questionIdsByType.getOrDefault(QuestionType.SCALE, List.of()))
                 .stream()

--- a/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelResultMapper.java
+++ b/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelResultMapper.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public final class ReportExcelResultMapper {
 
@@ -44,9 +45,17 @@ public final class ReportExcelResultMapper {
         Map<Long, String> contentById = new LinkedHashMap<>();
         for (Map<String, Object> optionStat : readOptionStats(reportResult)) {
             Object optionIdObject = optionStat.get("optionId");
-            Object contentObject = optionStat.get("content");
+            Long optionId = null;
             if (optionIdObject instanceof Number n) {
-                contentById.put(n.longValue(), contentObject instanceof String s ? s : "");
+                optionId = n.longValue();
+            } else if (optionIdObject instanceof String s) {
+                try {
+                    optionId = Long.parseLong(s);
+                } catch (NumberFormatException ignored) {
+                }
+            }
+            if (optionId != null) {
+                contentById.put(optionId, Objects.toString(optionStat.get("content"), ""));
             }
         }
         return contentById;
@@ -69,7 +78,7 @@ public final class ReportExcelResultMapper {
     public static List<FiveSecondOptionStatRow> toFiveSecondOptionStats(Map<String, Object> reportResult) {
         List<FiveSecondOptionStatRow> stats = new ArrayList<>();
         for (Map<String, Object> optionStat : readOptionStats(reportResult)) {
-            String content = optionStat.get("content") instanceof String s ? s : "";
+            String content = Objects.toString(optionStat.get("content"), "");
             stats.add(new FiveSecondOptionStatRow(
                     content,
                     readInt(optionStat.get("count")),

--- a/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelResultMapper.java
+++ b/src/main/java/server/MATE/domain/report/service/excel/support/ReportExcelResultMapper.java
@@ -1,7 +1,5 @@
 package server.MATE.domain.report.service.excel.support;
 
-import server.MATE.domain.question.entity.FiveSecondOption;
-import server.MATE.domain.question.entity.ObjectiveOption;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.report.excel.cardsorting.CardSortingCategoryStatRow;
 import server.MATE.domain.report.excel.fivesecond.FiveSecondOptionStatRow;
@@ -13,6 +11,7 @@ import server.MATE.global.common.exception.BaseException;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -41,60 +40,40 @@ public final class ReportExcelResultMapper {
         }
     }
 
-    public static List<ObjectiveOptionStatRow> toObjectiveOptionStats(
-            List<ObjectiveOption> options,
-            Map<String, Object> reportResult
-    ) {
-        Map<Long, Integer> countByOptionId = new HashMap<>();
-        Map<Long, Double> ratioByOptionId = new HashMap<>();
+    public static Map<Long, String> buildOptionContentFromReport(Map<String, Object> reportResult) {
+        Map<Long, String> contentById = new LinkedHashMap<>();
         for (Map<String, Object> optionStat : readOptionStats(reportResult)) {
             Object optionIdObject = optionStat.get("optionId");
-            if (!(optionIdObject instanceof Number optionIdNumber)) {
-                continue;
+            Object contentObject = optionStat.get("content");
+            if (optionIdObject instanceof Number n) {
+                contentById.put(n.longValue(), contentObject instanceof String s ? s : "");
             }
-            long optionId = optionIdNumber.longValue();
-            countByOptionId.put(optionId, readInt(optionStat.get("count")));
-            ratioByOptionId.put(optionId, readDouble(optionStat.get("ratio")));
         }
+        return contentById;
+    }
 
+    public static List<ObjectiveOptionStatRow> toObjectiveOptionStats(Map<String, Object> reportResult) {
+        List<Map<String, Object>> optionStats = readOptionStats(reportResult);
         List<ObjectiveOptionStatRow> stats = new ArrayList<>();
-        for (int index = 0; index < options.size(); index++) {
-            ObjectiveOption option = options.get(index);
-            int count = countByOptionId.getOrDefault(option.getId(), 0);
-            double ratio = ratioByOptionId.getOrDefault(option.getId(), 0.0);
+        for (int index = 0; index < optionStats.size(); index++) {
+            Map<String, Object> optionStat = optionStats.get(index);
             stats.add(new ObjectiveOptionStatRow(
                     "선지 " + (index + 1),
-                    count,
-                    formatObjectiveRatioPercent(ratio)
+                    readInt(optionStat.get("count")),
+                    formatObjectiveRatioPercent(readDouble(optionStat.get("ratio")))
             ));
         }
         return stats;
     }
 
-    public static List<FiveSecondOptionStatRow> toFiveSecondOptionStats(
-            List<FiveSecondOption> options,
-            Map<String, Object> reportResult
-    ) {
-        Map<Long, Integer> countByOptionId = new HashMap<>();
-        Map<Long, Double> ratioByOptionId = new HashMap<>();
-        for (Map<String, Object> optionStat : readOptionStats(reportResult)) {
-            Object optionIdObject = optionStat.get("optionId");
-            if (!(optionIdObject instanceof Number optionIdNumber)) {
-                continue;
-            }
-            long optionId = optionIdNumber.longValue();
-            countByOptionId.put(optionId, readInt(optionStat.get("count")));
-            ratioByOptionId.put(optionId, readDouble(optionStat.get("ratio")));
-        }
-
+    public static List<FiveSecondOptionStatRow> toFiveSecondOptionStats(Map<String, Object> reportResult) {
         List<FiveSecondOptionStatRow> stats = new ArrayList<>();
-        for (FiveSecondOption option : options) {
-            int count = countByOptionId.getOrDefault(option.getId(), 0);
-            double ratio = ratioByOptionId.getOrDefault(option.getId(), 0.0);
+        for (Map<String, Object> optionStat : readOptionStats(reportResult)) {
+            String content = optionStat.get("content") instanceof String s ? s : "";
             stats.add(new FiveSecondOptionStatRow(
-                    option.getContent(),
-                    count,
-                    formatObjectiveRatioPercent(ratio)
+                    content,
+                    readInt(optionStat.get("count")),
+                    formatObjectiveRatioPercent(readDouble(optionStat.get("ratio")))
             ));
         }
         return stats;

--- a/src/test/java/server/MATE/domain/report/service/excel/preparer/ObjectiveReportExcelServiceTest.java
+++ b/src/test/java/server/MATE/domain/report/service/excel/preparer/ObjectiveReportExcelServiceTest.java
@@ -6,8 +6,6 @@ import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import server.MATE.domain.answer.entity.Answer;
-import server.MATE.domain.question.entity.Objective;
-import server.MATE.domain.question.entity.ObjectiveOption;
 import server.MATE.domain.question.entity.Question;
 import server.MATE.domain.question.entity.QuestionType;
 import server.MATE.domain.report.excel.objective.ObjectiveReportExcelData;
@@ -37,19 +35,6 @@ class ObjectiveReportExcelServiceTest {
                 .build();
         ReflectionTestUtils.setField(question, "id", 20L);
 
-        ObjectiveOption option = ObjectiveOption.builder()
-                .content("선택1")
-                .sequence(1)
-                .build();
-        ReflectionTestUtils.setField(option, "id", 1L);
-
-        Objective objective = Objective.builder()
-                .question(question)
-                .isDuplicate(false)
-                .build();
-        ReflectionTestUtils.setField(objective, "id", 20L);
-        objective.addOption(option);
-
         Answer answer = Answer.builder()
                 .participationId(100L)
                 .questionId(20L)
@@ -66,7 +51,6 @@ class ObjectiveReportExcelServiceTest {
                 .questionById(Map.of(20L, question))
                 .reportResultByQuestionId(Map.of(20L, reportResult))
                 .answersByQuestionId(Map.of(20L, List.of(answer)))
-                .objectiveByQuestionId(Map.of(20L, objective))
                 .build();
 
         ObjectiveReportExcelData data = objectiveReportExcelService.prepareData(context, 20L);


### PR DESCRIPTION
 ## 📍 요약
  - 객관식 Excel 추출 시 옵션 ID 불일치로 "알 수 없는 선지" 및 통계 미출력 오류 수정

  ## 🔗 관련 이슈
  - Closes #222
  
  ## 📌 변경 사항
  - [ ] 기능
  - [x] 버그 수정
  - [x] 리팩토링
  - [ ] 문서
  - [x] 테스트
  - [ ] 기타 


## ✅ 작업 내용

### 버그 수정
  - `ObjectiveReportExcelService`, `FiveSecondReportExcelService`에서 응답자 행의 선지 내용을 현재 DB `objective_option` 조회  대신 `report.result`에 저장된 content 기반으로 변경
    - 기존: 현재 DB option ID → content 매핑 → option ID가 재생성되면 ID 불일치로 "알 수 없는 선지" 발생
    - 변경: 리포트 집계 시점에 저장된 optionId/content를 그대로 사용 → ID 변경 여부와 무관하게 정상 출력

  ### 리팩토링
  - `ReportExcelResultMapper.toObjectiveOptionStats`, `toFiveSecondOptionStats` 시그니처 변경
    - DB 엔티티(`List<ObjectiveOption>`, `List<FiveSecondOption>`) 파라미터 제거, `reportResult`만으로 통계 생성
    - `buildOptionContentFromReport` 메서드 추가
  - Excel export context에서 `objectiveByQuestionId` 완전 제거
    - `ReportExcelExportContextLoader`에서 `objectiveRepository.findAllByIdIn` 쿼리 제거
    - `ReportExcelExportContext` 필드/메서드/Builder 항목 제거
  - `fiveSecondRepository.findAllByIdIn` → `findAllById` 변경
    - 기존 `@EntityGraph(attributePaths = "options")`로 불필요한 options JOIN FETCH 발생
    - Excel 생성 시 options 미사용으로 `findAllById`(EntityGraph 없음)로 교체

  ## 테스트
  - [x] 로컬 테스트 완료
