### PR TITLE
refactor: Toss 연동 코드를 client와 gateway 계층으로 분리

### DIFF
--- a/src/main/java/server/MATE/domain/payment/controller/PaymentController.java
+++ b/src/main/java/server/MATE/domain/payment/controller/PaymentController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import server.MATE.domain.payment.dto.request.PaymentGrantRequest;
 import server.MATE.domain.payment.dto.request.PaymentRestoreRequest;
 import server.MATE.domain.payment.dto.response.PaymentOrderStatusResponse;
-import server.MATE.domain.payment.service.PaymentGrantService;
+import server.MATE.domain.payment.service.IapService;
 import server.MATE.global.common.response.ApiResponse;
 import server.MATE.global.security.principal.AuthenticatedUser;
 
@@ -29,7 +29,7 @@ import server.MATE.global.security.principal.AuthenticatedUser;
 @ConditionalOnProperty(prefix = "toss.api", name = "enabled", havingValue = "true")
 public class PaymentController {
 
-    private final PaymentGrantService paymentGrantService;
+    private final IapService iapService;
 
     @Operation(
             summary = "인앱결제 상품 지급 처리",
@@ -44,7 +44,7 @@ public class PaymentController {
             @RequestBody @Valid PaymentGrantRequest request,
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser
     ) {
-        boolean granted = paymentGrantService.grant(
+        boolean granted = iapService.grant(
                 request.orderId(),
                 request.draftId(),
                 authenticatedUser.getId()
@@ -65,7 +65,7 @@ public class PaymentController {
             @RequestBody @Valid PaymentRestoreRequest request,
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser
     ) {
-        boolean restored = paymentGrantService.restore(
+        boolean restored = iapService.restore(
                 request.orderId(),
                 request.draftId(),
                 authenticatedUser.getId()
@@ -86,7 +86,7 @@ public class PaymentController {
             @PathVariable String orderId,
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser
     ) {
-        PaymentOrderStatusResponse response = paymentGrantService.getOrderStatus(orderId, authenticatedUser.getId());
+        PaymentOrderStatusResponse response = iapService.getOrderStatus(orderId, authenticatedUser.getId());
         return ResponseEntity.ok(ApiResponse.ok("결제 상태를 조회했습니다.", response));
     }
 }

--- a/src/main/java/server/MATE/domain/payment/dto/response/PaymentOrderStatusResponse.java
+++ b/src/main/java/server/MATE/domain/payment/dto/response/PaymentOrderStatusResponse.java
@@ -1,10 +1,12 @@
 package server.MATE.domain.payment.dto.response;
 
-import server.MATE.toss.dto.response.IapOrderStatus;
+import java.time.LocalDateTime;
+
+import server.MATE.toss.gateway.IapOrderState;
 
 public record PaymentOrderStatusResponse(
-        IapOrderStatus status,
+        IapOrderState status,
         String reason,
-        String statusDeterminedAt
+        LocalDateTime statusDeterminedAt
 ) {
 }

--- a/src/main/java/server/MATE/domain/payment/service/IapService.java
+++ b/src/main/java/server/MATE/domain/payment/service/IapService.java
@@ -18,31 +18,24 @@ import server.MATE.domain.users.entity.TossAccount;
 import server.MATE.domain.users.repository.TossAccountRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
-import server.MATE.toss.client.http.TossHttpClient;
-import server.MATE.toss.config.TossProperties;
-import server.MATE.toss.dto.request.IapOrderStatusRequest;
-import server.MATE.toss.dto.response.IapOrderStatus;
-import server.MATE.toss.dto.response.IapOrderStatusResponse;
+import server.MATE.toss.config.TossIapProperties;
+import server.MATE.toss.gateway.IapOrderState;
+import server.MATE.toss.gateway.IapOrderStatusResult;
+import server.MATE.toss.gateway.TossIapGateway;
 
 import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeParseException;
 
 @Slf4j
 @Service
 @ConditionalOnProperty(prefix = "toss.api", name = "enabled", havingValue = "true")
 @RequiredArgsConstructor
-public class PaymentGrantService {
+public class IapService {
 
-    private static final String IAP_ORDER_STATUS_PATH = "/api-partner/v1/apps-in-toss/order/get-order-status";
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-
-    private final TossHttpClient tossHttpClient;
-    private final TossProperties tossProperties;
+    private final TossIapGateway tossIapGateway;
+    private final TossIapProperties tossIapProperties;
     private final TossAccountRepository tossAccountRepository;
     private final PaymentRepository paymentRepository;
-    private final PaymentWriter paymentWriter;
+    private final PaymentCreateService paymentCreateService;
     private final TestDraftRepository testDraftRepository;
     private final PaymentAmountCalculator paymentAmountCalculator;
     private final TestPublishService testPublishService;
@@ -114,30 +107,24 @@ public class PaymentGrantService {
         TossAccount tossAccount = tossAccountRepository.findByUserId(makerId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.PAYMENT_005));
 
-        IapOrderStatusResponse statusResponse = tossHttpClient.post(
-                IAP_ORDER_STATUS_PATH,
-                new IapOrderStatusRequest(orderId),
-                headers -> headers.set("x-toss-user-key", String.valueOf(tossAccount.getTossUserKey())),
-                IapOrderStatusResponse.class
-        );
+        IapOrderStatusResult result = tossIapGateway.getOrderStatus(tossAccount.getTossUserKey(), orderId);
 
-        validateSku(statusResponse.sku());
+        validateSku(result.sku());
 
-        if (statusResponse.status() != IapOrderStatus.PURCHASED
-                && statusResponse.status() != IapOrderStatus.PAYMENT_COMPLETED) {
+        if (result.status() != IapOrderState.PURCHASED
+                && result.status() != IapOrderState.PAYMENT_COMPLETED) {
             return null;
         }
 
         int amount = paymentAmountCalculator.totalAmount(draft.getGoalPpl(), draft.getReward());
-        LocalDateTime approvedAt = parseApprovedAt(statusResponse.statusDeterminedAt());
 
-        return savePaymentOrFallback(orderId, draftId, makerId, draft, amount, approvedAt);
+        return savePaymentOrFallback(orderId, draftId, makerId, draft, amount, result.statusDeterminedAt());
     }
 
     private Payment savePaymentOrFallback(String orderId, Long draftId, Long makerId,
                                           TestDraft draft, int amount, LocalDateTime approvedAt) {
         try {
-            return paymentWriter.save(Payment.builder()
+            return paymentCreateService.save(Payment.builder()
                     .draftId(draftId)
                     .makerId(makerId)
                     .orderNo(orderId)
@@ -163,28 +150,12 @@ public class PaymentGrantService {
     }
 
     private void validateSku(String sku) {
-        var allowedSkus = tossProperties.iap().allowedSkus();
+        var allowedSkus = tossIapProperties.allowedSkus();
         if (allowedSkus.isEmpty()) {
             return;
         }
         if (sku == null || !allowedSkus.contains(sku)) {
             throw new BaseException(BaseErrorCode.PAYMENT_006);
-        }
-    }
-
-    private LocalDateTime parseApprovedAt(String value) {
-        if (value == null || value.isBlank()) {
-            return LocalDateTime.now(KST);
-        }
-        try {
-            return LocalDateTime.parse(value);
-        } catch (DateTimeParseException e) {
-            try {
-                return OffsetDateTime.parse(value).atZoneSameInstant(KST).toLocalDateTime();
-            } catch (DateTimeParseException ex) {
-                log.warn("Unrecognized approvedAt format='{}', falling back to now", value);
-                return LocalDateTime.now(KST);
-            }
         }
     }
 
@@ -198,17 +169,12 @@ public class PaymentGrantService {
         TossAccount tossAccount = tossAccountRepository.findByUserId(makerId)
                 .orElseThrow(() -> new BaseException(BaseErrorCode.PAYMENT_005));
 
-        IapOrderStatusResponse statusResponse = tossHttpClient.post(
-                IAP_ORDER_STATUS_PATH,
-                new IapOrderStatusRequest(orderId),
-                headers -> headers.set("x-toss-user-key", String.valueOf(tossAccount.getTossUserKey())),
-                IapOrderStatusResponse.class
-        );
+        IapOrderStatusResult result = tossIapGateway.getOrderStatus(tossAccount.getTossUserKey(), orderId);
 
         return new PaymentOrderStatusResponse(
-                statusResponse.status(),
-                statusResponse.reason(),
-                statusResponse.statusDeterminedAt()
+                result.status(),
+                result.reason(),
+                result.statusDeterminedAt()
         );
     }
 }

--- a/src/main/java/server/MATE/domain/payment/service/PaymentCreateService.java
+++ b/src/main/java/server/MATE/domain/payment/service/PaymentCreateService.java
@@ -9,7 +9,7 @@ import server.MATE.domain.payment.repository.PaymentRepository;
 
 @Component
 @RequiredArgsConstructor
-public class PaymentWriter {
+public class PaymentCreateService {
 
     private final PaymentRepository paymentRepository;
 

--- a/src/main/java/server/MATE/toss/client/iap/TossIapApiClient.java
+++ b/src/main/java/server/MATE/toss/client/iap/TossIapApiClient.java
@@ -1,0 +1,28 @@
+package server.MATE.toss.client.iap;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import server.MATE.toss.client.http.TossHttpClient;
+import server.MATE.toss.dto.request.IapOrderStatusRequest;
+import server.MATE.toss.dto.response.IapOrderStatusResponse;
+
+@Component
+@ConditionalOnProperty(prefix = "toss.api", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class TossIapApiClient {
+
+    private static final String TOSS_USER_KEY_HEADER = "x-toss-user-key";
+    private static final String ORDER_STATUS_PATH = "/api-partner/v1/apps-in-toss/order/get-order-status";
+
+    private final TossHttpClient tossHttpClient;
+
+    public IapOrderStatusResponse getOrderStatus(Long tossUserKey, String orderId) {
+        return tossHttpClient.post(
+                ORDER_STATUS_PATH,
+                new IapOrderStatusRequest(orderId),
+                headers -> headers.set(TOSS_USER_KEY_HEADER, String.valueOf(tossUserKey)),
+                IapOrderStatusResponse.class
+        );
+    }
+}

--- a/src/main/java/server/MATE/toss/client/promotion/TossPromotionApiClient.java
+++ b/src/main/java/server/MATE/toss/client/promotion/TossPromotionApiClient.java
@@ -1,0 +1,55 @@
+package server.MATE.toss.client.promotion;
+
+import java.util.Map;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import server.MATE.toss.client.http.TossHttpClient;
+import server.MATE.toss.dto.response.TossPromotionExecuteResponse;
+import server.MATE.toss.dto.response.TossPromotionExecutionStatus;
+import server.MATE.toss.dto.response.TossPromotionKeyResponse;
+
+@Component
+@ConditionalOnProperty(prefix = "toss.api", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class TossPromotionApiClient {
+
+    private static final String TOSS_USER_KEY_HEADER = "x-toss-user-key";
+    private static final String GET_KEY_PATH = "/api-partner/v1/apps-in-toss/promotion/execute-promotion/get-key";
+    private static final String EXECUTE_PATH = "/api-partner/v1/apps-in-toss/promotion/execute-promotion";
+    private static final String RESULT_PATH = "/api-partner/v1/apps-in-toss/promotion/execution-result";
+
+    private final TossHttpClient tossHttpClient;
+
+    public TossPromotionKeyResponse issueKey(Long tossUserKey) {
+        return tossHttpClient.post(
+                GET_KEY_PATH,
+                Map.of(),
+                headers -> headers.set(TOSS_USER_KEY_HEADER, String.valueOf(tossUserKey)),
+                TossPromotionKeyResponse.class
+        );
+    }
+
+    public TossPromotionExecuteResponse execute(Long tossUserKey, String promotionCode, String rewardKey, Integer rewardAmount) {
+        return tossHttpClient.post(
+                EXECUTE_PATH,
+                new ExecuteBody(promotionCode, rewardKey, rewardAmount),
+                headers -> headers.set(TOSS_USER_KEY_HEADER, String.valueOf(tossUserKey)),
+                TossPromotionExecuteResponse.class
+        );
+    }
+
+    public TossPromotionExecutionStatus getExecutionStatus(Long tossUserKey, String promotionCode, String rewardKey) {
+        return tossHttpClient.post(
+                RESULT_PATH,
+                new ResultBody(promotionCode, rewardKey),
+                headers -> headers.set(TOSS_USER_KEY_HEADER, String.valueOf(tossUserKey)),
+                TossPromotionExecutionStatus.class
+        );
+    }
+
+    private record ExecuteBody(String promotionCode, String key, Integer amount) {}
+
+    private record ResultBody(String promotionCode, String key) {}
+}

--- a/src/main/java/server/MATE/toss/config/TossClientConfig.java
+++ b/src/main/java/server/MATE/toss/config/TossClientConfig.java
@@ -21,6 +21,7 @@ import server.MATE.toss.crypto.TossCryptoProperties;
 @EnableConfigurationProperties({
         TossProperties.class,
         TossPromotionProperties.class,
+        TossIapProperties.class,
         TossCryptoProperties.class,
         TokenEncryptionProperties.class
 })

--- a/src/main/java/server/MATE/toss/config/TossIapProperties.java
+++ b/src/main/java/server/MATE/toss/config/TossIapProperties.java
@@ -1,0 +1,17 @@
+package server.MATE.toss.config;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "toss.iap")
+public record TossIapProperties(
+        List<String> allowedSkus
+) {
+
+    public TossIapProperties {
+        if (allowedSkus == null) {
+            allowedSkus = List.of();
+        }
+    }
+}

--- a/src/main/java/server/MATE/toss/config/TossProperties.java
+++ b/src/main/java/server/MATE/toss/config/TossProperties.java
@@ -1,7 +1,6 @@
 package server.MATE.toss.config;
 
 import java.time.Duration;
-import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -10,8 +9,7 @@ public record TossProperties(
         boolean enabled,
         String baseUrl,
         Timeout timeout,
-        Ssl ssl,
-        Iap iap
+        Ssl ssl
 ) {
 
     public TossProperties {
@@ -23,9 +21,6 @@ public record TossProperties(
         }
         if (ssl == null) {
             ssl = new Ssl(false, null);
-        }
-        if (iap == null) {
-            iap = new Iap(List.of());
         }
     }
 
@@ -52,14 +47,6 @@ public record TossProperties(
         public Ssl {
             if (bundle == null || bundle.isBlank()) {
                 bundle = "toss";
-            }
-        }
-    }
-
-    public record Iap(List<String> allowedSkus) {
-        public Iap {
-            if (allowedSkus == null) {
-                allowedSkus = List.of();
             }
         }
     }

--- a/src/main/java/server/MATE/toss/gateway/IapOrderState.java
+++ b/src/main/java/server/MATE/toss/gateway/IapOrderState.java
@@ -1,0 +1,12 @@
+package server.MATE.toss.gateway;
+
+public enum IapOrderState {
+    PURCHASED,
+    PAYMENT_COMPLETED,
+    FAILED,
+    REFUNDED,
+    ORDER_IN_PROGRESS,
+    NOT_FOUND,
+    MINIAPP_MISMATCH,
+    ERROR
+}

--- a/src/main/java/server/MATE/toss/gateway/IapOrderStatusResult.java
+++ b/src/main/java/server/MATE/toss/gateway/IapOrderStatusResult.java
@@ -1,0 +1,11 @@
+package server.MATE.toss.gateway;
+
+import java.time.LocalDateTime;
+
+public record IapOrderStatusResult(
+        IapOrderState status,
+        String sku,
+        String reason,
+        LocalDateTime statusDeterminedAt
+) {
+}

--- a/src/main/java/server/MATE/toss/gateway/TossHttpIapGateway.java
+++ b/src/main/java/server/MATE/toss/gateway/TossHttpIapGateway.java
@@ -1,0 +1,65 @@
+package server.MATE.toss.gateway;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import server.MATE.toss.client.iap.TossIapApiClient;
+import server.MATE.toss.dto.response.IapOrderStatus;
+import server.MATE.toss.dto.response.IapOrderStatusResponse;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "toss.api", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class TossHttpIapGateway implements TossIapGateway {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final TossIapApiClient tossIapApiClient;
+
+    @Override
+    public IapOrderStatusResult getOrderStatus(Long tossUserKey, String orderId) {
+        IapOrderStatusResponse response = tossIapApiClient.getOrderStatus(tossUserKey, orderId);
+        return new IapOrderStatusResult(
+                toGatewayState(response.status()),
+                response.sku(),
+                response.reason(),
+                parseStatusDeterminedAt(response.statusDeterminedAt())
+        );
+    }
+
+    private IapOrderState toGatewayState(IapOrderStatus status) {
+        return switch (status) {
+            case PURCHASED -> IapOrderState.PURCHASED;
+            case PAYMENT_COMPLETED -> IapOrderState.PAYMENT_COMPLETED;
+            case FAILED -> IapOrderState.FAILED;
+            case REFUNDED -> IapOrderState.REFUNDED;
+            case ORDER_IN_PROGRESS -> IapOrderState.ORDER_IN_PROGRESS;
+            case NOT_FOUND -> IapOrderState.NOT_FOUND;
+            case MINIAPP_MISMATCH -> IapOrderState.MINIAPP_MISMATCH;
+            case ERROR -> IapOrderState.ERROR;
+        };
+    }
+
+    private LocalDateTime parseStatusDeterminedAt(String value) {
+        if (value == null || value.isBlank()) {
+            return LocalDateTime.now(KST);
+        }
+        try {
+            return LocalDateTime.parse(value);
+        } catch (DateTimeParseException e) {
+            try {
+                return OffsetDateTime.parse(value).atZoneSameInstant(KST).toLocalDateTime();
+            } catch (DateTimeParseException ex) {
+                log.warn("Unrecognized statusDeterminedAt format='{}', falling back to now", value);
+                return LocalDateTime.now(KST);
+            }
+        }
+    }
+}

--- a/src/main/java/server/MATE/toss/gateway/TossHttpIapGateway.java
+++ b/src/main/java/server/MATE/toss/gateway/TossHttpIapGateway.java
@@ -35,6 +35,9 @@ public class TossHttpIapGateway implements TossIapGateway {
     }
 
     private IapOrderState toGatewayState(IapOrderStatus status) {
+        if (status == null) {
+            throw new IllegalStateException("Toss IAP order status is null.");
+        }
         return switch (status) {
             case PURCHASED -> IapOrderState.PURCHASED;
             case PAYMENT_COMPLETED -> IapOrderState.PAYMENT_COMPLETED;

--- a/src/main/java/server/MATE/toss/gateway/TossHttpPromotionGateway.java
+++ b/src/main/java/server/MATE/toss/gateway/TossHttpPromotionGateway.java
@@ -1,58 +1,31 @@
 package server.MATE.toss.gateway;
 
-import java.util.Map;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
-import server.MATE.toss.client.http.TossHttpClient;
-import server.MATE.toss.dto.response.TossPromotionExecuteResponse;
+import server.MATE.toss.client.promotion.TossPromotionApiClient;
 import server.MATE.toss.dto.response.TossPromotionExecutionStatus;
-import server.MATE.toss.dto.response.TossPromotionKeyResponse;
 
 @Component
 @ConditionalOnProperty(prefix = "toss.api", name = "enabled", havingValue = "true")
 @RequiredArgsConstructor
 public class TossHttpPromotionGateway implements TossPromotionGateway {
 
-    private static final String TOSS_USER_KEY_HEADER = "x-toss-user-key";
-    private static final String GET_KEY_PATH = "/api-partner/v1/apps-in-toss/promotion/execute-promotion/get-key";
-    private static final String EXECUTE_PATH = "/api-partner/v1/apps-in-toss/promotion/execute-promotion";
-    private static final String RESULT_PATH = "/api-partner/v1/apps-in-toss/promotion/execution-result";
-
-    private final TossHttpClient tossHttpClient;
+    private final TossPromotionApiClient tossPromotionApiClient;
 
     @Override
     public String issueKey(Long tossUserKey) {
-        TossPromotionKeyResponse response = tossHttpClient.post(
-                GET_KEY_PATH,
-                Map.of(),
-                headers -> headers.set(TOSS_USER_KEY_HEADER, String.valueOf(tossUserKey)),
-                TossPromotionKeyResponse.class
-        );
-        return response.key();
+        return tossPromotionApiClient.issueKey(tossUserKey).key();
     }
 
     @Override
     public void execute(Long tossUserKey, String promotionCode, String rewardKey, Integer rewardAmount) {
-        var body = new ExecuteBody(promotionCode, rewardKey, rewardAmount);
-        tossHttpClient.post(
-                EXECUTE_PATH,
-                body,
-                headers -> headers.set(TOSS_USER_KEY_HEADER, String.valueOf(tossUserKey)),
-                TossPromotionExecuteResponse.class
-        );
+        tossPromotionApiClient.execute(tossUserKey, promotionCode, rewardKey, rewardAmount);
     }
 
     @Override
     public PromotionGatewayExecutionStatus getExecutionStatus(Long tossUserKey, String promotionCode, String rewardKey) {
-        var body = new ResultBody(promotionCode, rewardKey);
-        TossPromotionExecutionStatus status = tossHttpClient.post(
-                RESULT_PATH,
-                body,
-                headers -> headers.set(TOSS_USER_KEY_HEADER, String.valueOf(tossUserKey)),
-                TossPromotionExecutionStatus.class
-        );
+        TossPromotionExecutionStatus status = tossPromotionApiClient.getExecutionStatus(tossUserKey, promotionCode, rewardKey);
         return toGatewayStatus(status);
     }
 
@@ -66,8 +39,4 @@ public class TossHttpPromotionGateway implements TossPromotionGateway {
             case FAILED -> PromotionGatewayExecutionStatus.FAILED;
         };
     }
-
-    private record ExecuteBody(String promotionCode, String key, Integer amount) {}
-
-    private record ResultBody(String promotionCode, String key) {}
 }

--- a/src/main/java/server/MATE/toss/gateway/TossIapGateway.java
+++ b/src/main/java/server/MATE/toss/gateway/TossIapGateway.java
@@ -1,0 +1,5 @@
+package server.MATE.toss.gateway;
+
+public interface TossIapGateway {
+    IapOrderStatusResult getOrderStatus(Long tossUserKey, String orderId);
+}

--- a/src/test/java/server/MATE/domain/payment/service/IapServiceTest.java
+++ b/src/test/java/server/MATE/domain/payment/service/IapServiceTest.java
@@ -26,17 +26,14 @@ import server.MATE.domain.users.entity.Users;
 import server.MATE.domain.users.repository.TossAccountRepository;
 import server.MATE.global.common.exception.BaseErrorCode;
 import server.MATE.global.common.exception.BaseException;
-import server.MATE.toss.client.http.TossHttpClient;
-import server.MATE.toss.config.TossProperties;
-import server.MATE.toss.dto.request.IapOrderStatusRequest;
-import server.MATE.toss.dto.response.IapOrderStatus;
-import server.MATE.toss.dto.response.IapOrderStatusResponse;
+import server.MATE.toss.config.TossIapProperties;
+import server.MATE.toss.gateway.IapOrderState;
+import server.MATE.toss.gateway.IapOrderStatusResult;
+import server.MATE.toss.gateway.TossIapGateway;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-
-import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -48,28 +45,28 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class PaymentGrantServiceTest {
+class IapServiceTest {
 
-    @Mock private TossHttpClient tossHttpClient;
+    @Mock private TossIapGateway tossIapGateway;
     @Mock private TossAccountRepository tossAccountRepository;
     @Mock private PaymentRepository paymentRepository;
-    @Mock private PaymentWriter paymentWriter;
+    @Mock private PaymentCreateService paymentCreateService;
     @Mock private TestDraftRepository testDraftRepository;
     @Mock private PaymentAmountCalculator paymentAmountCalculator;
     @Mock private TestPublishService testPublishService;
 
-    private PaymentGrantService paymentGrantService;
+    private IapService iapService;
 
     private static final Long MAKER_ID = 1L;
     private static final Long DRAFT_ID = 10L;
     private static final String ORDER_ID = "order-abc-123";
+    private static final LocalDateTime APPROVED_AT = LocalDateTime.parse("2025-09-12T16:57:12");
 
     @BeforeEach
     void setUp() {
-        TossProperties properties = new TossProperties(true, null, null, null, null);
-        paymentGrantService = new PaymentGrantService(
-                tossHttpClient, properties,
-                tossAccountRepository, paymentRepository, paymentWriter,
+        iapService = new IapService(
+                tossIapGateway, new TossIapProperties(List.of()),
+                tossAccountRepository, paymentRepository, paymentCreateService,
                 testDraftRepository, paymentAmountCalculator, testPublishService
         );
     }
@@ -83,11 +80,11 @@ class PaymentGrantServiceTest {
             Payment existing = existingPayment(100L, MAKER_ID, PayStatus.PAY_SUCCEEDED);
             when(paymentRepository.findByOrderNo(ORDER_ID)).thenReturn(Optional.of(existing));
 
-            boolean result = paymentGrantService.grant(ORDER_ID, DRAFT_ID, MAKER_ID);
+            boolean result = iapService.grant(ORDER_ID, DRAFT_ID, MAKER_ID);
 
             assertThat(result).isTrue();
             verify(testPublishService).publish(100L);
-            verify(tossHttpClient, never()).post(any(), any(), any(Consumer.class), any());
+            verify(tossIapGateway, never()).getOrderStatus(any(), any());
         }
 
         @Test
@@ -96,7 +93,7 @@ class PaymentGrantServiceTest {
             Payment existing = existingPayment(100L, 999L, PayStatus.PAY_SUCCEEDED);
             when(paymentRepository.findByOrderNo(ORDER_ID)).thenReturn(Optional.of(existing));
 
-            assertThatThrownBy(() -> paymentGrantService.grant(ORDER_ID, DRAFT_ID, MAKER_ID))
+            assertThatThrownBy(() -> iapService.grant(ORDER_ID, DRAFT_ID, MAKER_ID))
                     .isInstanceOf(BaseException.class)
                     .extracting(e -> ((BaseException) e).getErrorCode())
                     .isEqualTo(BaseErrorCode.COMMON_009);
@@ -108,7 +105,7 @@ class PaymentGrantServiceTest {
             Payment existing = existingPayment(100L, MAKER_ID, PayStatus.REFUND_PENDING);
             when(paymentRepository.findByOrderNo(ORDER_ID)).thenReturn(Optional.of(existing));
 
-            boolean result = paymentGrantService.grant(ORDER_ID, DRAFT_ID, MAKER_ID);
+            boolean result = iapService.grant(ORDER_ID, DRAFT_ID, MAKER_ID);
 
             assertThat(result).isFalse();
             verify(testPublishService, never()).publish(any());
@@ -120,7 +117,7 @@ class PaymentGrantServiceTest {
             when(paymentRepository.findByOrderNo(ORDER_ID)).thenReturn(Optional.empty());
             when(testDraftRepository.findById(DRAFT_ID)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> paymentGrantService.grant(ORDER_ID, DRAFT_ID, MAKER_ID))
+            assertThatThrownBy(() -> iapService.grant(ORDER_ID, DRAFT_ID, MAKER_ID))
                     .isInstanceOf(BaseException.class)
                     .extracting(e -> ((BaseException) e).getErrorCode())
                     .isEqualTo(BaseErrorCode.DRAFT_001);
@@ -132,7 +129,7 @@ class PaymentGrantServiceTest {
             when(paymentRepository.findByOrderNo(ORDER_ID)).thenReturn(Optional.empty());
             when(testDraftRepository.findById(DRAFT_ID)).thenReturn(Optional.of(draftOf(999L)));
 
-            assertThatThrownBy(() -> paymentGrantService.grant(ORDER_ID, DRAFT_ID, MAKER_ID))
+            assertThatThrownBy(() -> iapService.grant(ORDER_ID, DRAFT_ID, MAKER_ID))
                     .isInstanceOf(BaseException.class)
                     .extracting(e -> ((BaseException) e).getErrorCode())
                     .isEqualTo(BaseErrorCode.DRAFT_002);
@@ -145,7 +142,7 @@ class PaymentGrantServiceTest {
             when(testDraftRepository.findById(DRAFT_ID)).thenReturn(Optional.of(draftOf(MAKER_ID)));
             when(tossAccountRepository.findByUserId(MAKER_ID)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> paymentGrantService.grant(ORDER_ID, DRAFT_ID, MAKER_ID))
+            assertThatThrownBy(() -> iapService.grant(ORDER_ID, DRAFT_ID, MAKER_ID))
                     .isInstanceOf(BaseException.class)
                     .extracting(e -> ((BaseException) e).getErrorCode())
                     .isEqualTo(BaseErrorCode.PAYMENT_005);
@@ -154,35 +151,28 @@ class PaymentGrantServiceTest {
         @Test
         @DisplayName("Toss 상태가 PURCHASED이면 결제를 저장하고 지급 후 true를 반환한다")
         void savesPaymentAndPublishesWhenStatusIsPurchased() {
-            TossProperties skuProps = new TossProperties(true, null, null, null,
-                    new TossProperties.Iap(List.of()));
-            paymentGrantService = new PaymentGrantService(
-                    tossHttpClient, skuProps,
-                    tossAccountRepository, paymentRepository, paymentWriter,
-                    testDraftRepository, paymentAmountCalculator, testPublishService
-            );
-
             when(paymentRepository.findByOrderNo(ORDER_ID)).thenReturn(Optional.empty());
             when(testDraftRepository.findById(DRAFT_ID)).thenReturn(Optional.of(draftOf(MAKER_ID)));
             when(tossAccountRepository.findByUserId(MAKER_ID)).thenReturn(Optional.of(tossAccount()));
-            when(tossHttpClient.post(any(), any(), any(Consumer.class), eq(IapOrderStatusResponse.class)))
-                    .thenReturn(new IapOrderStatusResponse(ORDER_ID, "test_sku", "2025-09-12T16:57:12", IapOrderStatus.PURCHASED, null));
+            when(tossIapGateway.getOrderStatus(eq(777L), eq(ORDER_ID)))
+                    .thenReturn(new IapOrderStatusResult(IapOrderState.PURCHASED, "test_sku", null, APPROVED_AT));
             when(paymentAmountCalculator.totalAmount(10, 500)).thenReturn(5500);
             Payment saved = savedPayment(200L);
-            when(paymentWriter.save(any())).thenReturn(saved);
+            when(paymentCreateService.save(any())).thenReturn(saved);
 
-            boolean result = paymentGrantService.grant(ORDER_ID, DRAFT_ID, MAKER_ID);
+            boolean result = iapService.grant(ORDER_ID, DRAFT_ID, MAKER_ID);
 
             assertThat(result).isTrue();
             verify(testPublishService).publish(200L);
 
             ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
-            verify(paymentWriter).save(captor.capture());
+            verify(paymentCreateService).save(captor.capture());
             Payment captured = captor.getValue();
             assertThat(captured.getPayStatus()).isEqualTo(PayStatus.PAY_SUCCEEDED);
             assertThat(captured.getPayMethod()).isEqualTo(PayMethod.IN_APP_PURCHASE);
             assertThat(captured.getIsTestPayment()).isFalse();
             assertThat(captured.getAmount()).isEqualTo(5500);
+            assertThat(captured.getApprovedAt()).isEqualTo(APPROVED_AT);
         }
 
         @Test
@@ -191,34 +181,32 @@ class PaymentGrantServiceTest {
             when(paymentRepository.findByOrderNo(ORDER_ID)).thenReturn(Optional.empty());
             when(testDraftRepository.findById(DRAFT_ID)).thenReturn(Optional.of(draftOf(MAKER_ID)));
             when(tossAccountRepository.findByUserId(MAKER_ID)).thenReturn(Optional.of(tossAccount()));
-            when(tossHttpClient.post(any(), any(), any(Consumer.class), eq(IapOrderStatusResponse.class)))
-                    .thenReturn(new IapOrderStatusResponse(ORDER_ID, "test_sku", "2025-09-12T16:57:12", IapOrderStatus.FAILED, "user_cancel"));
+            when(tossIapGateway.getOrderStatus(eq(777L), eq(ORDER_ID)))
+                    .thenReturn(new IapOrderStatusResult(IapOrderState.FAILED, "test_sku", "user_cancel", APPROVED_AT));
 
-            boolean result = paymentGrantService.grant(ORDER_ID, DRAFT_ID, MAKER_ID);
+            boolean result = iapService.grant(ORDER_ID, DRAFT_ID, MAKER_ID);
 
             assertThat(result).isFalse();
-            verify(paymentWriter, never()).save(any());
+            verify(paymentCreateService, never()).save(any());
             verify(testPublishService, never()).publish(any());
         }
 
         @Test
         @DisplayName("allowedSkus가 설정됐는데 SKU가 불일치하면 PAYMENT_006 예외를 던진다")
         void throwsPayment006WhenSkuNotAllowed() {
-            TossProperties skuProps = new TossProperties(true, null, null, null,
-                    new TossProperties.Iap(List.of("allowed_sku")));
-            paymentGrantService = new PaymentGrantService(
-                    tossHttpClient, skuProps,
-                    tossAccountRepository, paymentRepository, paymentWriter,
+            iapService = new IapService(
+                    tossIapGateway, new TossIapProperties(List.of("allowed_sku")),
+                    tossAccountRepository, paymentRepository, paymentCreateService,
                     testDraftRepository, paymentAmountCalculator, testPublishService
             );
 
             when(paymentRepository.findByOrderNo(ORDER_ID)).thenReturn(Optional.empty());
             when(testDraftRepository.findById(DRAFT_ID)).thenReturn(Optional.of(draftOf(MAKER_ID)));
             when(tossAccountRepository.findByUserId(MAKER_ID)).thenReturn(Optional.of(tossAccount()));
-            when(tossHttpClient.post(any(), any(), any(Consumer.class), eq(IapOrderStatusResponse.class)))
-                    .thenReturn(new IapOrderStatusResponse(ORDER_ID, "unknown_sku", "2025-09-12T16:57:12", IapOrderStatus.PURCHASED, null));
+            when(tossIapGateway.getOrderStatus(eq(777L), eq(ORDER_ID)))
+                    .thenReturn(new IapOrderStatusResult(IapOrderState.PURCHASED, "unknown_sku", null, APPROVED_AT));
 
-            assertThatThrownBy(() -> paymentGrantService.grant(ORDER_ID, DRAFT_ID, MAKER_ID))
+            assertThatThrownBy(() -> iapService.grant(ORDER_ID, DRAFT_ID, MAKER_ID))
                     .isInstanceOf(BaseException.class)
                     .extracting(e -> ((BaseException) e).getErrorCode())
                     .isEqualTo(BaseErrorCode.PAYMENT_006);
@@ -230,12 +218,12 @@ class PaymentGrantServiceTest {
             when(paymentRepository.findByOrderNo(ORDER_ID)).thenReturn(Optional.empty());
             when(testDraftRepository.findById(DRAFT_ID)).thenReturn(Optional.of(draftOf(MAKER_ID)));
             when(tossAccountRepository.findByUserId(MAKER_ID)).thenReturn(Optional.of(tossAccount()));
-            when(tossHttpClient.post(any(), any(), any(Consumer.class), eq(IapOrderStatusResponse.class)))
-                    .thenReturn(new IapOrderStatusResponse(ORDER_ID, "any_sku", "2025-09-12T16:57:12", IapOrderStatus.PURCHASED, null));
+            when(tossIapGateway.getOrderStatus(eq(777L), eq(ORDER_ID)))
+                    .thenReturn(new IapOrderStatusResult(IapOrderState.PURCHASED, "any_sku", null, APPROVED_AT));
             when(paymentAmountCalculator.totalAmount(any(Integer.class), any(Integer.class))).thenReturn(5500);
-            when(paymentWriter.save(any())).thenReturn(savedPayment(200L));
+            when(paymentCreateService.save(any())).thenReturn(savedPayment(200L));
 
-            boolean result = paymentGrantService.grant(ORDER_ID, DRAFT_ID, MAKER_ID);
+            boolean result = iapService.grant(ORDER_ID, DRAFT_ID, MAKER_ID);
 
             assertThat(result).isTrue();
         }
@@ -250,35 +238,15 @@ class PaymentGrantServiceTest {
                     .thenReturn(Optional.of(fallback));
             when(testDraftRepository.findById(DRAFT_ID)).thenReturn(Optional.of(draftOf(MAKER_ID)));
             when(tossAccountRepository.findByUserId(MAKER_ID)).thenReturn(Optional.of(tossAccount()));
-            when(tossHttpClient.post(any(), any(), any(Consumer.class), eq(IapOrderStatusResponse.class)))
-                    .thenReturn(new IapOrderStatusResponse(ORDER_ID, "sku", "2025-09-12T16:57:12", IapOrderStatus.PURCHASED, null));
+            when(tossIapGateway.getOrderStatus(eq(777L), eq(ORDER_ID)))
+                    .thenReturn(new IapOrderStatusResult(IapOrderState.PURCHASED, "sku", null, APPROVED_AT));
             when(paymentAmountCalculator.totalAmount(any(Integer.class), any(Integer.class))).thenReturn(5500);
-            when(paymentWriter.save(any())).thenThrow(new DataIntegrityViolationException("duplicate"));
+            when(paymentCreateService.save(any())).thenThrow(new DataIntegrityViolationException("duplicate"));
 
-            boolean result = paymentGrantService.grant(ORDER_ID, DRAFT_ID, MAKER_ID);
+            boolean result = iapService.grant(ORDER_ID, DRAFT_ID, MAKER_ID);
 
             assertThat(result).isTrue();
             verify(testPublishService).publish(300L);
-        }
-
-        @Test
-        @DisplayName("statusDeterminedAt이 null이어도 NPE 없이 현재 시각으로 저장한다")
-        void handlesNullStatusDeterminedAtWithoutNpe() {
-            when(paymentRepository.findByOrderNo(ORDER_ID)).thenReturn(Optional.empty());
-            when(testDraftRepository.findById(DRAFT_ID)).thenReturn(Optional.of(draftOf(MAKER_ID)));
-            when(tossAccountRepository.findByUserId(MAKER_ID)).thenReturn(Optional.of(tossAccount()));
-            when(tossHttpClient.post(any(), any(), any(Consumer.class), eq(IapOrderStatusResponse.class)))
-                    .thenReturn(new IapOrderStatusResponse(ORDER_ID, null, null, IapOrderStatus.PURCHASED, null));
-            when(paymentAmountCalculator.totalAmount(any(Integer.class), any(Integer.class))).thenReturn(5500);
-            when(paymentWriter.save(any())).thenReturn(savedPayment(200L));
-
-            boolean result = paymentGrantService.grant(ORDER_ID, DRAFT_ID, MAKER_ID);
-
-            assertThat(result).isTrue();
-
-            ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
-            verify(paymentWriter).save(captor.capture());
-            assertThat(captor.getValue().getApprovedAt()).isNotNull();
         }
 
         @Test
@@ -287,17 +255,17 @@ class PaymentGrantServiceTest {
             when(paymentRepository.findByOrderNo(ORDER_ID)).thenReturn(Optional.empty());
             when(testDraftRepository.findById(DRAFT_ID)).thenReturn(Optional.of(draftOf(MAKER_ID)));
             when(tossAccountRepository.findByUserId(MAKER_ID)).thenReturn(Optional.of(tossAccount()));
-            when(tossHttpClient.post(any(), any(), any(Consumer.class), eq(IapOrderStatusResponse.class)))
-                    .thenReturn(new IapOrderStatusResponse(ORDER_ID, null, "2025-09-12T16:57:12", IapOrderStatus.PURCHASED, null));
+            when(tossIapGateway.getOrderStatus(eq(777L), eq(ORDER_ID)))
+                    .thenReturn(new IapOrderStatusResult(IapOrderState.PURCHASED, null, null, APPROVED_AT));
             when(paymentAmountCalculator.totalAmount(any(Integer.class), any(Integer.class))).thenReturn(5500);
             Payment saved = savedPayment(200L);
-            when(paymentWriter.save(any())).thenReturn(saved);
+            when(paymentCreateService.save(any())).thenReturn(saved);
             doThrow(new RuntimeException("publish failed")).when(testPublishService).publish(200L);
 
-            boolean result = paymentGrantService.grant(ORDER_ID, DRAFT_ID, MAKER_ID);
+            boolean result = iapService.grant(ORDER_ID, DRAFT_ID, MAKER_ID);
 
             assertThat(result).isTrue();
-            verify(paymentWriter).save(any());
+            verify(paymentCreateService).save(any());
         }
     }
 
@@ -310,11 +278,11 @@ class PaymentGrantServiceTest {
             Payment existing = existingPayment(100L, MAKER_ID, PayStatus.PAY_SUCCEEDED);
             when(paymentRepository.findByOrderNo(ORDER_ID)).thenReturn(Optional.of(existing));
 
-            boolean result = paymentGrantService.restore(ORDER_ID, null, MAKER_ID);
+            boolean result = iapService.restore(ORDER_ID, null, MAKER_ID);
 
             assertThat(result).isTrue();
             verify(testPublishService).publish(100L);
-            verify(tossHttpClient, never()).post(any(), any(), any(Consumer.class), any());
+            verify(tossIapGateway, never()).getOrderStatus(any(), any());
         }
 
         @Test
@@ -322,7 +290,7 @@ class PaymentGrantServiceTest {
         void throwsPayment001WhenNoPaymentAndNoDraftId() {
             when(paymentRepository.findByOrderNo(ORDER_ID)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> paymentGrantService.restore(ORDER_ID, null, MAKER_ID))
+            assertThatThrownBy(() -> iapService.restore(ORDER_ID, null, MAKER_ID))
                     .isInstanceOf(BaseException.class)
                     .extracting(e -> ((BaseException) e).getErrorCode())
                     .isEqualTo(BaseErrorCode.PAYMENT_001);
@@ -334,16 +302,16 @@ class PaymentGrantServiceTest {
             when(paymentRepository.findByOrderNo(ORDER_ID)).thenReturn(Optional.empty());
             when(testDraftRepository.findById(DRAFT_ID)).thenReturn(Optional.of(draftOf(MAKER_ID)));
             when(tossAccountRepository.findByUserId(MAKER_ID)).thenReturn(Optional.of(tossAccount()));
-            when(tossHttpClient.post(any(), any(), any(Consumer.class), eq(IapOrderStatusResponse.class)))
-                    .thenReturn(new IapOrderStatusResponse(ORDER_ID, null, "2025-09-12T16:57:12", IapOrderStatus.PURCHASED, null));
+            when(tossIapGateway.getOrderStatus(eq(777L), eq(ORDER_ID)))
+                    .thenReturn(new IapOrderStatusResult(IapOrderState.PURCHASED, null, null, APPROVED_AT));
             when(paymentAmountCalculator.totalAmount(any(Integer.class), any(Integer.class))).thenReturn(5500);
             Payment saved = savedPayment(200L);
-            when(paymentWriter.save(any())).thenReturn(saved);
+            when(paymentCreateService.save(any())).thenReturn(saved);
 
-            boolean result = paymentGrantService.restore(ORDER_ID, DRAFT_ID, MAKER_ID);
+            boolean result = iapService.restore(ORDER_ID, DRAFT_ID, MAKER_ID);
 
             assertThat(result).isTrue();
-            verify(paymentWriter).save(any());
+            verify(paymentCreateService).save(any());
             verify(testPublishService).publish(200L);
         }
 
@@ -354,7 +322,7 @@ class PaymentGrantServiceTest {
             when(paymentRepository.findByOrderNo(ORDER_ID)).thenReturn(Optional.of(existing));
             doThrow(new RuntimeException("publish failed")).when(testPublishService).publish(100L);
 
-            assertThatThrownBy(() -> paymentGrantService.restore(ORDER_ID, null, MAKER_ID))
+            assertThatThrownBy(() -> iapService.restore(ORDER_ID, null, MAKER_ID))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessage("publish failed");
         }
@@ -365,7 +333,7 @@ class PaymentGrantServiceTest {
             Payment existing = existingPayment(100L, 999L, PayStatus.PAY_SUCCEEDED);
             when(paymentRepository.findByOrderNo(ORDER_ID)).thenReturn(Optional.of(existing));
 
-            assertThatThrownBy(() -> paymentGrantService.restore(ORDER_ID, null, MAKER_ID))
+            assertThatThrownBy(() -> iapService.restore(ORDER_ID, null, MAKER_ID))
                     .isInstanceOf(BaseException.class)
                     .extracting(e -> ((BaseException) e).getErrorCode())
                     .isEqualTo(BaseErrorCode.COMMON_009);
@@ -380,27 +348,24 @@ class PaymentGrantServiceTest {
         void throwsPayment005WhenTossAccountNotFound() {
             when(tossAccountRepository.findByUserId(MAKER_ID)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> paymentGrantService.getOrderStatus(ORDER_ID, MAKER_ID))
+            assertThatThrownBy(() -> iapService.getOrderStatus(ORDER_ID, MAKER_ID))
                     .isInstanceOf(BaseException.class)
                     .extracting(e -> ((BaseException) e).getErrorCode())
                     .isEqualTo(BaseErrorCode.PAYMENT_005);
         }
 
         @Test
-        @DisplayName("Toss 응답을 그대로 PaymentOrderStatusResponse로 반환한다")
-        void returnsOrderStatusFromTossResponse() {
+        @DisplayName("게이트웨이 결과를 그대로 PaymentOrderStatusResponse로 반환한다")
+        void returnsOrderStatusFromGatewayResult() {
             when(tossAccountRepository.findByUserId(MAKER_ID)).thenReturn(Optional.of(tossAccount()));
-            when(tossHttpClient.post(any(), any(), any(Consumer.class), eq(IapOrderStatusResponse.class)))
-                    .thenReturn(new IapOrderStatusResponse(ORDER_ID, "test_sku", "2025-09-12T16:57:12", IapOrderStatus.PURCHASED, null));
+            when(tossIapGateway.getOrderStatus(eq(777L), eq(ORDER_ID)))
+                    .thenReturn(new IapOrderStatusResult(IapOrderState.PURCHASED, "test_sku", null, APPROVED_AT));
 
-            PaymentOrderStatusResponse response = paymentGrantService.getOrderStatus(ORDER_ID, MAKER_ID);
+            PaymentOrderStatusResponse response = iapService.getOrderStatus(ORDER_ID, MAKER_ID);
 
-            assertThat(response.status()).isEqualTo(IapOrderStatus.PURCHASED);
-            assertThat(response.statusDeterminedAt()).isEqualTo("2025-09-12T16:57:12");
-
-            ArgumentCaptor<IapOrderStatusRequest> captor = ArgumentCaptor.forClass(IapOrderStatusRequest.class);
-            verify(tossHttpClient).post(any(), captor.capture(), any(Consumer.class), eq(IapOrderStatusResponse.class));
-            assertThat(captor.getValue().orderId()).isEqualTo(ORDER_ID);
+            assertThat(response.status()).isEqualTo(IapOrderState.PURCHASED);
+            assertThat(response.statusDeterminedAt()).isEqualTo(APPROVED_AT);
+            verify(tossIapGateway).getOrderStatus(777L, ORDER_ID);
         }
     }
 

--- a/src/test/java/server/MATE/toss/client/iap/TossIapApiClientTest.java
+++ b/src/test/java/server/MATE/toss/client/iap/TossIapApiClientTest.java
@@ -1,0 +1,57 @@
+package server.MATE.toss.client.iap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import server.MATE.toss.client.http.TossHttpClient;
+import server.MATE.toss.dto.request.IapOrderStatusRequest;
+import server.MATE.toss.dto.response.IapOrderStatus;
+import server.MATE.toss.dto.response.IapOrderStatusResponse;
+
+@ExtendWith(MockitoExtension.class)
+class TossIapApiClientTest {
+
+    private static final String ORDER_STATUS_PATH = "/api-partner/v1/apps-in-toss/order/get-order-status";
+
+    @Mock
+    private TossHttpClient tossHttpClient;
+
+    private TossIapApiClient apiClient;
+
+    @BeforeEach
+    void setUp() {
+        apiClient = new TossIapApiClient(tossHttpClient);
+    }
+
+    @Test
+    void getOrderStatusSendsUserKeyHeaderAndOrderIdBody() {
+        given(tossHttpClient.post(eq(ORDER_STATUS_PATH), any(), ArgumentMatchers.<Consumer<HttpHeaders>>any(), eq(IapOrderStatusResponse.class)))
+                .willReturn(new IapOrderStatusResponse("order-1", "sku", "2025-09-12T16:57:12", IapOrderStatus.PURCHASED, null));
+
+        IapOrderStatusResponse response = apiClient.getOrderStatus(777L, "order-1");
+
+        assertThat(response.status()).isEqualTo(IapOrderStatus.PURCHASED);
+
+        ArgumentCaptor<IapOrderStatusRequest> bodyCaptor = ArgumentCaptor.forClass(IapOrderStatusRequest.class);
+        ArgumentCaptor<Consumer<HttpHeaders>> headerCaptor = ArgumentCaptor.forClass(Consumer.class);
+        verify(tossHttpClient).post(eq(ORDER_STATUS_PATH), bodyCaptor.capture(), headerCaptor.capture(), eq(IapOrderStatusResponse.class));
+        assertThat(bodyCaptor.getValue().orderId()).isEqualTo("order-1");
+
+        HttpHeaders headers = new HttpHeaders();
+        headerCaptor.getValue().accept(headers);
+        assertThat(headers.getFirst("x-toss-user-key")).isEqualTo("777");
+    }
+}

--- a/src/test/java/server/MATE/toss/client/promotion/TossPromotionApiClientTest.java
+++ b/src/test/java/server/MATE/toss/client/promotion/TossPromotionApiClientTest.java
@@ -1,0 +1,76 @@
+package server.MATE.toss.client.promotion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import server.MATE.toss.client.http.TossHttpClient;
+import server.MATE.toss.dto.response.TossPromotionExecuteResponse;
+import server.MATE.toss.dto.response.TossPromotionExecutionStatus;
+import server.MATE.toss.dto.response.TossPromotionKeyResponse;
+
+@ExtendWith(MockitoExtension.class)
+class TossPromotionApiClientTest {
+
+    private static final String GET_KEY_PATH = "/api-partner/v1/apps-in-toss/promotion/execute-promotion/get-key";
+    private static final String EXECUTE_PATH = "/api-partner/v1/apps-in-toss/promotion/execute-promotion";
+    private static final String RESULT_PATH = "/api-partner/v1/apps-in-toss/promotion/execution-result";
+
+    @Mock
+    private TossHttpClient tossHttpClient;
+
+    private TossPromotionApiClient apiClient;
+
+    @BeforeEach
+    void setUp() {
+        apiClient = new TossPromotionApiClient(tossHttpClient);
+    }
+
+    @Test
+    void issueKeySendsUserKeyHeaderAndReturnsResponse() {
+        given(tossHttpClient.post(eq(GET_KEY_PATH), any(), ArgumentMatchers.<Consumer<HttpHeaders>>any(), eq(TossPromotionKeyResponse.class)))
+                .willReturn(new TossPromotionKeyResponse("issued-key"));
+
+        TossPromotionKeyResponse response = apiClient.issueKey(777L);
+
+        assertThat(response.key()).isEqualTo("issued-key");
+        ArgumentCaptor<Consumer<HttpHeaders>> headerCaptor = ArgumentCaptor.forClass(Consumer.class);
+        verify(tossHttpClient).post(eq(GET_KEY_PATH), any(), headerCaptor.capture(), eq(TossPromotionKeyResponse.class));
+        HttpHeaders headers = new HttpHeaders();
+        headerCaptor.getValue().accept(headers);
+        assertThat(headers.getFirst("x-toss-user-key")).isEqualTo("777");
+    }
+
+    @Test
+    void executeSendsPromotionCodeRewardKeyAndAmount() {
+        given(tossHttpClient.post(eq(EXECUTE_PATH), any(), ArgumentMatchers.<Consumer<HttpHeaders>>any(), eq(TossPromotionExecuteResponse.class)))
+                .willReturn(new TossPromotionExecuteResponse("reward-key"));
+
+        TossPromotionExecuteResponse response = apiClient.execute(777L, "promo-code", "reward-key", 1000);
+
+        assertThat(response.key()).isEqualTo("reward-key");
+        verify(tossHttpClient).post(eq(EXECUTE_PATH), any(), ArgumentMatchers.<Consumer<HttpHeaders>>any(), eq(TossPromotionExecuteResponse.class));
+    }
+
+    @Test
+    void getExecutionStatusReturnsRawStatus() {
+        given(tossHttpClient.post(eq(RESULT_PATH), any(), ArgumentMatchers.<Consumer<HttpHeaders>>any(), eq(TossPromotionExecutionStatus.class)))
+                .willReturn(TossPromotionExecutionStatus.SUCCESS);
+
+        TossPromotionExecutionStatus status = apiClient.getExecutionStatus(777L, "promo-code", "reward-key");
+
+        assertThat(status).isEqualTo(TossPromotionExecutionStatus.SUCCESS);
+    }
+}

--- a/src/test/java/server/MATE/toss/client/promotion/TossPromotionApiClientTest.java
+++ b/src/test/java/server/MATE/toss/client/promotion/TossPromotionApiClientTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import java.lang.reflect.Field;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -61,7 +62,13 @@ class TossPromotionApiClientTest {
         TossPromotionExecuteResponse response = apiClient.execute(777L, "promo-code", "reward-key", 1000);
 
         assertThat(response.key()).isEqualTo("reward-key");
-        verify(tossHttpClient).post(eq(EXECUTE_PATH), any(), ArgumentMatchers.<Consumer<HttpHeaders>>any(), eq(TossPromotionExecuteResponse.class));
+
+        ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(tossHttpClient).post(eq(EXECUTE_PATH), bodyCaptor.capture(), ArgumentMatchers.<Consumer<HttpHeaders>>any(), eq(TossPromotionExecuteResponse.class));
+        Object capturedBody = bodyCaptor.getValue();
+        assertThat(getFieldValue(capturedBody, "promotionCode")).isEqualTo("promo-code");
+        assertThat(getFieldValue(capturedBody, "key")).isEqualTo("reward-key");
+        assertThat(getFieldValue(capturedBody, "amount")).isEqualTo(1000);
     }
 
     @Test
@@ -72,5 +79,21 @@ class TossPromotionApiClientTest {
         TossPromotionExecutionStatus status = apiClient.getExecutionStatus(777L, "promo-code", "reward-key");
 
         assertThat(status).isEqualTo(TossPromotionExecutionStatus.SUCCESS);
+
+        ArgumentCaptor<Object> bodyCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(tossHttpClient).post(eq(RESULT_PATH), bodyCaptor.capture(), ArgumentMatchers.<Consumer<HttpHeaders>>any(), eq(TossPromotionExecutionStatus.class));
+        Object capturedBody = bodyCaptor.getValue();
+        assertThat(getFieldValue(capturedBody, "promotionCode")).isEqualTo("promo-code");
+        assertThat(getFieldValue(capturedBody, "key")).isEqualTo("reward-key");
+    }
+
+    private Object getFieldValue(Object obj, String fieldName) {
+        try {
+            Field field = obj.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.get(obj);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new AssertionError("Could not access field: " + fieldName, e);
+        }
     }
 }

--- a/src/test/java/server/MATE/toss/gateway/TossHttpIapGatewayTest.java
+++ b/src/test/java/server/MATE/toss/gateway/TossHttpIapGatewayTest.java
@@ -1,0 +1,102 @@
+package server.MATE.toss.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import server.MATE.toss.client.iap.TossIapApiClient;
+import server.MATE.toss.dto.response.IapOrderStatus;
+import server.MATE.toss.dto.response.IapOrderStatusResponse;
+
+@ExtendWith(MockitoExtension.class)
+class TossHttpIapGatewayTest {
+
+    @Mock
+    private TossIapApiClient tossIapApiClient;
+
+    private TossHttpIapGateway gateway;
+
+    @BeforeEach
+    void setUp() {
+        gateway = new TossHttpIapGateway(tossIapApiClient);
+    }
+
+    @Test
+    void mapsAllTossStatusesToGatewayStates() {
+        Map<IapOrderStatus, IapOrderState> expected = Map.of(
+                IapOrderStatus.PURCHASED, IapOrderState.PURCHASED,
+                IapOrderStatus.PAYMENT_COMPLETED, IapOrderState.PAYMENT_COMPLETED,
+                IapOrderStatus.FAILED, IapOrderState.FAILED,
+                IapOrderStatus.REFUNDED, IapOrderState.REFUNDED,
+                IapOrderStatus.ORDER_IN_PROGRESS, IapOrderState.ORDER_IN_PROGRESS,
+                IapOrderStatus.NOT_FOUND, IapOrderState.NOT_FOUND,
+                IapOrderStatus.MINIAPP_MISMATCH, IapOrderState.MINIAPP_MISMATCH,
+                IapOrderStatus.ERROR, IapOrderState.ERROR
+        );
+
+        expected.forEach((tossStatus, gatewayState) -> {
+            given(tossIapApiClient.getOrderStatus(777L, "order-1"))
+                    .willReturn(new IapOrderStatusResponse("order-1", "sku", "2025-09-12T16:57:12", tossStatus, null));
+
+            assertThat(gateway.getOrderStatus(777L, "order-1").status()).isEqualTo(gatewayState);
+        });
+    }
+
+    @Test
+    void passesThroughSkuAndReason() {
+        given(tossIapApiClient.getOrderStatus(777L, "order-1"))
+                .willReturn(new IapOrderStatusResponse("order-1", "test_sku", "2025-09-12T16:57:12", IapOrderStatus.FAILED, "user_cancel"));
+
+        IapOrderStatusResult result = gateway.getOrderStatus(777L, "order-1");
+
+        assertThat(result.sku()).isEqualTo("test_sku");
+        assertThat(result.reason()).isEqualTo("user_cancel");
+    }
+
+    @Test
+    void parsesLocalDateTimeFormat() {
+        given(tossIapApiClient.getOrderStatus(777L, "order-1"))
+                .willReturn(new IapOrderStatusResponse("order-1", "sku", "2025-09-12T16:57:12", IapOrderStatus.PURCHASED, null));
+
+        IapOrderStatusResult result = gateway.getOrderStatus(777L, "order-1");
+
+        assertThat(result.statusDeterminedAt()).isEqualTo(LocalDateTime.of(2025, 9, 12, 16, 57, 12));
+    }
+
+    @Test
+    void parsesOffsetDateTimeFormatAsKst() {
+        given(tossIapApiClient.getOrderStatus(777L, "order-1"))
+                .willReturn(new IapOrderStatusResponse("order-1", "sku", "2025-09-12T16:57:12+09:00", IapOrderStatus.PURCHASED, null));
+
+        IapOrderStatusResult result = gateway.getOrderStatus(777L, "order-1");
+
+        assertThat(result.statusDeterminedAt()).isEqualTo(LocalDateTime.of(2025, 9, 12, 16, 57, 12));
+    }
+
+    @Test
+    void fallsBackToNowWhenStatusDeterminedAtIsNull() {
+        given(tossIapApiClient.getOrderStatus(777L, "order-1"))
+                .willReturn(new IapOrderStatusResponse("order-1", "sku", null, IapOrderStatus.PURCHASED, null));
+
+        IapOrderStatusResult result = gateway.getOrderStatus(777L, "order-1");
+
+        assertThat(result.statusDeterminedAt()).isNotNull();
+    }
+
+    @Test
+    void fallsBackToNowWhenStatusDeterminedAtIsMalformed() {
+        given(tossIapApiClient.getOrderStatus(777L, "order-1"))
+                .willReturn(new IapOrderStatusResponse("order-1", "sku", "not-a-date", IapOrderStatus.PURCHASED, null));
+
+        IapOrderStatusResult result = gateway.getOrderStatus(777L, "order-1");
+
+        assertThat(result.statusDeterminedAt()).isNotNull();
+    }
+}

--- a/src/test/java/server/MATE/toss/gateway/TossHttpIapGatewayTest.java
+++ b/src/test/java/server/MATE/toss/gateway/TossHttpIapGatewayTest.java
@@ -1,6 +1,7 @@
 package server.MATE.toss.gateway;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import java.time.LocalDateTime;
@@ -98,5 +99,14 @@ class TossHttpIapGatewayTest {
         IapOrderStatusResult result = gateway.getOrderStatus(777L, "order-1");
 
         assertThat(result.statusDeterminedAt()).isNotNull();
+    }
+
+    @Test
+    void throwsIllegalStateExceptionWhenStatusIsNull() {
+        given(tossIapApiClient.getOrderStatus(777L, "order-1"))
+                .willReturn(new IapOrderStatusResponse("order-1", "sku", "2025-09-12T16:57:12", null, null));
+
+        assertThatThrownBy(() -> gateway.getOrderStatus(777L, "order-1"))
+                .isInstanceOf(IllegalStateException.class);
     }
 }

--- a/src/test/java/server/MATE/toss/gateway/TossHttpPromotionGatewayTest.java
+++ b/src/test/java/server/MATE/toss/gateway/TossHttpPromotionGatewayTest.java
@@ -2,40 +2,32 @@ package server.MATE.toss.gateway;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-
-import java.util.function.Consumer;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpHeaders;
-import server.MATE.toss.client.http.TossHttpClient;
+import server.MATE.toss.client.promotion.TossPromotionApiClient;
 import server.MATE.toss.dto.response.TossPromotionExecutionStatus;
 
 @ExtendWith(MockitoExtension.class)
 class TossHttpPromotionGatewayTest {
 
-    private static final String RESULT_PATH = "/api-partner/v1/apps-in-toss/promotion/execution-result";
-
     @Mock
-    private TossHttpClient tossHttpClient;
+    private TossPromotionApiClient tossPromotionApiClient;
 
     private TossHttpPromotionGateway gateway;
 
     @BeforeEach
     void setUp() {
-        gateway = new TossHttpPromotionGateway(tossHttpClient);
+        gateway = new TossHttpPromotionGateway(tossPromotionApiClient);
     }
 
     @Test
     void mapsSuccessToSucceeded() {
-        given(tossHttpClient.post(eq(RESULT_PATH), any(), ArgumentMatchers.<Consumer<HttpHeaders>>any(), eq(TossPromotionExecutionStatus.class)))
+        given(tossPromotionApiClient.getExecutionStatus(777L, "promo-code", "reward-key"))
                 .willReturn(TossPromotionExecutionStatus.SUCCESS);
 
         assertThat(gateway.getExecutionStatus(777L, "promo-code", "reward-key"))
@@ -44,7 +36,7 @@ class TossHttpPromotionGatewayTest {
 
     @Test
     void mapsPendingToPending() {
-        given(tossHttpClient.post(eq(RESULT_PATH), any(), ArgumentMatchers.<Consumer<HttpHeaders>>any(), eq(TossPromotionExecutionStatus.class)))
+        given(tossPromotionApiClient.getExecutionStatus(777L, "promo-code", "reward-key"))
                 .willReturn(TossPromotionExecutionStatus.PENDING);
 
         assertThat(gateway.getExecutionStatus(777L, "promo-code", "reward-key"))
@@ -53,7 +45,7 @@ class TossHttpPromotionGatewayTest {
 
     @Test
     void mapsFailedToFailed() {
-        given(tossHttpClient.post(eq(RESULT_PATH), any(), ArgumentMatchers.<Consumer<HttpHeaders>>any(), eq(TossPromotionExecutionStatus.class)))
+        given(tossPromotionApiClient.getExecutionStatus(777L, "promo-code", "reward-key"))
                 .willReturn(TossPromotionExecutionStatus.FAILED);
 
         assertThat(gateway.getExecutionStatus(777L, "promo-code", "reward-key"))
@@ -62,7 +54,7 @@ class TossHttpPromotionGatewayTest {
 
     @Test
     void throwsIllegalStateExceptionWhenStatusIsNull() {
-        given(tossHttpClient.post(eq(RESULT_PATH), any(), ArgumentMatchers.<Consumer<HttpHeaders>>any(), eq(TossPromotionExecutionStatus.class)))
+        given(tossPromotionApiClient.getExecutionStatus(777L, "promo-code", "reward-key"))
                 .willReturn(null);
 
         assertThatThrownBy(() -> gateway.getExecutionStatus(777L, "promo-code", "reward-key"))


### PR DESCRIPTION
## 📍 요약
- promotion 도메인의 raw HTTP 통신 로직을 TossPromotionApiClient로 분리하고, IAP 결제 흐름에도 토스 로그인과 동일한 client/gateway 3계층 구조 적용

## 🔗 관련 이슈
- Closes #260

## 📌 변경 사항
- [x] 리팩토링

## ✅ 작업 내용
- TossPromotionApiClient 신설, TossHttpPromotionGateway의 통신 로직 이관
- TossIapApiClient, TossIapGateway, TossHttpIapGateway 신설(IapOrderState/IapOrderStatusResult 게이트웨이 소유 타입 도입, statusDeterminedAt 파싱을 게이트웨이 경계로 이관)
- TossIapProperties 신설(toss.iap.* 네임스페이스 분리), TossProperties에서 Iap 중첩 레코드 제거
- IapService(구 PaymentGrantService), PaymentCreateService(구 PaymentWriter) 리네임 및 TossIapGateway 의존 전환, TossHttpClient/TossProperties/toss.dto.* 직접 참조 제거
- PaymentOrderStatusResponse 필드 타입 변경(status: IapOrderState, statusDeterminedAt: LocalDateTime)
- PaymentController를 IapService 참조로 갱신

## 테스트
- [x] 로컬 테스트 완료
- 테스트 방법:
  - ./gradlew build
  - ./gradlew test --tests "server.MATE.toss.client.promotion.TossPromotionApiClientTest" --tests "server.MATE.toss.gateway.TossHttpPromotionGatewayTest" --tests "server.MATE.toss.client.iap.TossIapApiClientTest" --tests "server.MATE.toss.gateway.TossHttpIapGatewayTest" --tests "server.MATE.domain.payment.service.IapServiceTest"
