### PR TITLE
fix: 테스트 개시 결제 금액 조회 및 closedAt 기준 자동 환불 처리 (#249)  

### DIFF
--- a/infra/terraform/environments/prod/terraform.tfvars
+++ b/infra/terraform/environments/prod/terraform.tfvars
@@ -17,7 +17,7 @@ postgres_server_name           = "mate-postgres"
 postgres_database_name         = "mate"
 postgres_admin_username        = "mateadmin"
 postgres_version               = "16"
-postgres_sku_name              = "B_Standard_B2s"
+postgres_sku_name              = "B_Standard_B1ms"
 postgres_storage_mb            = 32768
 postgres_backup_retention_days = 7
 

--- a/infra/terraform/modules/kubernetes_vms/main.tf
+++ b/infra/terraform/modules/kubernetes_vms/main.tf
@@ -199,7 +199,8 @@ resource "azurerm_network_interface" "control" {
   ip_configuration {
     name                          = "primary"
     subnet_id                     = var.subnet_id
-    private_ip_address_allocation = "Dynamic"
+    private_ip_address_allocation = "Static"
+    private_ip_address            = var.control_private_ip
     public_ip_address_id          = azurerm_public_ip.control.id
   }
 
@@ -214,7 +215,8 @@ resource "azurerm_network_interface" "worker" {
   ip_configuration {
     name                          = "primary"
     subnet_id                     = var.subnet_id
-    private_ip_address_allocation = "Dynamic"
+    private_ip_address_allocation = "Static"
+    private_ip_address            = var.worker_private_ip
     # 워커는 사설만 (마스터 경유 SSH / 클러스터 내부 통신)
   }
 

--- a/infra/terraform/modules/kubernetes_vms/variables.tf
+++ b/infra/terraform/modules/kubernetes_vms/variables.tf
@@ -46,6 +46,18 @@ variable "tags" {
   default     = {}
 }
 
+variable "control_private_ip" {
+  description = "Control plane VM 사설 IP (Static 고정). 재시작 시 IP 변경 방지."
+  type        = string
+  default     = "10.20.1.5"
+}
+
+variable "worker_private_ip" {
+  description = "Worker VM 사설 IP (Static 고정). 재시작 시 IP 변경 방지."
+  type        = string
+  default     = "10.20.1.4"
+}
+
 variable "control_vm_size" {
   description = "Control plane VM SKU. DASv5 패밀리는 구독·리전별 코어 할당량 0 일 수 있음 → D2s_v3 등 DSv3으로 대체ㅠㅠ"
   type        = string

--- a/src/main/java/server/MATE/domain/test/repository/TestRepository.java
+++ b/src/main/java/server/MATE/domain/test/repository/TestRepository.java
@@ -2,6 +2,11 @@ package server.MATE.domain.test.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.entity.TestStatus;
+
+import java.util.List;
 
 public interface TestRepository extends JpaRepository<Test, Long>, TestQueryRepository {
+
+    List<Test> findByTestStatusAndDeletedAtIsNull(TestStatus testStatus);
 }

--- a/src/main/java/server/MATE/domain/test/scheduler/TestAutoCloseScheduler.java
+++ b/src/main/java/server/MATE/domain/test/scheduler/TestAutoCloseScheduler.java
@@ -2,6 +2,7 @@ package server.MATE.domain.test.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import server.MATE.domain.test.service.TestAutoCloseService;
@@ -14,6 +15,7 @@ public class TestAutoCloseScheduler {
     private final TestAutoCloseService testAutoCloseService;
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @SchedulerLock(name = "testAutoCloseScheduler", lockAtMostFor = "PT10M")
     public void autoCloseExpiredTests() {
         log.info("테스트 자동 종료 스케줄러 실행");
         testAutoCloseService.closeExpiredTests();

--- a/src/main/java/server/MATE/domain/test/service/TestCloseScheduleInitializer.java
+++ b/src/main/java/server/MATE/domain/test/service/TestCloseScheduleInitializer.java
@@ -1,0 +1,55 @@
+package server.MATE.domain.test.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import server.MATE.domain.test.entity.Test;
+import server.MATE.domain.test.entity.TestStatus;
+import server.MATE.domain.test.repository.TestRepository;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TestCloseScheduleInitializer implements ApplicationRunner {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final TestRepository testRepository;
+    private final TestCloseScheduler testCloseScheduler;
+    private final TestCloseProcessor testCloseProcessor;
+    private final Clock clock;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        LocalDateTime now = LocalDateTime.now(clock.withZone(KST));
+        List<Test> inProgressTests = testRepository.findByTestStatusAndDeletedAtIsNull(TestStatus.IN_PROGRESS);
+
+        log.info("진행 중 테스트 자동 종료 예약 복원 대상: {}개", inProgressTests.size());
+
+        for (Test test : inProgressTests) {
+            if (test.getClosedAt() == null) {
+                continue;
+            }
+            if (!test.getClosedAt().isAfter(now)) {
+                closeImmediately(test.getId());
+                continue;
+            }
+            testCloseScheduler.schedule(test.getId(), test.getClosedAt());
+        }
+    }
+
+    private void closeImmediately(Long testId) {
+        try {
+            testCloseProcessor.process(testId);
+        } catch (Exception e) {
+            log.error("테스트 {} 기한 만료 즉시 종료 실패 - 자정 스케줄러에서 재처리됩니다", testId, e);
+        }
+    }
+}

--- a/src/main/java/server/MATE/domain/test/service/TestCloseScheduleInitializer.java
+++ b/src/main/java/server/MATE/domain/test/service/TestCloseScheduleInitializer.java
@@ -9,9 +9,6 @@ import server.MATE.domain.test.entity.Test;
 import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.domain.test.repository.TestRepository;
 
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 
 @Slf4j
@@ -19,37 +16,19 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TestCloseScheduleInitializer implements ApplicationRunner {
 
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-
     private final TestRepository testRepository;
     private final TestCloseScheduler testCloseScheduler;
-    private final TestCloseProcessor testCloseProcessor;
-    private final Clock clock;
 
     @Override
     public void run(ApplicationArguments args) {
-        LocalDateTime now = LocalDateTime.now(clock.withZone(KST));
         List<Test> inProgressTests = testRepository.findByTestStatusAndDeletedAtIsNull(TestStatus.IN_PROGRESS);
 
         log.info("진행 중 테스트 자동 종료 예약 복원 대상: {}개", inProgressTests.size());
 
         for (Test test : inProgressTests) {
-            if (test.getClosedAt() == null) {
-                continue;
+            if (test.getClosedAt() != null) {
+                testCloseScheduler.schedule(test.getId(), test.getClosedAt());
             }
-            if (!test.getClosedAt().isAfter(now)) {
-                closeImmediately(test.getId());
-                continue;
-            }
-            testCloseScheduler.schedule(test.getId(), test.getClosedAt());
-        }
-    }
-
-    private void closeImmediately(Long testId) {
-        try {
-            testCloseProcessor.process(testId);
-        } catch (Exception e) {
-            log.error("테스트 {} 기한 만료 즉시 종료 실패 - 자정 스케줄러에서 재처리됩니다", testId, e);
         }
     }
 }

--- a/src/main/java/server/MATE/domain/test/service/TestCloseScheduler.java
+++ b/src/main/java/server/MATE/domain/test/service/TestCloseScheduler.java
@@ -1,0 +1,38 @@
+package server.MATE.domain.test.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TestCloseScheduler {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final ThreadPoolTaskScheduler taskScheduler;
+    private final TestCloseProcessor testCloseProcessor;
+
+    public void schedule(Long testId, LocalDateTime closedAt) {
+        if (closedAt == null) {
+            log.warn("테스트 {} 마감 시각이 없어 자동 종료 예약을 건너뜁니다", testId);
+            return;
+        }
+
+        Instant triggerAt = closedAt.atZone(KST).toInstant();
+        taskScheduler.schedule(() -> {
+            try {
+                testCloseProcessor.process(testId);
+            } catch (Exception e) {
+                log.error("테스트 {} 자동 종료 실패 - 자정 스케줄러에서 재처리됩니다", testId, e);
+            }
+        }, triggerAt);
+        log.info("테스트 {} 자동 종료 예약 완료 - {}", testId, closedAt);
+    }
+}

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -3,6 +3,8 @@ package server.MATE.domain.test.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import server.MATE.domain.participation.repository.ParticipationRepository;
 import server.MATE.domain.test.dto.response.*;
 import server.MATE.domain.test.entity.Test;
@@ -91,7 +93,14 @@ public class TestService {
                     throw new BaseException(BaseErrorCode.TEST_007);
                 }
                 test.start();
-                testCloseScheduler.schedule(test.getId(), test.getClosedAt());
+                Long approvedTestId = test.getId();
+                LocalDateTime closedAt = test.getClosedAt();
+                TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        testCloseScheduler.schedule(approvedTestId, closedAt);
+                    }
+                });
             }
             case REJECTED -> {
                 if (role != Role.ADMIN) {

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -1,8 +1,6 @@
 package server.MATE.domain.test.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.MATE.domain.participation.repository.ParticipationRepository;
@@ -18,7 +16,6 @@ import server.MATE.global.common.exception.BaseException;
 import server.MATE.global.storage.FileStorageService;
 
 import java.time.Clock;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -26,7 +23,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -39,7 +35,7 @@ public class TestService {
     private final ParticipationRepository participationRepository;
     private final FileStorageService fileStorageService;
     private final TestCloseProcessor testCloseProcessor;
-    private final ThreadPoolTaskScheduler taskScheduler;
+    private final TestCloseScheduler testCloseScheduler;
     private final Clock clock;
 
     @Transactional(readOnly = true)
@@ -95,7 +91,7 @@ public class TestService {
                     throw new BaseException(BaseErrorCode.TEST_007);
                 }
                 test.start();
-                scheduleClose(test.getId(), test.getClosedAt());
+                testCloseScheduler.schedule(test.getId(), test.getClosedAt());
             }
             case REJECTED -> {
                 if (role != Role.ADMIN) {
@@ -196,22 +192,5 @@ public class TestService {
                 .map(Test::getId)
                 .toList();
         return new HashSet<>(testLikeRepository.findLikedTestIds(userId, testIds));
-    }
-
-    private void scheduleClose(Long testId, LocalDateTime closedAt) {
-        if (closedAt == null) {
-            log.warn("테스트 {} 마감 시각이 없어 자동 종료 예약을 건너뜁니다", testId);
-            return;
-        }
-
-        Instant triggerAt = closedAt.atZone(KST).toInstant();
-        taskScheduler.schedule(() -> {
-            try {
-                testCloseProcessor.process(testId);
-            } catch (Exception e) {
-                log.error("테스트 {} 자동 종료 실패 - 자정 스케줄러에서 재처리됩니다", testId, e);
-            }
-        }, triggerAt);
-        log.info("테스트 {} 자동 종료 예약 완료 - {}", testId, closedAt);
     }
 }

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -199,6 +199,11 @@ public class TestService {
     }
 
     private void scheduleClose(Long testId, LocalDateTime closedAt) {
+        if (closedAt == null) {
+            log.warn("테스트 {} 마감 시각이 없어 자동 종료 예약을 건너뜁니다", testId);
+            return;
+        }
+
         Instant triggerAt = closedAt.atZone(KST).toInstant();
         taskScheduler.schedule(() -> {
             try {

--- a/src/main/java/server/MATE/domain/test/service/TestService.java
+++ b/src/main/java/server/MATE/domain/test/service/TestService.java
@@ -1,6 +1,8 @@
 package server.MATE.domain.test.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.MATE.domain.participation.repository.ParticipationRepository;
@@ -16,6 +18,7 @@ import server.MATE.global.common.exception.BaseException;
 import server.MATE.global.storage.FileStorageService;
 
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -23,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -35,6 +39,7 @@ public class TestService {
     private final ParticipationRepository participationRepository;
     private final FileStorageService fileStorageService;
     private final TestCloseProcessor testCloseProcessor;
+    private final ThreadPoolTaskScheduler taskScheduler;
     private final Clock clock;
 
     @Transactional(readOnly = true)
@@ -90,6 +95,7 @@ public class TestService {
                     throw new BaseException(BaseErrorCode.TEST_007);
                 }
                 test.start();
+                scheduleClose(test.getId(), test.getClosedAt());
             }
             case REJECTED -> {
                 if (role != Role.ADMIN) {
@@ -190,5 +196,17 @@ public class TestService {
                 .map(Test::getId)
                 .toList();
         return new HashSet<>(testLikeRepository.findLikedTestIds(userId, testIds));
+    }
+
+    private void scheduleClose(Long testId, LocalDateTime closedAt) {
+        Instant triggerAt = closedAt.atZone(KST).toInstant();
+        taskScheduler.schedule(() -> {
+            try {
+                testCloseProcessor.process(testId);
+            } catch (Exception e) {
+                log.error("테스트 {} 자동 종료 실패 - 자정 스케줄러에서 재처리됩니다", testId, e);
+            }
+        }, triggerAt);
+        log.info("테스트 {} 자동 종료 예약 완료 - {}", testId, closedAt);
     }
 }

--- a/src/main/java/server/MATE/domain/testdraft/dto/response/PaymentAmountResponse.java
+++ b/src/main/java/server/MATE/domain/testdraft/dto/response/PaymentAmountResponse.java
@@ -1,0 +1,25 @@
+package server.MATE.domain.testdraft.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import server.MATE.domain.payment.policy.PaymentAmountBreakdown;
+
+@Schema(description = "결제 금액 내역")
+public record PaymentAmountResponse(
+        @Schema(description = "테스터 리워드 총액", example = "10000")
+        int testerRewardAmount,
+        @Schema(description = "수수료", example = "6667")
+        int feeAmount,
+        @Schema(description = "부가세", example = "1667")
+        int vatAmount,
+        @Schema(description = "최종 결제 금액", example = "18334")
+        int totalAmount
+) {
+    public static PaymentAmountResponse from(PaymentAmountBreakdown breakdown) {
+        return new PaymentAmountResponse(
+                breakdown.testerRewardAmount(),
+                breakdown.feeAmount(),
+                breakdown.vatAmount(),
+                breakdown.totalAmount()
+        );
+    }
+}

--- a/src/main/java/server/MATE/domain/testdraft/dto/response/TestDraftResponse.java
+++ b/src/main/java/server/MATE/domain/testdraft/dto/response/TestDraftResponse.java
@@ -23,9 +23,10 @@ public record TestDraftResponse(
         TestDraftStatus status,
         Long publishedTestId,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        PaymentAmountResponse amountBreakdown
 ) {
-    public static TestDraftResponse from(TestDraft draft, JsonNode questionsPayload) {
+    public static TestDraftResponse from(TestDraft draft, JsonNode questionsPayload, PaymentAmountResponse amountBreakdown) {
         return new TestDraftResponse(
                 draft.getId(),
                 draft.getMakerId(),
@@ -42,7 +43,8 @@ public record TestDraftResponse(
                 draft.getStatus(),
                 draft.getPublishedTestId(),
                 draft.getCreatedAt(),
-                draft.getUpdatedAt()
+                draft.getUpdatedAt(),
+                amountBreakdown
         );
     }
 }

--- a/src/main/java/server/MATE/domain/testdraft/service/TestDraftService.java
+++ b/src/main/java/server/MATE/domain/testdraft/service/TestDraftService.java
@@ -102,7 +102,7 @@ public class TestDraftService {
     }
 
     private PaymentAmountResponse computeAmountBreakdown(TestDraft draft) {
-        if (draft.getGoalPpl() == null || draft.getReward() == null) {
+        if (draft.getGoalPpl() == null || draft.getReward() == null || draft.getClosedAt() == null) {
             return null;
         }
         return PaymentAmountResponse.from(paymentAmountCalculator.breakdown(draft.getGoalPpl(), draft.getReward()));

--- a/src/main/java/server/MATE/domain/testdraft/service/TestDraftService.java
+++ b/src/main/java/server/MATE/domain/testdraft/service/TestDraftService.java
@@ -5,10 +5,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import server.MATE.domain.payment.policy.PaymentAmountCalculator;
 import server.MATE.domain.testdraft.dto.request.TestDraftClosedAtParser;
 import server.MATE.domain.testdraft.dto.request.TestDraftUpdateRequest;
 import server.MATE.domain.testdraft.dto.response.MyTestDraftItem;
 import server.MATE.domain.testdraft.dto.response.MyTestDraftResponse;
+import server.MATE.domain.testdraft.dto.response.PaymentAmountResponse;
 import server.MATE.domain.testdraft.dto.response.TestDraftResponse;
 import server.MATE.domain.testdraft.entity.TestDraft;
 import server.MATE.domain.testdraft.repository.TestDraftRepository;
@@ -26,18 +28,19 @@ public class TestDraftService {
 
     private final TestDraftRepository testDraftRepository;
     private final ObjectMapper objectMapper;
+    private final PaymentAmountCalculator paymentAmountCalculator;
 
     public TestDraftResponse createDraft(Long makerId) {
         TestDraft draft = testDraftRepository.save(TestDraft.builder()
                 .makerId(makerId)
                 .build());
-        return TestDraftResponse.from(draft, null);
+        return TestDraftResponse.from(draft, null, null);
     }
 
     @Transactional(readOnly = true)
     public TestDraftResponse getDraft(Long draftId, Long makerId) {
         TestDraft draft = getOwnedDraft(draftId, makerId);
-        return TestDraftResponse.from(draft, toJsonNode(draft.getQuestionsPayload()));
+        return TestDraftResponse.from(draft, toJsonNode(draft.getQuestionsPayload()), computeAmountBreakdown(draft));
     }
 
     @Transactional(readOnly = true)
@@ -63,7 +66,7 @@ public class TestDraftService {
                 parseClosedAt(request.closedAt()),
                 toMap(request.questionsPayload())
         );
-        return TestDraftResponse.from(draft, toJsonNode(draft.getQuestionsPayload()));
+        return TestDraftResponse.from(draft, toJsonNode(draft.getQuestionsPayload()), computeAmountBreakdown(draft));
     }
 
     public void deleteDraft(Long draftId, Long makerId) {
@@ -96,5 +99,12 @@ public class TestDraftService {
         return payload == null || !payload.isObject()
                 ? null
                 : objectMapper.convertValue(payload, Map.class);
+    }
+
+    private PaymentAmountResponse computeAmountBreakdown(TestDraft draft) {
+        if (draft.getGoalPpl() == null || draft.getReward() == null) {
+            return null;
+        }
+        return PaymentAmountResponse.from(paymentAmountCalculator.breakdown(draft.getGoalPpl(), draft.getReward()));
     }
 }

--- a/src/main/java/server/MATE/domain/testdraft/service/TestDraftService.java
+++ b/src/main/java/server/MATE/domain/testdraft/service/TestDraftService.java
@@ -102,9 +102,9 @@ public class TestDraftService {
     }
 
     private PaymentAmountResponse computeAmountBreakdown(TestDraft draft) {
-        if (draft.getGoalPpl() == null || draft.getReward() == null || draft.getClosedAt() == null) {
-            return null;
-        }
+        if (draft.getGoalPpl() == null || draft.getGoalPpl() <= 0) return null;
+        if (draft.getReward() == null || draft.getReward() <= 0) return null;
+        if (draft.getClosedAt() == null) return null;
         return PaymentAmountResponse.from(paymentAmountCalculator.breakdown(draft.getGoalPpl(), draft.getReward()));
     }
 }

--- a/src/main/java/server/MATE/global/config/SchedulingConfig.java
+++ b/src/main/java/server/MATE/global/config/SchedulingConfig.java
@@ -1,0 +1,17 @@
+package server.MATE.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulingConfig {
+
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(4);
+        scheduler.setThreadNamePrefix("test-close-");
+        return scheduler;
+    }
+}

--- a/src/main/java/server/MATE/global/config/SchedulingConfig.java
+++ b/src/main/java/server/MATE/global/config/SchedulingConfig.java
@@ -7,11 +7,13 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 @Configuration
 public class SchedulingConfig {
 
-    @Bean
+    @Bean(destroyMethod = "shutdown")
     public ThreadPoolTaskScheduler taskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
         scheduler.setPoolSize(4);
         scheduler.setThreadNamePrefix("test-close-");
+        scheduler.setRemoveOnCancelPolicy(true);
+        scheduler.initialize();
         return scheduler;
     }
 }

--- a/src/test/java/server/MATE/domain/test/service/TestCloseScheduleInitializerTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestCloseScheduleInitializerTest.java
@@ -1,0 +1,114 @@
+package server.MATE.domain.test.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.DefaultApplicationArguments;
+import org.springframework.test.util.ReflectionTestUtils;
+import server.MATE.domain.test.entity.TestStatus;
+import server.MATE.domain.test.repository.TestRepository;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TestCloseScheduleInitializerTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Mock
+    private TestRepository testRepository;
+
+    @Mock
+    private TestCloseScheduler testCloseScheduler;
+
+    @Mock
+    private TestCloseProcessor testCloseProcessor;
+
+    private TestCloseScheduleInitializer initializer;
+
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.fixed(Instant.parse("2026-07-12T03:00:00Z"), KST);
+        initializer = new TestCloseScheduleInitializer(
+                testRepository,
+                testCloseScheduler,
+                testCloseProcessor,
+                clock
+        );
+    }
+
+    @Test
+    @DisplayName("마감 시각이 남은 진행 중 테스트는 자동 종료 예약을 복원한다")
+    void restoresScheduleForFutureTests() throws Exception {
+        server.MATE.domain.test.entity.Test futureTest = inProgressTest(
+                1L,
+                LocalDateTime.of(2099, 12, 31, 23, 59, 59)
+        );
+        given(testRepository.findByTestStatusAndDeletedAtIsNull(TestStatus.IN_PROGRESS))
+                .willReturn(List.of(futureTest));
+
+        initializer.run(new DefaultApplicationArguments(new String[]{}));
+
+        verify(testCloseScheduler).schedule(1L, futureTest.getClosedAt());
+        verify(testCloseProcessor, never()).process(1L);
+    }
+
+    @Test
+    @DisplayName("마감 시각이 지난 진행 중 테스트는 즉시 종료한다")
+    void closesExpiredTestsImmediately() throws Exception {
+        server.MATE.domain.test.entity.Test expiredTest = inProgressTest(
+                2L,
+                LocalDateTime.of(2020, 1, 1, 23, 59, 59)
+        );
+        given(testRepository.findByTestStatusAndDeletedAtIsNull(TestStatus.IN_PROGRESS))
+                .willReturn(List.of(expiredTest));
+
+        initializer.run(new DefaultApplicationArguments(new String[]{}));
+
+        verify(testCloseProcessor).process(2L);
+        verify(testCloseScheduler, never()).schedule(2L, expiredTest.getClosedAt());
+    }
+
+    @Test
+    @DisplayName("closedAt이 없는 진행 중 테스트는 복원 대상에서 제외한다")
+    void skipsTestsWithoutClosedAt() throws Exception {
+        server.MATE.domain.test.entity.Test testWithoutClosedAt = inProgressTest(
+                3L,
+                LocalDateTime.of(2099, 12, 31, 23, 59, 59)
+        );
+        ReflectionTestUtils.setField(testWithoutClosedAt, "closedAt", null);
+        given(testRepository.findByTestStatusAndDeletedAtIsNull(TestStatus.IN_PROGRESS))
+                .willReturn(List.of(testWithoutClosedAt));
+
+        initializer.run(new DefaultApplicationArguments(new String[]{}));
+
+        verify(testCloseScheduler, never()).schedule(3L, null);
+        verify(testCloseProcessor, never()).process(3L);
+    }
+
+    private server.MATE.domain.test.entity.Test inProgressTest(Long id, LocalDateTime closedAt) {
+        server.MATE.domain.test.entity.Test test = server.MATE.domain.test.entity.Test.builder()
+                .makerId(1L)
+                .title("테스트")
+                .description("설명")
+                .serviceName("서비스")
+                .serviceDescription("서비스 설명")
+                .imageKeys(List.of())
+                .closedAt(closedAt)
+                .testStatus(TestStatus.IN_PROGRESS)
+                .build();
+        ReflectionTestUtils.setField(test, "id", id);
+        return test;
+    }
+}

--- a/src/test/java/server/MATE/domain/test/service/TestCloseScheduleInitializerTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestCloseScheduleInitializerTest.java
@@ -11,10 +11,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import server.MATE.domain.test.entity.TestStatus;
 import server.MATE.domain.test.repository.TestRepository;
 
-import java.time.Clock;
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 
 import static org.mockito.BDDMockito.given;
@@ -24,28 +21,17 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 class TestCloseScheduleInitializerTest {
 
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-
     @Mock
     private TestRepository testRepository;
 
     @Mock
     private TestCloseScheduler testCloseScheduler;
 
-    @Mock
-    private TestCloseProcessor testCloseProcessor;
-
     private TestCloseScheduleInitializer initializer;
 
     @BeforeEach
     void setUp() {
-        Clock clock = Clock.fixed(Instant.parse("2026-07-12T03:00:00Z"), KST);
-        initializer = new TestCloseScheduleInitializer(
-                testRepository,
-                testCloseScheduler,
-                testCloseProcessor,
-                clock
-        );
+        initializer = new TestCloseScheduleInitializer(testRepository, testCloseScheduler);
     }
 
     @Test
@@ -61,12 +47,11 @@ class TestCloseScheduleInitializerTest {
         initializer.run(new DefaultApplicationArguments(new String[]{}));
 
         verify(testCloseScheduler).schedule(1L, futureTest.getClosedAt());
-        verify(testCloseProcessor, never()).process(1L);
     }
 
     @Test
-    @DisplayName("마감 시각이 지난 진행 중 테스트는 즉시 종료한다")
-    void closesExpiredTestsImmediately() throws Exception {
+    @DisplayName("마감 시각이 지난 진행 중 테스트도 스케줄러에 위임한다 (백그라운드 즉시 실행)")
+    void delegatesExpiredTestsToScheduler() throws Exception {
         server.MATE.domain.test.entity.Test expiredTest = inProgressTest(
                 2L,
                 LocalDateTime.of(2020, 1, 1, 23, 59, 59)
@@ -76,8 +61,7 @@ class TestCloseScheduleInitializerTest {
 
         initializer.run(new DefaultApplicationArguments(new String[]{}));
 
-        verify(testCloseProcessor).process(2L);
-        verify(testCloseScheduler, never()).schedule(2L, expiredTest.getClosedAt());
+        verify(testCloseScheduler).schedule(2L, expiredTest.getClosedAt());
     }
 
     @Test
@@ -94,7 +78,6 @@ class TestCloseScheduleInitializerTest {
         initializer.run(new DefaultApplicationArguments(new String[]{}));
 
         verify(testCloseScheduler, never()).schedule(3L, null);
-        verify(testCloseProcessor, never()).process(3L);
     }
 
     private server.MATE.domain.test.entity.Test inProgressTest(Long id, LocalDateTime closedAt) {

--- a/src/test/java/server/MATE/domain/test/service/TestCloseSchedulerTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestCloseSchedulerTest.java
@@ -1,0 +1,58 @@
+package server.MATE.domain.test.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TestCloseSchedulerTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Mock
+    private ThreadPoolTaskScheduler taskScheduler;
+
+    @Mock
+    private TestCloseProcessor testCloseProcessor;
+
+    private TestCloseScheduler testCloseScheduler;
+
+    @BeforeEach
+    void setUp() {
+        testCloseScheduler = new TestCloseScheduler(taskScheduler, testCloseProcessor);
+    }
+
+    @Test
+    @DisplayName("closedAt이 있으면 해당 시각에 자동 종료를 예약한다")
+    void schedulesCloseAtClosedAt() {
+        LocalDateTime closedAt = LocalDateTime.of(2099, 12, 31, 23, 59, 59);
+
+        testCloseScheduler.schedule(10L, closedAt);
+
+        ArgumentCaptor<Instant> triggerCaptor = ArgumentCaptor.forClass(Instant.class);
+        verify(taskScheduler).schedule(any(Runnable.class), triggerCaptor.capture());
+        assertThat(triggerCaptor.getValue()).isEqualTo(closedAt.atZone(KST).toInstant());
+    }
+
+    @Test
+    @DisplayName("closedAt이 없으면 자동 종료 예약을 건너뛴다")
+    void skipsScheduleWhenClosedAtIsNull() {
+        testCloseScheduler.schedule(10L, null);
+
+        verify(taskScheduler, never()).schedule(any(Runnable.class), any(Instant.class));
+    }
+}

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import org.junit.jupiter.api.Assertions;
@@ -55,6 +56,9 @@ class TestServiceTest {
 
     @Mock
     private FileStorageService fileStorageService;
+
+    @Mock
+    private ThreadPoolTaskScheduler taskScheduler;
 
     @Mock
     private Clock clock;
@@ -235,6 +239,7 @@ class TestServiceTest {
         TestStatusUpdateResponse response = testService.updateTestStatus(TEST_ID, 999L, Role.ADMIN, TestStatus.IN_PROGRESS);
 
         assertThat(response.testStatus()).isEqualTo(TestStatus.IN_PROGRESS);
+        verify(taskScheduler).schedule(any(Runnable.class), any(Instant.class));
     }
 
     @Test

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import org.junit.jupiter.api.Assertions;
@@ -58,7 +57,7 @@ class TestServiceTest {
     private FileStorageService fileStorageService;
 
     @Mock
-    private ThreadPoolTaskScheduler taskScheduler;
+    private TestCloseScheduler testCloseScheduler;
 
     @Mock
     private Clock clock;
@@ -239,7 +238,7 @@ class TestServiceTest {
         TestStatusUpdateResponse response = testService.updateTestStatus(TEST_ID, 999L, Role.ADMIN, TestStatus.IN_PROGRESS);
 
         assertThat(response.testStatus()).isEqualTo(TestStatus.IN_PROGRESS);
-        verify(taskScheduler).schedule(any(Runnable.class), any(Instant.class));
+        verify(testCloseScheduler).schedule(TEST_ID, test.getClosedAt());
     }
 
     @Test

--- a/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
+++ b/src/test/java/server/MATE/domain/test/service/TestServiceTest.java
@@ -35,6 +35,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -235,10 +237,19 @@ class TestServiceTest {
         ReflectionTestUtils.setField(test, "testStatus", TestStatus.WAITING);
         given(testRepository.findActiveById(TEST_ID)).willReturn(Optional.of(test));
 
-        TestStatusUpdateResponse response = testService.updateTestStatus(TEST_ID, 999L, Role.ADMIN, TestStatus.IN_PROGRESS);
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            TestStatusUpdateResponse response = testService.updateTestStatus(TEST_ID, 999L, Role.ADMIN, TestStatus.IN_PROGRESS);
 
-        assertThat(response.testStatus()).isEqualTo(TestStatus.IN_PROGRESS);
-        verify(testCloseScheduler).schedule(TEST_ID, test.getClosedAt());
+            assertThat(response.testStatus()).isEqualTo(TestStatus.IN_PROGRESS);
+
+            TransactionSynchronizationManager.getSynchronizations()
+                    .forEach(sync -> sync.afterCommit());
+
+            verify(testCloseScheduler).schedule(TEST_ID, test.getClosedAt());
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
     }
 
     @Test

--- a/src/test/java/server/MATE/domain/testdraft/controller/TestDraftControllerTest.java
+++ b/src/test/java/server/MATE/domain/testdraft/controller/TestDraftControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import server.MATE.domain.auth.jwt.TokenType;
 import server.MATE.domain.testdraft.dto.response.MyTestDraftItem;
 import server.MATE.domain.testdraft.dto.response.MyTestDraftResponse;
+import server.MATE.domain.testdraft.dto.response.PaymentAmountResponse;
 import server.MATE.domain.testdraft.dto.response.TestDraftResponse;
 import server.MATE.domain.testdraft.entity.TestDraftStatus;
 import server.MATE.domain.testdraft.service.TestDraftService;
@@ -93,7 +94,11 @@ class TestDraftControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("테스트 초안을 조회했습니다."))
                 .andExpect(jsonPath("$.data.draftId").value(10L))
-                .andExpect(jsonPath("$.data.questionsPayload.questions[0].type").value("OBJECTIVE"));
+                .andExpect(jsonPath("$.data.questionsPayload.questions[0].type").value("OBJECTIVE"))
+                .andExpect(jsonPath("$.data.amountBreakdown.testerRewardAmount").value(30000))
+                .andExpect(jsonPath("$.data.amountBreakdown.feeAmount").value(20000))
+                .andExpect(jsonPath("$.data.amountBreakdown.vatAmount").value(5000))
+                .andExpect(jsonPath("$.data.amountBreakdown.totalAmount").value(55000));
     }
 
     @Test
@@ -234,7 +239,7 @@ class TestDraftControllerTest {
                 null,
                 LocalDateTime.parse("2026-05-25T11:00:00"),
                 LocalDateTime.parse("2026-05-25T12:00:00"),
-                new server.MATE.domain.testdraft.dto.response.PaymentAmountResponse(30000, 20001, 5001, 55002)
+                new PaymentAmountResponse(30000, 20000, 5000, 55000)
         );
     }
 

--- a/src/test/java/server/MATE/domain/testdraft/controller/TestDraftControllerTest.java
+++ b/src/test/java/server/MATE/domain/testdraft/controller/TestDraftControllerTest.java
@@ -233,7 +233,8 @@ class TestDraftControllerTest {
                 TestDraftStatus.DRAFT,
                 null,
                 LocalDateTime.parse("2026-05-25T11:00:00"),
-                LocalDateTime.parse("2026-05-25T12:00:00")
+                LocalDateTime.parse("2026-05-25T12:00:00"),
+                new server.MATE.domain.testdraft.dto.response.PaymentAmountResponse(30000, 20001, 5001, 55002)
         );
     }
 

--- a/src/test/java/server/MATE/domain/testdraft/service/TestDraftServiceTest.java
+++ b/src/test/java/server/MATE/domain/testdraft/service/TestDraftServiceTest.java
@@ -62,6 +62,28 @@ class TestDraftServiceTest {
         assertThat(response.amountBreakdown()).isNull();
     }
 
+    @Test
+    @DisplayName("리워드가 0원이면 결제 금액 내역을 반환하지 않는다")
+    void returnsNullAmountBreakdownWhenRewardIsZero() {
+        TestDraft draft = draftWith(30, 0, LocalDateTime.parse("2099-06-30T23:59:59"));
+        given(testDraftRepository.findById(10L)).willReturn(Optional.of(draft));
+
+        TestDraftResponse response = testDraftService.getDraft(10L, 1L);
+
+        assertThat(response.amountBreakdown()).isNull();
+    }
+
+    @Test
+    @DisplayName("목표 인원이 0명이면 결제 금액 내역을 반환하지 않는다")
+    void returnsNullAmountBreakdownWhenGoalPplIsZero() {
+        TestDraft draft = draftWith(0, 200, LocalDateTime.parse("2099-06-30T23:59:59"));
+        given(testDraftRepository.findById(10L)).willReturn(Optional.of(draft));
+
+        TestDraftResponse response = testDraftService.getDraft(10L, 1L);
+
+        assertThat(response.amountBreakdown()).isNull();
+    }
+
     private TestDraft draftWith(int goalPpl, int reward, LocalDateTime closedAt) {
         TestDraft draft = TestDraft.builder()
                 .makerId(1L)

--- a/src/test/java/server/MATE/domain/testdraft/service/TestDraftServiceTest.java
+++ b/src/test/java/server/MATE/domain/testdraft/service/TestDraftServiceTest.java
@@ -1,0 +1,75 @@
+package server.MATE.domain.testdraft.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import server.MATE.domain.payment.policy.DefaultPaymentAmountCalculator;
+import server.MATE.domain.payment.policy.PaymentAmountCalculator;
+import server.MATE.domain.testdraft.dto.response.PaymentAmountResponse;
+import server.MATE.domain.testdraft.dto.response.TestDraftResponse;
+import server.MATE.domain.testdraft.entity.TestDraft;
+import server.MATE.domain.testdraft.repository.TestDraftRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class TestDraftServiceTest {
+
+    @Mock
+    private TestDraftRepository testDraftRepository;
+
+    private TestDraftService testDraftService;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+        PaymentAmountCalculator paymentAmountCalculator = new DefaultPaymentAmountCalculator();
+        testDraftService = new TestDraftService(testDraftRepository, objectMapper, paymentAmountCalculator);
+    }
+
+    @Test
+    @DisplayName("기간·인원·리워드가 모두 있으면 결제 금액 내역을 반환한다")
+    void returnsAmountBreakdownWhenAllPaymentFieldsArePresent() {
+        TestDraft draft = draftWith(30, 200, LocalDateTime.parse("2099-06-30T23:59:59"));
+        given(testDraftRepository.findById(10L)).willReturn(Optional.of(draft));
+
+        TestDraftResponse response = testDraftService.getDraft(10L, 1L);
+
+        PaymentAmountResponse amountBreakdown = response.amountBreakdown();
+        assertThat(amountBreakdown.testerRewardAmount()).isEqualTo(6000);
+        assertThat(amountBreakdown.feeAmount()).isEqualTo(4000);
+        assertThat(amountBreakdown.vatAmount()).isEqualTo(1000);
+        assertThat(amountBreakdown.totalAmount()).isEqualTo(11000);
+    }
+
+    @Test
+    @DisplayName("closedAt이 없으면 결제 금액 내역을 반환하지 않는다")
+    void returnsNullAmountBreakdownWhenClosedAtIsMissing() {
+        TestDraft draft = draftWith(30, 200, null);
+        given(testDraftRepository.findById(10L)).willReturn(Optional.of(draft));
+
+        TestDraftResponse response = testDraftService.getDraft(10L, 1L);
+
+        assertThat(response.amountBreakdown()).isNull();
+    }
+
+    private TestDraft draftWith(int goalPpl, int reward, LocalDateTime closedAt) {
+        TestDraft draft = TestDraft.builder()
+                .makerId(1L)
+                .goalPpl(goalPpl)
+                .reward(reward)
+                .closedAt(closedAt)
+                .build();
+        ReflectionTestUtils.setField(draft, "id", 10L);
+        return draft;
+    }
+}


### PR DESCRIPTION
## 📍 요약
                                                                                                                               
  - 테스트 초안 입력 시 결제 금액을 즉시 확인할 수 있도록 응답에 추가하고, 자정 기준이던 자동 환불을 테스트 응답 기간 종료 시각(closedAt) 기준으로 변경     
## 🔗 관련 이슈
- Closes #249 

## 📌 변경 사항
- [x] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
  결제 금액 조회                                                                                                                                   
  - PATCH, GET 응답에 amountBreakdown 필드 추가                                        
    - goalPpl, reward, closedAt 모두 입력되고 각각 0 초과인 경우에만 반환                                                                          
    - 항목: 테스터 리워드 총액 / 수수료 / 부가세 / 최종 결제 금액                                                                                  
  - PaymentAmountResponse DTO 신규 추가                                                                                                            
                                                                                                                                                   
  closedAt 기준 자동 종료 및 환불                                                                                                                  
  - 관리자 승인(WAITING → IN_PROGRESS) 시 TaskScheduler로 closedAt 시각에 테스트 자동 종료 1회 예약                                                
  - 서버 재시작 시 TestCloseScheduleInitializer가 진행 중 테스트 복원                                                                              
    - closedAt 이미 지난 테스트는 즉시 종료 처리                                                                                                   
    - 미래인 테스트는 종료 예약 복원                                                                                                               
  - TestAutoCloseScheduler(자정 cron)는 재시작 유실 대비 안전망으로 유지                                                                           
  - TestAutoCloseScheduler에 @SchedulerLock 추가해 멀티 인스턴스 중복 실행 방지                                                                    
                                                                                                                                                   
  버그 수정                                                                                                                                        
  - goalPpl 또는 reward가 0일 때 amountBreakdown: null 반환하도록 수정                                                                             
            

## 테스트
- [ ] 로컬 테스트 완료
- 테스트 방법: