### PR TITLE
feat: PENDING 상태 프로모션 재조회 스케줄러 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,10 @@ dependencies {
   
 	// retry
 	implementation 'org.springframework.retry:spring-retry'
+
+	// shedlock
+	implementation 'net.javacrumbs.shedlock:shedlock-spring:5.16.0'
+	implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.16.0'
 	implementation 'org.springframework:spring-aspects'
 
 	// excel

--- a/src/main/java/server/MATE/domain/promotion/repository/PromotionRewardRepository.java
+++ b/src/main/java/server/MATE/domain/promotion/repository/PromotionRewardRepository.java
@@ -14,7 +14,7 @@ public interface PromotionRewardRepository extends JpaRepository<PromotionReward
 
     Optional<PromotionReward> findByParticipationId(Long participationId);
 
-    List<PromotionReward> findAllByStatusIn(List<PromotionRewardStatus> statuses);
+    List<PromotionReward> findTop100ByStatusIn(List<PromotionRewardStatus> statuses);
 
     @Query("""
             select coalesce(sum(pr.rewardAmount), 0)

--- a/src/main/java/server/MATE/domain/promotion/repository/PromotionRewardRepository.java
+++ b/src/main/java/server/MATE/domain/promotion/repository/PromotionRewardRepository.java
@@ -1,5 +1,6 @@
 package server.MATE.domain.promotion.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,6 +13,8 @@ import server.MATE.domain.promotion.entity.PromotionRewardStatus;
 public interface PromotionRewardRepository extends JpaRepository<PromotionReward, Long> {
 
     Optional<PromotionReward> findByParticipationId(Long participationId);
+
+    List<PromotionReward> findAllByStatusIn(List<PromotionRewardStatus> statuses);
 
     @Query("""
             select coalesce(sum(pr.rewardAmount), 0)

--- a/src/main/java/server/MATE/domain/promotion/scheduler/PromotionPendingScheduler.java
+++ b/src/main/java/server/MATE/domain/promotion/scheduler/PromotionPendingScheduler.java
@@ -2,6 +2,7 @@ package server.MATE.domain.promotion.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,7 @@ public class PromotionPendingScheduler {
     private final PromotionPendingResolverService promotionPendingResolverService;
 
     @Scheduled(fixedDelay = 300_000)
+    @SchedulerLock(name = "promotionPendingScheduler", lockAtMostFor = "PT4M")
     public void resolvePromotionPending() {
         log.info("PROMOTION PENDING 재조회 스케줄러 실행");
         promotionPendingResolverService.resolveAll();

--- a/src/main/java/server/MATE/domain/promotion/scheduler/PromotionPendingScheduler.java
+++ b/src/main/java/server/MATE/domain/promotion/scheduler/PromotionPendingScheduler.java
@@ -1,0 +1,23 @@
+package server.MATE.domain.promotion.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.promotion.service.PromotionPendingResolverService;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "toss.api", name = "enabled", havingValue = "true")
+public class PromotionPendingScheduler {
+
+    private final PromotionPendingResolverService promotionPendingResolverService;
+
+    @Scheduled(fixedDelay = 300_000)
+    public void resolvePromotionPending() {
+        log.info("PROMOTION PENDING 재조회 스케줄러 실행");
+        promotionPendingResolverService.resolveAll();
+    }
+}

--- a/src/main/java/server/MATE/domain/promotion/service/PromotionPendingResolverService.java
+++ b/src/main/java/server/MATE/domain/promotion/service/PromotionPendingResolverService.java
@@ -1,0 +1,58 @@
+package server.MATE.domain.promotion.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import server.MATE.domain.promotion.entity.PromotionReward;
+import server.MATE.domain.promotion.entity.PromotionRewardStatus;
+import server.MATE.domain.promotion.repository.PromotionRewardRepository;
+import server.MATE.toss.dto.request.TossPromotionResultRequest;
+import server.MATE.toss.gateway.TossPromotionGateway;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PromotionPendingResolverService {
+
+    private static final String ERROR_CODE_EXECUTION_FAILED = "PROMOTION_EXECUTION_FAILED";
+    private static final String ERROR_REASON_EXECUTION_FAILED = "Promotion execution result is FAILED.";
+
+    private final PromotionRewardRepository promotionRewardRepository;
+    private final PromotionExecuteStateService promotionExecuteStateService;
+    private final PromotionFailureStateService promotionFailureStateService;
+    private final TossPromotionGateway tossPromotionGateway;
+
+    public void resolveAll() {
+        List<PromotionReward> pendingRewards = promotionRewardRepository.findAllByStatusIn(
+                List.of(PromotionRewardStatus.EXECUTED, PromotionRewardStatus.PENDING)
+        );
+
+        for (PromotionReward reward : pendingRewards) {
+            try {
+                resolve(reward);
+            } catch (Exception e) {
+                log.warn("PROMOTION PENDING resolve failed. rewardId={}", reward.getId(), e);
+            }
+        }
+    }
+
+    private void resolve(PromotionReward reward) {
+        var result = tossPromotionGateway.getExecutionResult(
+                new TossPromotionResultRequest(reward.getTossUserKey(), reward.getPromotionCode(), reward.getRewardKey())
+        );
+
+        switch (result.status()) {
+            case SUCCESS -> {
+                promotionExecuteStateService.markSucceeded(reward.getId());
+                log.info("PROMOTION PENDING resolved to SUCCEEDED. rewardId={}", reward.getId());
+            }
+            case FAILED -> {
+                promotionFailureStateService.markFailed(reward.getId(), ERROR_CODE_EXECUTION_FAILED, ERROR_REASON_EXECUTION_FAILED);
+                log.warn("PROMOTION PENDING resolved to FAILED. rewardId={}", reward.getId());
+            }
+            case PENDING -> log.debug("PROMOTION still PENDING. rewardId={}", reward.getId());
+        }
+    }
+}

--- a/src/main/java/server/MATE/domain/promotion/service/PromotionPendingResolverService.java
+++ b/src/main/java/server/MATE/domain/promotion/service/PromotionPendingResolverService.java
@@ -18,6 +18,8 @@ public class PromotionPendingResolverService {
 
     private static final String ERROR_CODE_EXECUTION_FAILED = "PROMOTION_EXECUTION_FAILED";
     private static final String ERROR_REASON_EXECUTION_FAILED = "Promotion execution result is FAILED.";
+    private static final String ERROR_CODE_INVALID_STATE = "INVALID_PROMOTION_STATE";
+    private static final String ERROR_REASON_INVALID_STATE = "Required fields are missing.";
 
     private final PromotionRewardRepository promotionRewardRepository;
     private final PromotionExecuteStateService promotionExecuteStateService;
@@ -25,7 +27,7 @@ public class PromotionPendingResolverService {
     private final TossPromotionGateway tossPromotionGateway;
 
     public void resolveAll() {
-        List<PromotionReward> pendingRewards = promotionRewardRepository.findAllByStatusIn(
+        List<PromotionReward> pendingRewards = promotionRewardRepository.findTop100ByStatusIn(
                 List.of(PromotionRewardStatus.EXECUTED, PromotionRewardStatus.PENDING)
         );
 
@@ -39,6 +41,12 @@ public class PromotionPendingResolverService {
     }
 
     private void resolve(PromotionReward reward) {
+        if (reward.getTossUserKey() == null || reward.getPromotionCode() == null || reward.getRewardKey() == null) {
+            log.error("PROMOTION PENDING resolve skipped due to missing required fields. rewardId={}", reward.getId());
+            promotionFailureStateService.markFailed(reward.getId(), ERROR_CODE_INVALID_STATE, ERROR_REASON_INVALID_STATE);
+            return;
+        }
+
         var result = tossPromotionGateway.getExecutionResult(
                 new TossPromotionResultRequest(reward.getTossUserKey(), reward.getPromotionCode(), reward.getRewardKey())
         );

--- a/src/main/java/server/MATE/global/config/ShedLockConfig.java
+++ b/src/main/java/server/MATE/global/config/ShedLockConfig.java
@@ -1,0 +1,18 @@
+package server.MATE.global.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "PT4M")
+public class ShedLockConfig {
+
+    @Bean
+    public LockProvider lockProvider(RedisConnectionFactory connectionFactory) {
+        return new RedisLockProvider(connectionFactory);
+    }
+}

--- a/src/test/java/server/MATE/domain/promotion/service/PromotionPendingResolverServiceTest.java
+++ b/src/test/java/server/MATE/domain/promotion/service/PromotionPendingResolverServiceTest.java
@@ -1,0 +1,177 @@
+package server.MATE.domain.promotion.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import server.MATE.domain.promotion.entity.PromotionReward;
+import server.MATE.domain.promotion.entity.PromotionRewardStatus;
+import server.MATE.domain.promotion.repository.PromotionRewardRepository;
+import server.MATE.toss.dto.request.TossPromotionResultRequest;
+import server.MATE.toss.dto.response.TossPromotionExecutionStatus;
+import server.MATE.toss.dto.response.TossPromotionResultResponse;
+import server.MATE.toss.gateway.TossPromotionGateway;
+
+@ExtendWith(MockitoExtension.class)
+class PromotionPendingResolverServiceTest {
+
+    @Mock
+    private PromotionRewardRepository promotionRewardRepository;
+
+    @Mock
+    private PromotionExecuteStateService promotionExecuteStateService;
+
+    @Mock
+    private PromotionFailureStateService promotionFailureStateService;
+
+    @Mock
+    private TossPromotionGateway tossPromotionGateway;
+
+    private PromotionPendingResolverService resolverService;
+
+    @BeforeEach
+    void setUp() {
+        resolverService = new PromotionPendingResolverService(
+                promotionRewardRepository,
+                promotionExecuteStateService,
+                promotionFailureStateService,
+                tossPromotionGateway
+        );
+    }
+
+    private PromotionReward pendingReward(Long id) {
+        PromotionReward reward = PromotionReward.builder()
+                .participationId(id)
+                .testId(1L)
+                .testerId(1L)
+                .tossUserKey(777L)
+                .rewardAmount(300)
+                .promotionCode("promo-answer")
+                .rewardKey("reward-key-" + id)
+                .status(PromotionRewardStatus.PENDING)
+                .build();
+        ReflectionTestUtils.setField(reward, "id", id);
+        return reward;
+    }
+
+    private PromotionReward executedReward(Long id) {
+        PromotionReward reward = PromotionReward.builder()
+                .participationId(id)
+                .testId(1L)
+                .testerId(1L)
+                .tossUserKey(777L)
+                .rewardAmount(300)
+                .promotionCode("promo-answer")
+                .rewardKey("reward-key-" + id)
+                .status(PromotionRewardStatus.EXECUTED)
+                .build();
+        ReflectionTestUtils.setField(reward, "id", id);
+        return reward;
+    }
+
+    @Test
+    @DisplayName("PENDING 건의 결과가 SUCCESS면 SUCCEEDED로 업데이트한다")
+    void resolvesSuccessFromPending() {
+        PromotionReward reward = pendingReward(1L);
+        given(promotionRewardRepository.findAllByStatusIn(any())).willReturn(List.of(reward));
+        given(tossPromotionGateway.getExecutionResult(any(TossPromotionResultRequest.class)))
+                .willReturn(new TossPromotionResultResponse(TossPromotionExecutionStatus.SUCCESS));
+
+        resolverService.resolveAll();
+
+        verify(promotionExecuteStateService).markSucceeded(1L);
+        verify(promotionFailureStateService, never()).markFailed(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("PENDING 건의 결과가 FAILED면 FAILED로 업데이트한다")
+    void resolvesFailedFromPending() {
+        PromotionReward reward = pendingReward(1L);
+        given(promotionRewardRepository.findAllByStatusIn(any())).willReturn(List.of(reward));
+        given(tossPromotionGateway.getExecutionResult(any(TossPromotionResultRequest.class)))
+                .willReturn(new TossPromotionResultResponse(TossPromotionExecutionStatus.FAILED));
+
+        resolverService.resolveAll();
+
+        verify(promotionFailureStateService).markFailed(eq(1L), any(), any());
+        verify(promotionExecuteStateService, never()).markSucceeded(any());
+    }
+
+    @Test
+    @DisplayName("PENDING 건의 결과가 여전히 PENDING이면 상태를 변경하지 않는다")
+    void doesNothingWhenStillPending() {
+        PromotionReward reward = pendingReward(1L);
+        given(promotionRewardRepository.findAllByStatusIn(any())).willReturn(List.of(reward));
+        given(tossPromotionGateway.getExecutionResult(any(TossPromotionResultRequest.class)))
+                .willReturn(new TossPromotionResultResponse(TossPromotionExecutionStatus.PENDING));
+
+        resolverService.resolveAll();
+
+        verify(promotionExecuteStateService, never()).markSucceeded(any());
+        verify(promotionFailureStateService, never()).markFailed(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("EXECUTED 건의 결과가 SUCCESS면 SUCCEEDED로 업데이트한다")
+    void resolvesSuccessFromExecuted() {
+        PromotionReward reward = executedReward(2L);
+        given(promotionRewardRepository.findAllByStatusIn(any())).willReturn(List.of(reward));
+        given(tossPromotionGateway.getExecutionResult(any(TossPromotionResultRequest.class)))
+                .willReturn(new TossPromotionResultResponse(TossPromotionExecutionStatus.SUCCESS));
+
+        resolverService.resolveAll();
+
+        verify(promotionExecuteStateService).markSucceeded(2L);
+    }
+
+    @Test
+    @DisplayName("특정 건에서 예외가 발생해도 나머지 건은 계속 처리한다")
+    void continuesProcessingOnPartialFailure() {
+        PromotionReward failingReward = pendingReward(1L);
+        PromotionReward successReward = pendingReward(2L);
+        given(promotionRewardRepository.findAllByStatusIn(any())).willReturn(List.of(failingReward, successReward));
+        given(tossPromotionGateway.getExecutionResult(any(TossPromotionResultRequest.class)))
+                .willThrow(new RuntimeException("Toss API 오류"))
+                .willReturn(new TossPromotionResultResponse(TossPromotionExecutionStatus.SUCCESS));
+
+        resolverService.resolveAll();
+
+        verify(promotionExecuteStateService).markSucceeded(2L);
+    }
+
+    @Test
+    @DisplayName("처리할 건이 없으면 gateway를 호출하지 않는다")
+    void doesNothingWhenNoPendingRewards() {
+        given(promotionRewardRepository.findAllByStatusIn(any())).willReturn(List.of());
+
+        resolverService.resolveAll();
+
+        verify(tossPromotionGateway, never()).getExecutionResult(any());
+    }
+
+    @Test
+    @DisplayName("gateway 호출 시 저장된 tossUserKey, promotionCode, rewardKey를 그대로 사용한다")
+    void usesStoredCredentialsForGatewayCall() {
+        PromotionReward reward = pendingReward(1L);
+        given(promotionRewardRepository.findAllByStatusIn(any())).willReturn(List.of(reward));
+        given(tossPromotionGateway.getExecutionResult(any(TossPromotionResultRequest.class)))
+                .willReturn(new TossPromotionResultResponse(TossPromotionExecutionStatus.SUCCESS));
+
+        resolverService.resolveAll();
+
+        verify(tossPromotionGateway).getExecutionResult(
+                new TossPromotionResultRequest(777L, "promo-answer", "reward-key-1")
+        );
+    }
+}

--- a/src/test/java/server/MATE/domain/promotion/service/PromotionPendingResolverServiceTest.java
+++ b/src/test/java/server/MATE/domain/promotion/service/PromotionPendingResolverServiceTest.java
@@ -84,7 +84,7 @@ class PromotionPendingResolverServiceTest {
     @DisplayName("PENDING 건의 결과가 SUCCESS면 SUCCEEDED로 업데이트한다")
     void resolvesSuccessFromPending() {
         PromotionReward reward = pendingReward(1L);
-        given(promotionRewardRepository.findAllByStatusIn(any())).willReturn(List.of(reward));
+        given(promotionRewardRepository.findTop100ByStatusIn(any())).willReturn(List.of(reward));
         given(tossPromotionGateway.getExecutionResult(any(TossPromotionResultRequest.class)))
                 .willReturn(new TossPromotionResultResponse(TossPromotionExecutionStatus.SUCCESS));
 
@@ -98,7 +98,7 @@ class PromotionPendingResolverServiceTest {
     @DisplayName("PENDING 건의 결과가 FAILED면 FAILED로 업데이트한다")
     void resolvesFailedFromPending() {
         PromotionReward reward = pendingReward(1L);
-        given(promotionRewardRepository.findAllByStatusIn(any())).willReturn(List.of(reward));
+        given(promotionRewardRepository.findTop100ByStatusIn(any())).willReturn(List.of(reward));
         given(tossPromotionGateway.getExecutionResult(any(TossPromotionResultRequest.class)))
                 .willReturn(new TossPromotionResultResponse(TossPromotionExecutionStatus.FAILED));
 
@@ -112,7 +112,7 @@ class PromotionPendingResolverServiceTest {
     @DisplayName("PENDING 건의 결과가 여전히 PENDING이면 상태를 변경하지 않는다")
     void doesNothingWhenStillPending() {
         PromotionReward reward = pendingReward(1L);
-        given(promotionRewardRepository.findAllByStatusIn(any())).willReturn(List.of(reward));
+        given(promotionRewardRepository.findTop100ByStatusIn(any())).willReturn(List.of(reward));
         given(tossPromotionGateway.getExecutionResult(any(TossPromotionResultRequest.class)))
                 .willReturn(new TossPromotionResultResponse(TossPromotionExecutionStatus.PENDING));
 
@@ -126,7 +126,7 @@ class PromotionPendingResolverServiceTest {
     @DisplayName("EXECUTED 건의 결과가 SUCCESS면 SUCCEEDED로 업데이트한다")
     void resolvesSuccessFromExecuted() {
         PromotionReward reward = executedReward(2L);
-        given(promotionRewardRepository.findAllByStatusIn(any())).willReturn(List.of(reward));
+        given(promotionRewardRepository.findTop100ByStatusIn(any())).willReturn(List.of(reward));
         given(tossPromotionGateway.getExecutionResult(any(TossPromotionResultRequest.class)))
                 .willReturn(new TossPromotionResultResponse(TossPromotionExecutionStatus.SUCCESS));
 
@@ -140,7 +140,7 @@ class PromotionPendingResolverServiceTest {
     void continuesProcessingOnPartialFailure() {
         PromotionReward failingReward = pendingReward(1L);
         PromotionReward successReward = pendingReward(2L);
-        given(promotionRewardRepository.findAllByStatusIn(any())).willReturn(List.of(failingReward, successReward));
+        given(promotionRewardRepository.findTop100ByStatusIn(any())).willReturn(List.of(failingReward, successReward));
         given(tossPromotionGateway.getExecutionResult(any(TossPromotionResultRequest.class)))
                 .willThrow(new RuntimeException("Toss API 오류"))
                 .willReturn(new TossPromotionResultResponse(TossPromotionExecutionStatus.SUCCESS));
@@ -151,9 +151,28 @@ class PromotionPendingResolverServiceTest {
     }
 
     @Test
+    @DisplayName("tossUserKey, promotionCode, rewardKey 중 하나라도 null이면 FAILED 처리한다")
+    void marksFailedWhenRequiredFieldsAreMissing() {
+        PromotionReward reward = PromotionReward.builder()
+                .participationId(1L)
+                .testId(1L)
+                .testerId(1L)
+                .rewardAmount(300)
+                .status(PromotionRewardStatus.PENDING)
+                .build();
+        ReflectionTestUtils.setField(reward, "id", 1L);
+        given(promotionRewardRepository.findTop100ByStatusIn(any())).willReturn(List.of(reward));
+
+        resolverService.resolveAll();
+
+        verify(promotionFailureStateService).markFailed(eq(1L), any(), any());
+        verify(tossPromotionGateway, never()).getExecutionResult(any());
+    }
+
+    @Test
     @DisplayName("처리할 건이 없으면 gateway를 호출하지 않는다")
     void doesNothingWhenNoPendingRewards() {
-        given(promotionRewardRepository.findAllByStatusIn(any())).willReturn(List.of());
+        given(promotionRewardRepository.findTop100ByStatusIn(any())).willReturn(List.of());
 
         resolverService.resolveAll();
 
@@ -164,7 +183,7 @@ class PromotionPendingResolverServiceTest {
     @DisplayName("gateway 호출 시 저장된 tossUserKey, promotionCode, rewardKey를 그대로 사용한다")
     void usesStoredCredentialsForGatewayCall() {
         PromotionReward reward = pendingReward(1L);
-        given(promotionRewardRepository.findAllByStatusIn(any())).willReturn(List.of(reward));
+        given(promotionRewardRepository.findTop100ByStatusIn(any())).willReturn(List.of(reward));
         given(tossPromotionGateway.getExecutionResult(any(TossPromotionResultRequest.class)))
                 .willReturn(new TossPromotionResultResponse(TossPromotionExecutionStatus.SUCCESS));
 


### PR DESCRIPTION
## 📍 요약
  프로모션 포인트 지급 후 PENDING/EXECUTED 상태로 남는 건을 주기적으로 Toss API에 재조회하여 최종 상태로 업데이트하는 스케줄러 구현
  
  ## 🔗 관련 이슈
  - Closes #244
  
  ## 📌 변경 사항
  - [x] 기능

  
  ## ✅ 작업 내용
  - `PromotionRewardRepository` - PENDING/EXECUTED 상태 일괄 조회 쿼리 추가
  - `PromotionPendingResolverService` - Toss `/execution-result` 재조회 후 SUCCESS/FAILED 상태 업데이트
  - `PromotionPendingScheduler` - 5분 간격 스케줄러 (`toss.api.enabled=true` 환경에서만 동작)
  - `PromotionPendingResolverServiceTest` - 유닛 테스트 7케이스 추가
  
  ## 테스트
  - 유닛 테스트 로컬 실행 완료
  - PENDING → SUCCESS/FAILED/PENDING, EXECUTED → SUCCESS, 부분 실패 격리, 빈 목록 케이스 검증