### PR TITLE
refactor: Toss unlink 시 식별정보 비식별화 적용

### DIFF
--- a/src/main/java/server/MATE/domain/promotion/repository/PromotionRewardRepository.java
+++ b/src/main/java/server/MATE/domain/promotion/repository/PromotionRewardRepository.java
@@ -38,6 +38,11 @@ public interface PromotionRewardRepository extends JpaRepository<PromotionReward
             update PromotionReward pr
             set pr.tossUserKey = null
             where pr.testerId = :testerId
+              and pr.status not in (
+                  server.MATE.domain.promotion.entity.PromotionRewardStatus.KEY_ISSUED,
+                  server.MATE.domain.promotion.entity.PromotionRewardStatus.PENDING,
+                  server.MATE.domain.promotion.entity.PromotionRewardStatus.EXECUTED
+              )
             """)
     int clearTossUserKeyByTesterId(@Param("testerId") Long testerId);
 }

--- a/src/main/java/server/MATE/domain/promotion/repository/PromotionRewardRepository.java
+++ b/src/main/java/server/MATE/domain/promotion/repository/PromotionRewardRepository.java
@@ -32,4 +32,12 @@ public interface PromotionRewardRepository extends JpaRepository<PromotionReward
             where pr.testId = :testId
             """)
     int deleteAllByTestId(@Param("testId") Long testId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update PromotionReward pr
+            set pr.tossUserKey = null
+            where pr.testerId = :testerId
+            """)
+    int clearTossUserKeyByTesterId(@Param("testerId") Long testerId);
 }

--- a/src/main/java/server/MATE/domain/users/entity/TossAccount.java
+++ b/src/main/java/server/MATE/domain/users/entity/TossAccount.java
@@ -33,7 +33,7 @@ public class TossAccount extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private Users user;
 
-    @Column(nullable = false, unique = true)
+    @Column(unique = true)
     private Long tossUserKey;
 
     @Column(length = 2000)
@@ -113,7 +113,9 @@ public class TossAccount extends BaseEntity {
 
     public void markUnlinked(TossUnlinkReferrer unlinkReferrer, LocalDateTime unlinkedAt) {
         this.isLinked = false;
+        this.tossUserKey = null;
         this.encryptedTossRefreshToken = null;
+        this.scope = null;
         this.unlinkReferrer = unlinkReferrer;
         this.unlinkedAt = unlinkedAt;
     }

--- a/src/main/java/server/MATE/domain/users/entity/Users.java
+++ b/src/main/java/server/MATE/domain/users/entity/Users.java
@@ -24,7 +24,7 @@ public class Users extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = true, unique = true)
     private String ci;
 
     @Column
@@ -46,5 +46,9 @@ public class Users extends BaseEntity {
             return;
         }
         this.name = name;
+    }
+
+    public void anonymizeForTossUnlink() {
+        this.ci = null;
     }
 }

--- a/src/main/java/server/MATE/toss/service/TossLoginService.java
+++ b/src/main/java/server/MATE/toss/service/TossLoginService.java
@@ -19,6 +19,7 @@ import server.MATE.domain.auth.jwt.TokenType;
 import server.MATE.domain.auth.crypto.TokenEncryptor;
 import server.MATE.domain.auth.jwt.JwtProvider;
 import server.MATE.domain.auth.store.UserRefreshTokenStore;
+import server.MATE.domain.promotion.repository.PromotionRewardRepository;
 import server.MATE.domain.users.entity.TossAccount;
 import server.MATE.domain.users.dto.response.MeResponse;
 import server.MATE.domain.users.entity.Users;
@@ -51,6 +52,7 @@ public class TossLoginService {
     private final UserRefreshTokenStore userRefreshTokenStore;
     private final TokenEncryptor tokenEncryptor;
     private final TossLoginSessionService tossLoginSessionService;
+    private final PromotionRewardRepository promotionRewardRepository;
     private final Clock clock;
 
     @Value("${toss.callback.basic-auth-header:}")
@@ -300,6 +302,8 @@ public class TossLoginService {
     private void revokeLinkedState(Users user, TossAccount tossAccount, TossUnlinkReferrer referrer) {
         tossLoginSessionService.clearLoginTokens(user.getId());
         userRefreshTokenStore.delete(user.getId());
+        promotionRewardRepository.clearTossUserKeyByTesterId(user.getId());
+        user.anonymizeForTossUnlink();
         tossAccount.markUnlinked(referrer, LocalDateTime.now(clock));
     }
 

--- a/src/main/java/server/MATE/toss/service/TossLoginService.java
+++ b/src/main/java/server/MATE/toss/service/TossLoginService.java
@@ -302,9 +302,9 @@ public class TossLoginService {
     private void revokeLinkedState(Users user, TossAccount tossAccount, TossUnlinkReferrer referrer) {
         tossLoginSessionService.clearLoginTokens(user.getId());
         userRefreshTokenStore.delete(user.getId());
-        promotionRewardRepository.clearTossUserKeyByTesterId(user.getId());
         user.anonymizeForTossUnlink();
         tossAccount.markUnlinked(referrer, LocalDateTime.now(clock));
+        promotionRewardRepository.clearTossUserKeyByTesterId(user.getId());
     }
 
     private boolean isInvalidAccessToken(TossApiException e) {

--- a/src/test/java/server/MATE/domain/promotion/repository/PromotionRewardRepositoryTest.java
+++ b/src/test/java/server/MATE/domain/promotion/repository/PromotionRewardRepositoryTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 
 import server.MATE.domain.promotion.entity.PromotionReward;
+import server.MATE.domain.promotion.entity.PromotionRewardStatus;
 import server.MATE.global.config.ClockConfig;
 import server.MATE.global.config.JpaAuditingConfig;
 import server.MATE.global.config.QuerydslConfig;
@@ -48,5 +49,51 @@ class PromotionRewardRepositoryTest {
         assertThat(updated).isEqualTo(1);
         assertThat(promotionRewardRepository.findById(target.getId()).orElseThrow().getTossUserKey()).isNull();
         assertThat(promotionRewardRepository.findById(other.getId()).orElseThrow().getTossUserKey()).isEqualTo(888L);
+    }
+
+    @Test
+    @DisplayName("clearTossUserKeyByTesterId: 진행중 상태(KEY_ISSUED/PENDING/EXECUTED)의 tossUserKey는 유지한다")
+    void keepsTossUserKeyForInFlightStatuses() {
+        PromotionReward keyIssued = em.persistAndFlush(PromotionReward.builder()
+                .participationId(11L)
+                .testId(10L)
+                .testerId(300L)
+                .tossUserKey(111L)
+                .rewardAmount(1000)
+                .status(PromotionRewardStatus.KEY_ISSUED)
+                .build());
+        PromotionReward pending = em.persistAndFlush(PromotionReward.builder()
+                .participationId(12L)
+                .testId(10L)
+                .testerId(300L)
+                .tossUserKey(222L)
+                .rewardAmount(1000)
+                .status(PromotionRewardStatus.PENDING)
+                .build());
+        PromotionReward executed = em.persistAndFlush(PromotionReward.builder()
+                .participationId(13L)
+                .testId(10L)
+                .testerId(300L)
+                .tossUserKey(333L)
+                .rewardAmount(1000)
+                .status(PromotionRewardStatus.EXECUTED)
+                .build());
+        PromotionReward succeeded = em.persistAndFlush(PromotionReward.builder()
+                .participationId(14L)
+                .testId(10L)
+                .testerId(300L)
+                .tossUserKey(444L)
+                .rewardAmount(1000)
+                .status(PromotionRewardStatus.SUCCEEDED)
+                .build());
+        em.clear();
+
+        int updated = promotionRewardRepository.clearTossUserKeyByTesterId(300L);
+
+        assertThat(updated).isEqualTo(1);
+        assertThat(promotionRewardRepository.findById(keyIssued.getId()).orElseThrow().getTossUserKey()).isEqualTo(111L);
+        assertThat(promotionRewardRepository.findById(pending.getId()).orElseThrow().getTossUserKey()).isEqualTo(222L);
+        assertThat(promotionRewardRepository.findById(executed.getId()).orElseThrow().getTossUserKey()).isEqualTo(333L);
+        assertThat(promotionRewardRepository.findById(succeeded.getId()).orElseThrow().getTossUserKey()).isNull();
     }
 }

--- a/src/test/java/server/MATE/domain/promotion/repository/PromotionRewardRepositoryTest.java
+++ b/src/test/java/server/MATE/domain/promotion/repository/PromotionRewardRepositoryTest.java
@@ -1,0 +1,52 @@
+package server.MATE.domain.promotion.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import server.MATE.domain.promotion.entity.PromotionReward;
+import server.MATE.global.config.ClockConfig;
+import server.MATE.global.config.JpaAuditingConfig;
+import server.MATE.global.config.QuerydslConfig;
+
+@DataJpaTest
+@Import({QuerydslConfig.class, ClockConfig.class, JpaAuditingConfig.class})
+class PromotionRewardRepositoryTest {
+
+    @Autowired
+    private PromotionRewardRepository promotionRewardRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    @DisplayName("clearTossUserKeyByTesterId: 대상 testerId의 tossUserKey만 null 처리한다")
+    void clearsTossUserKeyForMatchingTesterId() {
+        PromotionReward target = em.persistAndFlush(PromotionReward.builder()
+                .participationId(1L)
+                .testId(10L)
+                .testerId(100L)
+                .tossUserKey(777L)
+                .rewardAmount(1000)
+                .build());
+        PromotionReward other = em.persistAndFlush(PromotionReward.builder()
+                .participationId(2L)
+                .testId(10L)
+                .testerId(200L)
+                .tossUserKey(888L)
+                .rewardAmount(1000)
+                .build());
+        em.clear();
+
+        int updated = promotionRewardRepository.clearTossUserKeyByTesterId(100L);
+
+        assertThat(updated).isEqualTo(1);
+        assertThat(promotionRewardRepository.findById(target.getId()).orElseThrow().getTossUserKey()).isNull();
+        assertThat(promotionRewardRepository.findById(other.getId()).orElseThrow().getTossUserKey()).isEqualTo(888L);
+    }
+}

--- a/src/test/java/server/MATE/domain/users/entity/TossAccountTest.java
+++ b/src/test/java/server/MATE/domain/users/entity/TossAccountTest.java
@@ -1,0 +1,39 @@
+package server.MATE.domain.users.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TossAccountTest {
+
+    @Test
+    @DisplayName("markUnlinked 호출 시 tossUserKey와 scope까지 null로 처리한다")
+    void markUnlinkedClearsIdentifyingFields() {
+        Users user = Users.builder()
+                .ci("ci-1")
+                .name("tester")
+                .role(Role.USER)
+                .build();
+        TossAccount tossAccount = TossAccount.builder()
+                .user(user)
+                .tossUserKey(777L)
+                .encryptedTossRefreshToken("encrypted-refresh")
+                .scope("user_ci")
+                .isLinked(true)
+                .lastLoginAt(LocalDateTime.of(2026, 5, 14, 12, 0))
+                .lastTokenRefreshedAt(LocalDateTime.of(2026, 5, 14, 12, 0))
+                .build();
+
+        tossAccount.markUnlinked(TossUnlinkReferrer.UNLINK, LocalDateTime.of(2026, 5, 15, 0, 0));
+
+        assertThat(tossAccount.isLinked()).isFalse();
+        assertThat(tossAccount.getTossUserKey()).isNull();
+        assertThat(tossAccount.getScope()).isNull();
+        assertThat(tossAccount.getEncryptedTossRefreshToken()).isNull();
+        assertThat(tossAccount.getUnlinkReferrer()).isEqualTo(TossUnlinkReferrer.UNLINK);
+        assertThat(tossAccount.getUnlinkedAt()).isEqualTo(LocalDateTime.of(2026, 5, 15, 0, 0));
+    }
+}

--- a/src/test/java/server/MATE/domain/users/entity/UsersTest.java
+++ b/src/test/java/server/MATE/domain/users/entity/UsersTest.java
@@ -1,0 +1,23 @@
+package server.MATE.domain.users.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UsersTest {
+
+    @Test
+    @DisplayName("anonymizeForTossUnlink 호출 시 ci를 null로 처리한다")
+    void anonymizeForTossUnlinkClearsCi() {
+        Users user = Users.builder()
+                .ci("ci-1")
+                .name("tester")
+                .role(Role.USER)
+                .build();
+
+        user.anonymizeForTossUnlink();
+
+        assertThat(user.getCi()).isNull();
+    }
+}

--- a/src/test/java/server/MATE/toss/integration/TossLoginIntegrationTest.java
+++ b/src/test/java/server/MATE/toss/integration/TossLoginIntegrationTest.java
@@ -25,6 +25,8 @@ import server.MATE.domain.auth.crypto.TokenEncryptor;
 import server.MATE.domain.auth.dto.response.TossLoginResponse;
 import server.MATE.domain.auth.store.TossTokenStore;
 import server.MATE.domain.auth.store.UserRefreshTokenStore;
+import server.MATE.domain.promotion.entity.PromotionReward;
+import server.MATE.domain.promotion.repository.PromotionRewardRepository;
 import server.MATE.domain.users.entity.TossAccount;
 import server.MATE.domain.users.entity.TossUnlinkReferrer;
 import server.MATE.domain.users.entity.Users;
@@ -67,6 +69,9 @@ class TossLoginIntegrationTest {
     private TossAccountRepository tossAccountRepository;
 
     @Autowired
+    private PromotionRewardRepository promotionRewardRepository;
+
+    @Autowired
     private TokenEncryptor tokenEncryptor;
 
     @MockitoBean
@@ -86,6 +91,7 @@ class TossLoginIntegrationTest {
 
     @AfterEach
     void tearDown() {
+        promotionRewardRepository.deleteAll();
         tossAccountRepository.deleteAll();
         usersRepository.deleteAll();
     }
@@ -182,16 +188,29 @@ class TossLoginIntegrationTest {
                 .lastLoginAt(LocalDateTime.now().minusDays(1))
                 .lastTokenRefreshedAt(LocalDateTime.now().minusDays(1))
                 .build());
+        PromotionReward reward = promotionRewardRepository.save(PromotionReward.builder()
+                .participationId(1L)
+                .testId(10L)
+                .testerId(user.getId())
+                .tossUserKey(777L)
+                .rewardAmount(1000)
+                .build());
 
         when(tossTokenStore.findAccessToken(user.getId())).thenReturn(Optional.of("cached-access"));
 
         tossLoginService.unlinkCurrentUser(user.getId());
 
         TossAccount updatedAccount = tossAccountRepository.findById(tossAccount.getId()).orElseThrow();
+        Users updatedUser = usersRepository.findById(user.getId()).orElseThrow();
+        PromotionReward updatedReward = promotionRewardRepository.findById(reward.getId()).orElseThrow();
         assertThat(updatedAccount.isLinked()).isFalse();
         assertThat(updatedAccount.getUnlinkReferrer()).isEqualTo(TossUnlinkReferrer.UNLINK);
         assertThat(updatedAccount.getUnlinkedAt()).isNotNull();
         assertThat(updatedAccount.getEncryptedTossRefreshToken()).isNull();
+        assertThat(updatedAccount.getTossUserKey()).isNull();
+        assertThat(updatedAccount.getScope()).isNull();
+        assertThat(updatedUser.getCi()).isNull();
+        assertThat(updatedReward.getTossUserKey()).isNull();
 
         verify(tossLoginApiClient).removeByAccessToken("cached-access");
         verify(tossTokenStore).deleteAccessToken(user.getId());
@@ -215,14 +234,27 @@ class TossLoginIntegrationTest {
                 .lastLoginAt(LocalDateTime.now().minusDays(1))
                 .lastTokenRefreshedAt(LocalDateTime.now().minusDays(1))
                 .build());
+        PromotionReward reward = promotionRewardRepository.save(PromotionReward.builder()
+                .participationId(2L)
+                .testId(10L)
+                .testerId(user.getId())
+                .tossUserKey(777L)
+                .rewardAmount(1000)
+                .build());
 
         tossLoginService.handleUnlinkCallback(777L, TossUnlinkReferrer.WITHDRAWAL_TOSS);
 
         TossAccount updatedAccount = tossAccountRepository.findById(tossAccount.getId()).orElseThrow();
+        Users updatedUser = usersRepository.findById(user.getId()).orElseThrow();
+        PromotionReward updatedReward = promotionRewardRepository.findById(reward.getId()).orElseThrow();
         assertThat(updatedAccount.isLinked()).isFalse();
         assertThat(updatedAccount.getUnlinkReferrer()).isEqualTo(TossUnlinkReferrer.WITHDRAWAL_TOSS);
         assertThat(updatedAccount.getUnlinkedAt()).isNotNull();
         assertThat(updatedAccount.getEncryptedTossRefreshToken()).isNull();
+        assertThat(updatedAccount.getTossUserKey()).isNull();
+        assertThat(updatedAccount.getScope()).isNull();
+        assertThat(updatedUser.getCi()).isNull();
+        assertThat(updatedReward.getTossUserKey()).isNull();
 
         verify(tossTokenStore).deleteAccessToken(user.getId());
         verify(tossTokenStore).deleteRefreshToken(user.getId());

--- a/src/test/java/server/MATE/toss/service/TossLoginServiceTest.java
+++ b/src/test/java/server/MATE/toss/service/TossLoginServiceTest.java
@@ -33,6 +33,7 @@ import server.MATE.domain.auth.dto.response.TossLoginResponse;
 import server.MATE.domain.auth.jwt.JwtProvider;
 import server.MATE.domain.auth.jwt.TokenType;
 import server.MATE.domain.auth.store.UserRefreshTokenStore;
+import server.MATE.domain.promotion.repository.PromotionRewardRepository;
 import server.MATE.domain.users.entity.Role;
 import server.MATE.domain.users.entity.TossAccount;
 import server.MATE.domain.users.entity.TossUnlinkReferrer;
@@ -77,6 +78,9 @@ class TossLoginServiceTest {
     @Mock
     private TossLoginSessionService tossLoginSessionService;
 
+    @Mock
+    private PromotionRewardRepository promotionRewardRepository;
+
     private TossLoginService tossLoginService;
     private final Clock fixedClock = Clock.fixed(Instant.parse("2026-05-15T00:00:00Z"), ZoneId.of("Asia/Seoul"));
 
@@ -91,6 +95,7 @@ class TossLoginServiceTest {
                 userRefreshTokenStore,
                 tokenEncryptor,
                 tossLoginSessionService,
+                promotionRewardRepository,
                 fixedClock
         );
         ReflectionTestUtils.setField(tossLoginService, "callbackBasicAuthHeader", "callback-secret");
@@ -267,7 +272,11 @@ class TossLoginServiceTest {
             verify(tossLoginApiClient).removeByAccessToken("valid-access");
             verify(tossLoginSessionService).clearLoginTokens(1L);
             verify(userRefreshTokenStore).delete(1L);
+            verify(promotionRewardRepository).clearTossUserKeyByTesterId(1L);
             assertThat(tossAccount.isLinked()).isFalse();
+            assertThat(tossAccount.getTossUserKey()).isNull();
+            assertThat(tossAccount.getScope()).isNull();
+            assertThat(tossAccount.getUser().getCi()).isNull();
             assertThat(tossAccount.getUnlinkReferrer()).isEqualTo(TossUnlinkReferrer.UNLINK);
             assertThat(tossAccount.getUnlinkedAt()).isEqualTo(LocalDateTime.now(fixedClock));
         }
@@ -354,7 +363,9 @@ class TossLoginServiceTest {
 
             verify(tossLoginSessionService, never()).clearLoginTokens(1L);
             verify(userRefreshTokenStore, never()).delete(1L);
+            verify(promotionRewardRepository, never()).clearTossUserKeyByTesterId(any());
             assertThat(tossAccount.isLinked()).isTrue();
+            assertThat(tossAccount.getUser().getCi()).isEqualTo("ci-1");
         }
 
         @Test
@@ -383,7 +394,11 @@ class TossLoginServiceTest {
             verify(tossLoginApiClient).removeByUserKey(777L);
             verify(tossLoginSessionService).clearLoginTokens(1L);
             verify(userRefreshTokenStore).delete(1L);
+            verify(promotionRewardRepository).clearTossUserKeyByTesterId(1L);
             assertThat(tossAccount.isLinked()).isFalse();
+            assertThat(tossAccount.getTossUserKey()).isNull();
+            assertThat(tossAccount.getScope()).isNull();
+            assertThat(tossAccount.getUser().getCi()).isNull();
             assertThat(tossAccount.getUnlinkReferrer()).isEqualTo(TossUnlinkReferrer.UNLINK);
         }
 
@@ -422,7 +437,11 @@ class TossLoginServiceTest {
 
             verify(tossLoginSessionService).clearLoginTokens(1L);
             verify(userRefreshTokenStore).delete(1L);
+            verify(promotionRewardRepository).clearTossUserKeyByTesterId(1L);
             assertThat(tossAccount.isLinked()).isFalse();
+            assertThat(tossAccount.getTossUserKey()).isNull();
+            assertThat(tossAccount.getScope()).isNull();
+            assertThat(tossAccount.getUser().getCi()).isNull();
             assertThat(tossAccount.getUnlinkReferrer()).isEqualTo(TossUnlinkReferrer.WITHDRAWAL_TOSS);
             assertThat(tossAccount.getUnlinkedAt()).isEqualTo(LocalDateTime.now(fixedClock));
         }


### PR DESCRIPTION
## 📍 요약
- 토스 로그인 연결 해제(unlink) 시 운영 이력 row는 유지하되, 토스로부터 받은 식별정보 5개 컬럼을 null 처리하도록 변경

## 🔗 관련 이슈
- Closes #255

## 📌 변경 사항
- [x] 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서
- [x] 테스트
- [ ] 기타

## ✅ 작업 내용
- unlink 시 `users.ci`, `toss_accounts.toss_user_key`/`scope`/`encrypted_toss_refresh_token`, `promotion_reward.toss_user_key`를 null 처리하도록 엔티티/스키마 nullable 전환
- `TossLoginService.revokeLinkedState()`에 익명화 로직을 연결해 3개 unlink 진입점(`unlinkCurrentUser`, `unlinkByUserKey`, `handleUnlinkCallback`) 전체에 동일 적용
- JPA `flushAutomatically`/`clearAutomatically` 순서 문제로 엔티티 변경이 조용히 유실되던 버그 수정
- 진행중 상태(`KEY_ISSUED`/`PENDING`/`EXECUTED`) 프로모션 리워드는 unlink 시 `toss_user_key`를 유지하도록 예외 처리해, 비동기 스케줄러의 오탐 `FAILED` 처리 방지
- 과거 unlink 이력 데이터 백필은 범위에서 제외 (현재 DB는 테스트 데이터뿐)

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - `./gradlew test --tests "server.MATE.domain.users.entity.UsersTest" --tests "server.MATE.domain.users.entity.TossAccountTest" --tests "server.MATE.domain.promotion.repository.PromotionRewardRepositoryTest" --tests "server.MATE.toss.service.TossLoginServiceTest" --tests "server.MATE.toss.integration.TossLoginIntegrationTest"`
  - `./gradlew test` (전체 스위트)
