### PR TITLE
feat: 토스 프로모션 전용 에러 파서 추가

### DIFF
--- a/src/main/java/server/MATE/toss/exception/parser/DefaultTossErrorResponseParser.java
+++ b/src/main/java/server/MATE/toss/exception/parser/DefaultTossErrorResponseParser.java
@@ -57,14 +57,4 @@ public class DefaultTossErrorResponseParser implements TossErrorResponseParser {
         ));
     }
 
-    private String textOrDefault(JsonNode node, String defaultValue) {
-        if (node == null || node.isMissingNode() || node.isNull() || node.asText().isBlank()) {
-            return defaultValue;
-        }
-        return node.asText();
-    }
-
-    private TossErrorContext result(TossErrorCode errorCode, TossErrorResponse errorResponse) {
-        return new TossErrorContext(errorCode, errorResponse);
-    }
 }

--- a/src/main/java/server/MATE/toss/exception/parser/TossErrorResponseParser.java
+++ b/src/main/java/server/MATE/toss/exception/parser/TossErrorResponseParser.java
@@ -1,10 +1,24 @@
 package server.MATE.toss.exception.parser;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.http.HttpStatusCode;
+import server.MATE.toss.exception.TossErrorCode;
+import server.MATE.toss.response.TossErrorResponse;
 
 public interface TossErrorResponseParser {
 
     boolean supports(HttpStatusCode statusCode, String path, String responseBody);
 
     TossErrorContext parse(HttpStatusCode statusCode, String path, String responseBody);
+
+    default String textOrDefault(JsonNode node, String defaultValue) {
+        if (node == null || node.isMissingNode() || node.isNull() || node.asText().isBlank()) {
+            return defaultValue;
+        }
+        return node.asText();
+    }
+
+    default TossErrorContext result(TossErrorCode errorCode, TossErrorResponse errorResponse) {
+        return new TossErrorContext(errorCode, errorResponse);
+    }
 }

--- a/src/main/java/server/MATE/toss/exception/parser/TossLoginErrorResponseParser.java
+++ b/src/main/java/server/MATE/toss/exception/parser/TossLoginErrorResponseParser.java
@@ -190,14 +190,4 @@ public class TossLoginErrorResponseParser implements TossErrorResponseParser {
         ));
     }
 
-    private String textOrDefault(JsonNode node, String defaultValue) {
-        if (node == null || node.isMissingNode() || node.isNull() || node.asText().isBlank()) {
-            return defaultValue;
-        }
-        return node.asText();
-    }
-
-    private TossErrorContext result(TossErrorCode errorCode, TossErrorResponse errorResponse) {
-        return new TossErrorContext(errorCode, errorResponse);
-    }
 }

--- a/src/main/java/server/MATE/toss/exception/parser/TossPromotionErrorResponseParser.java
+++ b/src/main/java/server/MATE/toss/exception/parser/TossPromotionErrorResponseParser.java
@@ -33,6 +33,10 @@ public class TossPromotionErrorResponseParser implements TossErrorResponseParser
     @Override
     public TossErrorContext parse(HttpStatusCode statusCode, String path, String responseBody) {
         String defaultReason = defaultReasonFor(path);
+        if (responseBody == null || responseBody.isBlank()) {
+            return result(TossErrorCode.TOSS_001, new TossErrorResponse(UNKNOWN_PROMOTION_ERROR_CODE, defaultReason));
+        }
+
         try {
             JsonNode root = objectMapper.readTree(responseBody);
             JsonNode error = root.path("error");
@@ -46,7 +50,7 @@ public class TossPromotionErrorResponseParser implements TossErrorResponseParser
             }
 
             if (error.isTextual()) {
-                String errorCode = error.asText(UNKNOWN_PROMOTION_ERROR_CODE);
+                String errorCode = textOrDefault(error, UNKNOWN_PROMOTION_ERROR_CODE);
                 TossErrorResponse errorResponse = new TossErrorResponse(
                         errorCode,
                         textOrDefault(root.path("error_description"), defaultReason)

--- a/src/main/java/server/MATE/toss/exception/parser/TossPromotionErrorResponseParser.java
+++ b/src/main/java/server/MATE/toss/exception/parser/TossPromotionErrorResponseParser.java
@@ -1,0 +1,75 @@
+package server.MATE.toss.exception.parser;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import server.MATE.toss.exception.TossErrorCode;
+import server.MATE.toss.response.TossErrorResponse;
+
+@Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)
+@Component
+@RequiredArgsConstructor
+public class TossPromotionErrorResponseParser implements TossErrorResponseParser {
+
+    private static final String PROMOTION_API_PREFIX = "/api-partner/v1/apps-in-toss/promotion";
+    private static final String GET_KEY_PATH = PROMOTION_API_PREFIX + "/execute-promotion/get-key";
+    private static final String EXECUTE_PATH = PROMOTION_API_PREFIX + "/execute-promotion";
+    private static final String RESULT_PATH = PROMOTION_API_PREFIX + "/execution-result";
+    private static final String UNKNOWN_PROMOTION_ERROR_CODE = "TOSS_PROMOTION_UNKNOWN_ERROR";
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean supports(HttpStatusCode statusCode, String path, String responseBody) {
+        return path != null && path.startsWith(PROMOTION_API_PREFIX);
+    }
+
+    @Override
+    public TossErrorContext parse(HttpStatusCode statusCode, String path, String responseBody) {
+        String defaultReason = defaultReasonFor(path);
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+            JsonNode error = root.path("error");
+
+            if (error.isObject()) {
+                TossErrorResponse errorResponse = new TossErrorResponse(
+                        textOrDefault(error.path("errorCode"), UNKNOWN_PROMOTION_ERROR_CODE),
+                        textOrDefault(error.path("reason"), defaultReason)
+                );
+                return result(TossErrorCode.from(errorResponse.errorCode()), errorResponse);
+            }
+
+            if (error.isTextual()) {
+                String errorCode = error.asText(UNKNOWN_PROMOTION_ERROR_CODE);
+                TossErrorResponse errorResponse = new TossErrorResponse(
+                        errorCode,
+                        textOrDefault(root.path("error_description"), defaultReason)
+                );
+                return result(TossErrorCode.from(errorCode), errorResponse);
+            }
+        } catch (Exception e) {
+            log.warn("토스 프로모션 에러 응답 파싱 실패: path={}, status={}", path, statusCode.value(), e);
+        }
+
+        return result(TossErrorCode.TOSS_001, new TossErrorResponse(UNKNOWN_PROMOTION_ERROR_CODE, defaultReason));
+    }
+
+    private String defaultReasonFor(String path) {
+        if (GET_KEY_PATH.equals(path)) {
+            return "토스 프로모션 지급 키 발급에 실패했습니다.";
+        }
+        if (EXECUTE_PATH.equals(path)) {
+            return "토스 프로모션 지급 실행에 실패했습니다.";
+        }
+        if (RESULT_PATH.equals(path)) {
+            return "토스 프로모션 지급 결과 조회에 실패했습니다.";
+        }
+        return "토스 프로모션 API 호출에 실패했습니다.";
+    }
+}

--- a/src/test/java/server/MATE/toss/client/http/TossHttpClientTest.java
+++ b/src/test/java/server/MATE/toss/client/http/TossHttpClientTest.java
@@ -18,10 +18,12 @@ import org.springframework.web.reactive.function.client.WebClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import reactor.core.publisher.Mono;
+import server.MATE.toss.dto.response.TossPromotionKeyResponse;
 import server.MATE.toss.dto.response.TossTokenResponse;
 import server.MATE.toss.exception.TossApiException;
 import server.MATE.toss.exception.TossErrorCode;
 import server.MATE.toss.exception.parser.TossLoginErrorResponseParser;
+import server.MATE.toss.exception.parser.TossPromotionErrorResponseParser;
 
 class TossHttpClientTest {
 
@@ -139,15 +141,72 @@ class TossHttpClientTest {
                 });
     }
 
+    @Test
+    @DisplayName("promotion 경로의 success wrapper를 정상 unwrap 한다")
+    void unwrapsPromotionSuccessResponse() {
+        TossHttpClient tossHttpClient = createPromotionAwareClient(request -> Mono.just(jsonResponse(
+                HttpStatus.OK,
+                """
+                {
+                  "resultType": "SUCCESS",
+                  "success": {
+                    "key": "3oBpxjUgl5r66edcVi7ynHGIjhzr9KOka6FfEKikev0="
+                  }
+                }
+                """
+        )));
+
+        TossPromotionKeyResponse response = tossHttpClient.post(
+                "/api-partner/v1/apps-in-toss/promotion/execute-promotion/get-key",
+                java.util.Map.of(),
+                TossPromotionKeyResponse.class
+        );
+
+        assertThat(response.key()).isEqualTo("3oBpxjUgl5r66edcVi7ynHGIjhzr9KOka6FfEKikev0=");
+    }
+
+    @Test
+    @DisplayName("promotion 경로의 FAIL wrapper는 TossPromotionErrorResponseParser를 통해 구체적인 코드로 변환한다")
+    void convertsPromotionFailWrapperToTossApiException() {
+        TossHttpClient tossHttpClient = createPromotionAwareClient(request -> Mono.just(jsonResponse(
+                HttpStatus.OK,
+                """
+                {
+                  "resultType": "FAIL",
+                  "error": {
+                    "errorCode": "4112",
+                    "reason": "프로모션 머니가 부족해요"
+                  }
+                }
+                """
+        )));
+
+        assertThatThrownBy(() -> tossHttpClient.post(
+                "/api-partner/v1/apps-in-toss/promotion/execute-promotion",
+                java.util.Map.of(),
+                TossPromotionKeyResponse.class
+        ))
+                .isInstanceOf(TossApiException.class)
+                .extracting(exception -> ((TossApiException) exception).getErrorCode())
+                .isEqualTo(TossErrorCode.TOSS_014);
+    }
+
     private TossHttpClient createClient(ExchangeFunction exchangeFunction) {
+        return createClientWithParsers(exchangeFunction, List.of(new TossLoginErrorResponseParser(objectMapper)));
+    }
+
+    private TossHttpClient createPromotionAwareClient(ExchangeFunction exchangeFunction) {
+        return createClientWithParsers(exchangeFunction, List.of(
+                new TossLoginErrorResponseParser(objectMapper),
+                new TossPromotionErrorResponseParser(objectMapper)
+        ));
+    }
+
+    private TossHttpClient createClientWithParsers(ExchangeFunction exchangeFunction, List<server.MATE.toss.exception.parser.TossErrorResponseParser> parsers) {
         WebClient webClient = WebClient.builder()
                 .exchangeFunction(exchangeFunction)
                 .build();
-        return new TossHttpClient(
-                webClient,
-                objectMapper,
-                List.of(new TossLoginErrorResponseParser(objectMapper))
-        );
+        return new TossHttpClient(webClient, objectMapper, parsers);
     }
 
     private ClientResponse jsonResponse(HttpStatus status, String body) {

--- a/src/test/java/server/MATE/toss/client/http/TossHttpClientTest.java
+++ b/src/test/java/server/MATE/toss/client/http/TossHttpClientTest.java
@@ -191,6 +191,21 @@ class TossHttpClientTest {
                 .isEqualTo(TossErrorCode.TOSS_014);
     }
 
+    @Test
+    @DisplayName("promotion 경로의 네트워크 예외도 TOSS_001 TossApiException으로 변환한다")
+    void convertsPromotionNetworkExceptionToToss001() {
+        TossHttpClient tossHttpClient = createPromotionAwareClient(request -> Mono.error(new IllegalStateException("network failure")));
+
+        assertThatThrownBy(() -> tossHttpClient.post(
+                "/api-partner/v1/apps-in-toss/promotion/execute-promotion/get-key",
+                java.util.Map.of(),
+                TossPromotionKeyResponse.class
+        ))
+                .isInstanceOf(TossApiException.class)
+                .extracting(exception -> ((TossApiException) exception).getErrorCode())
+                .isEqualTo(TossErrorCode.TOSS_001);
+    }
+
     private TossHttpClient createClient(ExchangeFunction exchangeFunction) {
         return createClientWithParsers(exchangeFunction, List.of(new TossLoginErrorResponseParser(objectMapper)));
     }

--- a/src/test/java/server/MATE/toss/client/http/TossHttpClientTest.java
+++ b/src/test/java/server/MATE/toss/client/http/TossHttpClientTest.java
@@ -22,6 +22,7 @@ import server.MATE.toss.dto.response.TossPromotionKeyResponse;
 import server.MATE.toss.dto.response.TossTokenResponse;
 import server.MATE.toss.exception.TossApiException;
 import server.MATE.toss.exception.TossErrorCode;
+import server.MATE.toss.exception.parser.TossErrorResponseParser;
 import server.MATE.toss.exception.parser.TossLoginErrorResponseParser;
 import server.MATE.toss.exception.parser.TossPromotionErrorResponseParser;
 
@@ -217,7 +218,7 @@ class TossHttpClientTest {
         ));
     }
 
-    private TossHttpClient createClientWithParsers(ExchangeFunction exchangeFunction, List<server.MATE.toss.exception.parser.TossErrorResponseParser> parsers) {
+    private TossHttpClient createClientWithParsers(ExchangeFunction exchangeFunction, List<TossErrorResponseParser> parsers) {
         WebClient webClient = WebClient.builder()
                 .exchangeFunction(exchangeFunction)
                 .build();

--- a/src/test/java/server/MATE/toss/exception/parser/TossPromotionErrorResponseParserTest.java
+++ b/src/test/java/server/MATE/toss/exception/parser/TossPromotionErrorResponseParserTest.java
@@ -1,0 +1,124 @@
+package server.MATE.toss.exception.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import server.MATE.toss.exception.TossErrorCode;
+
+class TossPromotionErrorResponseParserTest {
+
+    private static final String EXECUTE_PATH = "/api-partner/v1/apps-in-toss/promotion/execute-promotion";
+    private static final String GET_KEY_PATH = EXECUTE_PATH + "/get-key";
+    private static final String RESULT_PATH = "/api-partner/v1/apps-in-toss/promotion/execution-result";
+
+    private final TossPromotionErrorResponseParser parser = new TossPromotionErrorResponseParser(new ObjectMapper());
+
+    @Test
+    void parsesPromotionNotFound() {
+        assertThat(parseErrorCode(EXECUTE_PATH, "4100")).isEqualTo(TossErrorCode.TOSS_010);
+    }
+
+    @Test
+    void parsesPromotionNotRunning() {
+        assertThat(parseErrorCode(EXECUTE_PATH, "4109")).isEqualTo(TossErrorCode.TOSS_011);
+    }
+
+    @Test
+    void parsesExecutionFailed() {
+        assertThat(parseErrorCode(EXECUTE_PATH, "4110")).isEqualTo(TossErrorCode.TOSS_012);
+    }
+
+    @Test
+    void parsesExecutionResultNotFound() {
+        assertThat(parseErrorCode(RESULT_PATH, "4111")).isEqualTo(TossErrorCode.TOSS_013);
+    }
+
+    @Test
+    void parsesInsufficientBudget() {
+        assertThat(parseErrorCode(EXECUTE_PATH, "4112")).isEqualTo(TossErrorCode.TOSS_014);
+    }
+
+    @Test
+    void parsesAlreadyExecutedKey() {
+        assertThat(parseErrorCode(EXECUTE_PATH, "4113")).isEqualTo(TossErrorCode.TOSS_015);
+    }
+
+    @Test
+    void parsesSingleGrantLimitExceeded() {
+        assertThat(parseErrorCode(EXECUTE_PATH, "4114")).isEqualTo(TossErrorCode.TOSS_016);
+    }
+
+    @Test
+    void parsesTotalBudgetLimitExceeded() {
+        assertThat(parseErrorCode(EXECUTE_PATH, "4116")).isEqualTo(TossErrorCode.TOSS_017);
+    }
+
+    @Test
+    void parsesTextualErrorBody() {
+        TossErrorContext context = parser.parse(
+                HttpStatus.BAD_REQUEST,
+                EXECUTE_PATH,
+                """
+                {
+                  "error": "4112"
+                }
+                """
+        );
+
+        assertThat(context.errorCode()).isEqualTo(TossErrorCode.TOSS_014);
+        assertThat(context.errorResponse().errorCode()).isEqualTo("4112");
+    }
+
+    @Test
+    void usesEndpointSpecificFallbackReasonWhenReasonMissing() {
+        TossErrorContext context = parser.parse(
+                HttpStatus.BAD_REQUEST,
+                GET_KEY_PATH,
+                """
+                {
+                  "error": {
+                    "errorCode": "4100"
+                  }
+                }
+                """
+        );
+
+        assertThat(context.errorResponse().reason()).isEqualTo("토스 프로모션 지급 키 발급에 실패했습니다.");
+    }
+
+    @Test
+    void parsesMalformedBodyAsFallbackError() {
+        TossErrorContext context = parser.parse(
+                HttpStatus.BAD_REQUEST,
+                EXECUTE_PATH,
+                "not-json"
+        );
+
+        assertThat(context.errorCode()).isEqualTo(TossErrorCode.TOSS_001);
+        assertThat(context.errorResponse().errorCode()).isEqualTo("TOSS_PROMOTION_UNKNOWN_ERROR");
+    }
+
+    @Test
+    void supportsOnlyTossPromotionApiPath() {
+        assertThat(parser.supports(HttpStatus.BAD_REQUEST, EXECUTE_PATH, "{}")).isTrue();
+        assertThat(parser.supports(HttpStatus.BAD_REQUEST, "/api-partner/v1/apps-in-toss/user/oauth2/login-me", "{}")).isFalse();
+    }
+
+    private TossErrorCode parseErrorCode(String path, String numericErrorCode) {
+        TossErrorContext context = parser.parse(
+                HttpStatus.BAD_REQUEST,
+                path,
+                """
+                {
+                  "error": {
+                    "errorCode": "%s",
+                    "reason": "테스트 사유"
+                  }
+                }
+                """.formatted(numericErrorCode)
+        );
+        return context.errorCode();
+    }
+}

--- a/src/test/java/server/MATE/toss/exception/parser/TossPromotionErrorResponseParserTest.java
+++ b/src/test/java/server/MATE/toss/exception/parser/TossPromotionErrorResponseParserTest.java
@@ -101,6 +101,37 @@ class TossPromotionErrorResponseParserTest {
     }
 
     @Test
+    void parsesBlankBodyAsFallbackErrorWithoutThrowing() {
+        TossErrorContext context = parser.parse(HttpStatus.BAD_REQUEST, EXECUTE_PATH, "");
+
+        assertThat(context.errorCode()).isEqualTo(TossErrorCode.TOSS_001);
+        assertThat(context.errorResponse().errorCode()).isEqualTo("TOSS_PROMOTION_UNKNOWN_ERROR");
+    }
+
+    @Test
+    void parsesNullBodyAsFallbackErrorWithoutThrowing() {
+        TossErrorContext context = parser.parse(HttpStatus.BAD_REQUEST, EXECUTE_PATH, null);
+
+        assertThat(context.errorCode()).isEqualTo(TossErrorCode.TOSS_001);
+        assertThat(context.errorResponse().errorCode()).isEqualTo("TOSS_PROMOTION_UNKNOWN_ERROR");
+    }
+
+    @Test
+    void fallsBackToUnknownCodeWhenTextualErrorIsBlank() {
+        TossErrorContext context = parser.parse(
+                HttpStatus.BAD_REQUEST,
+                EXECUTE_PATH,
+                """
+                {
+                  "error": ""
+                }
+                """
+        );
+
+        assertThat(context.errorResponse().errorCode()).isEqualTo("TOSS_PROMOTION_UNKNOWN_ERROR");
+    }
+
+    @Test
     void supportsOnlyTossPromotionApiPath() {
         assertThat(parser.supports(HttpStatus.BAD_REQUEST, EXECUTE_PATH, "{}")).isTrue();
         assertThat(parser.supports(HttpStatus.BAD_REQUEST, "/api-partner/v1/apps-in-toss/user/oauth2/login-me", "{}")).isFalse();


### PR DESCRIPTION
  ## 📍 요약
  - 토스 프로모션 API 에러를 파서로 구체적인 에러 코드로 매핑하도록 수정
  
  ## 🔗 관련 이슈
  - Closes #251
  
  ## 📌 변경 사항
  - [x] 기능 
  
  ## ✅ 작업 내용
  - TossPromotionErrorResponseParser 추가, 프로모션 에러 코드(4100~4116)를 TossErrorCode로 매핑
  - TossErrorResponseParser 인터페이스에 공통 파싱 헬퍼(textOrDefault/result)를 default 메서드로 이동, 기존 파서 2곳의 중복 구현 제거
  
  ## 테스트
  - [x] 로컬 테스트 완료
  - 테스트 방법:
    - ./gradlew test